### PR TITLE
feat: install.sh installer/updater + Updating docs (A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,23 +99,43 @@ Every skill works in two modes:
 ## Installation
 
 Skills are discovered from `.claude/skills/` (per project) or
-`~/.claude/skills/` (personal, all projects).
+`~/.claude/skills/` (personal, all projects). Clone the repo, then run the
+installer — it symlinks every skill (and your profile, if you have one):
 
-**Personal (all projects):**
+```sh
+git clone https://github.com/martinholovsky/SOTA-skills && cd SOTA-skills
+./scripts/install.sh                 # personal: ~/.claude/skills (all projects)
+./scripts/install.sh --project DIR   # one project: DIR/.claude/skills
+./scripts/install.sh --copy          # copy instead of symlink (pin a snapshot)
+```
+
+Prefer no script? The personal install is just:
 
 ```sh
 mkdir -p ~/.claude/skills
 for d in skills/*/; do ln -sfn "$(pwd)/$d" ~/.claude/skills/"$(basename "$d")"; done
 ```
 
-**Per project:**
+### Updating
+
+Because install is symlink-based, **existing skills update the moment you pull**
+— the symlinks already point at the live files, no re-install needed:
 
 ```sh
-mkdir -p /path/to/project/.claude/skills
-for d in skills/*/; do ln -sfn "$(pwd)/$d" /path/to/project/.claude/skills/"$(basename "$d")"; done
+git -C /path/to/SOTA-skills pull
 ```
 
-(Copy instead of symlink if you want the project pinned to a snapshot.)
+To also pick up **newly added** skills (a pull alone won't link a brand-new
+skill directory) and prune links to removed ones, re-run the installer — or do
+both at once:
+
+```sh
+./scripts/install.sh --update        # git pull --ff-only, then re-link
+```
+
+It's idempotent: re-running only links what's new and prunes what's gone, and
+never touches symlinks it didn't create. (Snapshot installs done with `--copy`
+don't auto-update — re-run the installer to refresh them.)
 
 ### Always-on routing (recommended)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# install.sh — link the SOTA skills into Claude Code, and update them later.
+#
+# Installation is symlink-based, so this script is also the updater: re-run it
+# after `git pull` and it links any newly-added skills and prunes links to
+# skills that were removed/renamed. Existing skills update with no action at all
+# (the symlinks already point at the live files).
+#
+# Usage:
+#   scripts/install.sh                 # link skills into ~/.claude/skills (all projects)
+#   scripts/install.sh --project DIR   # link into DIR/.claude/skills (one project)
+#   scripts/install.sh --update        # git pull --ff-only first, then re-link
+#   scripts/install.sh --copy          # copy instead of symlink (pin a snapshot)
+#   scripts/install.sh --help
+#
+set -euo pipefail
+
+# Repo root = parent of this script's dir, so cwd does not matter.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd -- "$SCRIPT_DIR/.." && pwd)"; readonly REPO
+readonly SKILLS_SRC="$REPO/skills"
+
+TARGET="$HOME/.claude/skills"
+DO_UPDATE=0
+USE_COPY=0
+
+log()  { printf '  %s\n' "$*"; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+usage() { sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//; /^set -euo/d'; exit "${1:-0}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update)  DO_UPDATE=1 ;;
+    --copy)    USE_COPY=1 ;;
+    --project) shift; [ $# -gt 0 ] || die "--project needs a directory"; TARGET="$1/.claude/skills" ;;
+    -h|--help) usage 0 ;;
+    *)         die "unknown argument: $1 (try --help)" ;;
+  esac
+  shift
+done
+
+[ -d "$SKILLS_SRC" ] || die "no skills/ dir at $SKILLS_SRC — run from a SOTA-skills checkout"
+
+# --- optional self-update ----------------------------------------------------
+if [ "$DO_UPDATE" -eq 1 ]; then
+  if git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    log "updating $(basename "$REPO") (git pull --ff-only)…"
+    git -C "$REPO" pull --ff-only || die "pull failed — resolve manually, then re-run"
+  else
+    warn "$REPO is not a git checkout — skipping --update"
+  fi
+fi
+
+mkdir -p "$TARGET"
+
+# --- link (or copy) every skill, idempotently --------------------------------
+linked=0; created=0
+for src in "$SKILLS_SRC"/*/; do
+  name="$(basename "$src")"
+  dest="$TARGET/$name"
+  [ -e "$dest" ] || [ -L "$dest" ] || created=$((created + 1))
+  if [ "$USE_COPY" -eq 1 ]; then
+    rm -rf "$dest"
+    cp -R "${src%/}" "$dest"
+  else
+    ln -sfn "${src%/}" "$dest"
+  fi
+  linked=$((linked + 1))
+done
+
+# --- prune stale links: ours (point into this repo) but source now gone -------
+pruned=0
+if [ "$USE_COPY" -eq 0 ] && [ -d "$TARGET" ]; then
+  for dest in "$TARGET"/*; do
+    [ -L "$dest" ] || continue
+    tgt="$(readlink "$dest")"
+    case "$tgt" in
+      "$SKILLS_SRC"/*) [ -e "$tgt" ] || { rm -f "$dest"; pruned=$((pruned + 1)); log "pruned stale link: $(basename "$dest")"; } ;;
+    esac
+  done
+fi
+
+log "linked $linked skill(s) into $TARGET ($created new, $pruned pruned)$([ "$USE_COPY" -eq 1 ] && echo ' [copied]')"
+
+# --- profile convenience (personal install only) -----------------------------
+if [ "$TARGET" = "$HOME/.claude/skills" ] && [ "$USE_COPY" -eq 0 ]; then
+  prof="$(find "$REPO/profiles" -maxdepth 1 -name '*.md' ! -name 'example.md.template' 2>/dev/null | head -n1 || true)"
+  if [ -n "$prof" ]; then
+    mkdir -p "$HOME/.claude/profiles"
+    ln -sfn "$prof" "$HOME/.claude/profiles/$(basename "$prof")"
+    log "linked profile: ~/.claude/profiles/$(basename "$prof")"
+  else
+    log "no profile yet — cp profiles/example.md.template profiles/<you>.md, then re-run"
+  fi
+fi
+
+cat <<NEXT
+
+Done. To update later:
+  git -C "$REPO" pull   # existing skills update live (symlinks); then…
+  "$REPO/scripts/install.sh"   # …re-link to pick up any new skills
+
+Or in one step:  scripts/install.sh --update
+NEXT


### PR DESCRIPTION
First half of the update-mechanism work (the **A — now** track). Today the only way to get new skills is an undocumented `git pull`, and a pull doesn't link *newly added* skills. This fixes that for the clone-based flow.

## `scripts/install.sh`
- Symlinks every skill into `~/.claude/skills` (or `--project DIR`).
- **Doubles as the updater**: re-run after a pull to link new skills and prune links to removed/renamed ones. Idempotent; never touches symlinks it didn't create (foreign links left alone).
- `--update` pulls (`--ff-only`) then re-links; `--copy` pins a snapshot.
- Links the local `profiles/*.md` on personal installs.

## README
- Installation now leads with the installer (manual loop kept as a fallback).
- New **Updating** section: existing skills update live on pull (symlinks); new skills need a re-link / `--update`.

## Verification
- shellcheck-clean; tested link (30 skills), idempotent re-run (0 new), stale-link prune, and that foreign symlinks are preserved.
- Invariants + gitleaks pass; README 344/500.

Next: **B** — publish as a Claude Code plugin + marketplace so non-cloners get native `/plugin` updates.
