### PR TITLE
README: copywriting pass on the hero + badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
 # SOTA Engineering Skills
 
 <p align="center">
+  <a href="https://github.com/martinholovsky/SOTA-skills/releases"><img src="https://img.shields.io/github/v/release/martinholovsky/SOTA-skills?color=2fa45f&label=release" alt="Latest release"></a>
+  <a href="https://github.com/martinholovsky/SOTA-skills/actions/workflows/ci.yml"><img src="https://github.com/martinholovsky/SOTA-skills/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
+  <img src="https://img.shields.io/badge/skills-30-2fa45f" alt="30 skills">
+  <img src="https://img.shields.io/badge/modes-BUILD%20%2B%20AUDIT-2fa45f" alt="BUILD + AUDIT">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-CC%20BY%204.0-blue" alt="License: CC BY 4.0"></a>
+</p>
+
+<p align="center">
   <img src="assets/social-preview.png" alt="SOTA Engineering Skills — 30 Claude Code skills to build and audit software at state-of-the-art practices" width="100%">
 </p>
 
-A library of Claude Code skills encoding state-of-the-art (2026) practices for
-building **and** auditing applications and services. 30 skills, 216 files,
-~46k lines — every file under 500 lines so skills load incrementally without
-blowing the context window. Fast-moving claims (versions, specs, regulations)
-are web-verified against primary sources; last refresh: 2026-06-14.
+**Make your AI coding assistant build and audit like your most senior engineer.**
+
+Your assistant is brilliant — it just doesn't know your standards. SOTA-skills
+teaches it: a library of Claude Code skills that encode state-of-the-art (2026)
+practices for building **and** auditing software, and that verify their own
+claims. 30 skills, 216 files, ~46k lines — every file under 500 lines, so the
+right rules load exactly when your task needs them, never bloating the context
+window. Fast-moving claims (versions, specs, regulations) are web-verified
+against primary sources; last refresh: 2026-06-14.
 
 Two cross-cutting pieces live outside the domain skills:
 


### PR DESCRIPTION
Tightens the top of the README using the copywriting skill, scoped to the marketing-appropriate hero (the skill explicitly excludes technical docs, so reference sections are left precise and unchanged).

- **Benefit-led hero**: a one-line value proposition + a problem→solution opener ("your assistant is brilliant — it just doesn't know your standards").
- **Spec reframed as benefit**: "every file under 500 lines, so the right rules load exactly when your task needs them."
- **Trust signals**: release / CI / skills / BUILD+AUDIT / license badges under the title.

Every spec and claim preserved; invariants + gitleaks pass locally.
