### PR TITLE
feat: standing 'validate' + 'keep docs current' rules in the always-on directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through the skills. Thin pointer built from each skill's frontmatter; reads
   rules on demand, no duplication; idempotent managed block.
 
+### Changed
+
+- The always-on directive (generated `AGENTS.md` and the README `CLAUDE.md`
+  example) now leads with two standing rules that apply to **every answer**:
+  *validate every claim against a primary source before asserting*, and *keep
+  docs current in the same change*.
+
 ## [1.1.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -173,12 +173,18 @@ every project. Add a routing mandate so the skills apply without trigger words:
 ```md
 # Global engineering directive
 
+Always, on every answer: (1) **validate before you assert** — verify any claim
+about code, system state, config, versions, or facts against a primary source
+(read the file / run the command / fetch official docs) before answering or
+proposing, and label anything unverified as such; (2) **keep docs current** —
+when you change code/behavior/config, update the affected docs (README,
+CHANGELOG, comments, runbooks, AGENTS.md) in the same change, unprompted.
+
 For any task that builds, designs, refactors, debugs, reviews, or audits code —
 in any language or repo — consult the `sota` router skill first, load the
 matching `sota-*` skills, and apply their rules before acting. This holds even
 when I never say "SOTA" or "audit". Treat `~/.claude/profiles/<you>.md` as the
-BUILD default and AUDIT baseline. Validate claims against primary sources and
-stop-and-ask on security-relevant choices.
+BUILD default and AUDIT baseline, and stop-and-ask on security-relevant choices.
 ```
 
 **3. (Optional) A per-prompt reminder.** In long sessions a directive read many

--- a/scripts/gen-agents-md.sh
+++ b/scripts/gen-agents-md.sh
@@ -87,10 +87,22 @@ emit_block() {
 $BEGIN_MARK
 ## SOTA Engineering Skills
 
-A state-of-the-art engineering skills library is available at
-\`$SKILLS_DIR\`. For any task that builds, designs, refactors, debugs, reviews,
-or audits code — in any language — apply it before acting, regardless of how the
-request is phrased:
+A state-of-the-art engineering skills library is available at \`$SKILLS_DIR\`.
+
+**Always — every answer, not just code tasks:**
+
+- **Validate before you assert.** Never state a claim about code, system state,
+  configuration, installed versions, APIs, or external facts from memory. Verify
+  it first against a primary source — read the file/code in full, run the command
+  and read its output, or fetch the official docs at use time. Label anything
+  unverified as such; never present it as fact. Applies to answers, proposals,
+  and plans.
+- **Keep docs current in the same change.** When you change code, behavior,
+  config, or interfaces, update the affected docs (README, CHANGELOG, comments,
+  runbooks, this AGENTS.md) in the same change, unprompted.
+
+**For any task that builds, designs, refactors, debugs, reviews, or audits code**
+— in any language — apply the library before acting, regardless of phrasing:
 
 1. **Route**: read \`$SKILLS_DIR/sota/SKILL.md\` to map the task to the relevant
    domain and language skills.
@@ -98,11 +110,9 @@ request is phrased:
    \`rules/*.md\` files matching the code in front of you. Never load everything.
 3. **Modes**: BUILD applies the rules while writing; AUDIT reports findings as
    \`file:line | rule | severity | effort | fix\`.
-4. **Operating principles**: validate every claim against a primary source (code
-   read in full, official docs at use time, or reproduced behavior — never
-   training data); re-verify version/CVE facts before pinning; stop and ask on
-   security-relevant decisions (authn/z, crypto, secrets, trust boundaries,
-   network exposure).
+4. **Stop and ask** on security-relevant decisions (authn/z, crypto, secrets,
+   trust boundaries, network exposure) rather than silently picking; never trust
+   training data for version/CVE/spec facts.
 5. **Stack profile**: if one exists (e.g. \`~/.claude/profiles/*.md\`), treat its
    choices as the BUILD default and the AUDIT baseline.
 


### PR DESCRIPTION
Makes two behaviors automatic so they don't have to be re-requested each prompt.

## What
The generated `AGENTS.md` (gen-agents-md.sh) and the README `CLAUDE.md` example now **lead** with two standing rules that apply to **every answer**, above the code-routing steps:

1. **Validate before you assert** — verify any claim about code, system state, config, versions, or facts against a primary source (read the file / run the command / fetch official docs) before answering or proposing; label anything unverified as such. (Elevates the existing operating-principle #0 from buried to front-and-center.)
2. **Keep docs current** — when you change code/behavior/config, update affected docs (README, CHANGELOG, comments, runbooks, AGENTS.md) in the same change, unprompted. (New — operationalizes docs-workflow rules/01 §2 as an always-on default.)

Paired with the same edits to the user's personal `~/.claude/CLAUDE.md` and the `UserPromptSubmit` hook (local, not in this repo) so the rules land across Claude Code **and** the other agents via AGENTS.md.

## Verification
- gen-agents-md.sh shellcheck-clean; dry-run confirms the two mandates lead the generated block.
- Invariants + gitleaks pass; README 383/500. CHANGELOG `[Unreleased]` updated.

Honest note: these are instructions models follow by default every turn — strong, but not a hard guarantee. The only *enforceable* half is a CI/pre-commit gate that flags code-changed-without-docs; offered separately since it's heuristic and noisier.
