### PR TITLE
feat(install): interactive, dotfiles-aware always-on routing setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invocations), plus model / context % / dir / branch; falls back to the count
   of installed skills before any are used. Requires `jq`.
 
+### Changed
+
+- **`scripts/install.sh` now offers always-on routing setup** (global CLAUDE.md
+  directive + `UserPromptSubmit` hook) after linking — interactive and
+  dotfiles-aware: detects existing/symlinked `~/.claude/CLAUDE.md` and
+  `settings.json`, asks before changing anything (recommended pre-filled), backs
+  up, writes through symlinks so dotfiles stay authoritative, and is idempotent
+  via managed markers. Flags: `--routing`, `--no-routing`, `--yes`.
+
 ## [1.2.0] - 2026-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -156,7 +156,17 @@ don't auto-update — re-run the installer to refresh them.)
 Skill descriptions are matched per prompt, so routing is opt-in and depends on
 how you phrase the request. To make the skills apply to **every** session
 regardless of wording, pin the routing instruction where Claude Code always
-sees it. Three layers, strongest last:
+sees it.
+
+**The quick path:** `./scripts/install.sh` offers to set this up for you after
+linking the skills — it's interactive and **dotfiles-aware**: it detects an
+existing or symlinked `~/.claude/CLAUDE.md` / `settings.json`, **asks before
+touching anything** (recommended answer pre-filled), backs up first, writes
+*through* a symlink so dotfiles stay in charge, and uses managed markers so
+re-runs never duplicate. Use `--routing` to force it, `--no-routing` to skip,
+`--yes` for non-interactive. Or wire the three layers by hand:
+
+Three layers, strongest last:
 
 **1. A stack profile.** Copy the template, fill in your stack, and symlink it
 into `~/.claude/` so the router finds it in every project (not just this repo):

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,11 +7,20 @@
 # skills that were removed/renamed. Existing skills update with no action at all
 # (the symlinks already point at the live files).
 #
+# After linking, on a personal install it offers to set up "always-on routing"
+# (a global CLAUDE.md directive + a prompt hook) so the skills apply without
+# trigger words. It is dotfiles-aware: it detects existing/symlinked config and
+# ASKS before touching anything, backing up first and using managed markers so
+# re-runs are idempotent and your own content is preserved.
+#
 # Usage:
 #   scripts/install.sh                 # link skills into ~/.claude/skills (all projects)
 #   scripts/install.sh --project DIR   # link into DIR/.claude/skills (one project)
 #   scripts/install.sh --update        # git pull --ff-only first, then re-link
 #   scripts/install.sh --copy          # copy instead of symlink (pin a snapshot)
+#   scripts/install.sh --routing       # also set up always-on routing (force)
+#   scripts/install.sh --no-routing    # skip the routing offer
+#   scripts/install.sh --yes           # assume the recommended answer to prompts
 #   scripts/install.sh --help
 #
 set -euo pipefail
@@ -24,6 +33,11 @@ readonly SKILLS_SRC="$REPO/skills"
 TARGET="$HOME/.claude/skills"
 DO_UPDATE=0
 USE_COPY=0
+DO_ROUTING=-1   # -1 = ask/auto, 0 = skip, 1 = force
+ASSUME_YES=0
+
+INTERACTIVE=0
+{ [ -t 0 ] && [ -t 1 ]; } && INTERACTIVE=1
 
 log()  { printf '  %s\n' "$*"; }
 warn() { printf 'warning: %s\n' "$*" >&2; }
@@ -31,13 +45,127 @@ die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
 
 usage() { sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//; /^set -euo/d'; exit "${1:-0}"; }
 
+# --- interactive / routing helpers -------------------------------------------
+readonly RT_BEGIN="<!-- >>> sota-skills routing (managed by install.sh) >>> -->"
+# kept on one line; contains "sota" so re-runs detect it and never duplicate
+readonly HOOK_CMD="echo 'sota standing rules: (1) validate every claim about code/system/config/versions/facts against a primary source before answering or proposing, and label anything unverified; (2) keep docs current in the same change. For code tasks, route through the sota skill and apply the matching sota-* skills; treat ~/.claude/profiles as the baseline.'"
+
+ask_yn() {  # $1 prompt, $2 default(y|n); honors --yes and non-interactive
+  local def="${2:-y}" ans
+  if [ "$ASSUME_YES" -eq 1 ] || [ "$INTERACTIVE" -eq 0 ]; then
+    [ "$def" = y ] && return 0 || return 1
+  fi
+  printf '%s [%s] ' "$1" "$([ "$def" = y ] && printf 'Y/n' || printf 'y/N')" >/dev/tty
+  read -r ans </dev/tty || ans=""
+  [ -z "$ans" ] && ans="$def"
+  case "$ans" in [Yy]*) return 0 ;; *) return 1 ;; esac
+}
+
+backup() { [ -e "$1" ] && cp -L "$1" "$1.bak" && log "backed up $1 → $1.bak"; }
+
+emit_routing_block() {
+  cat <<'MD'
+<!-- >>> sota-skills routing (managed by install.sh) >>> -->
+## Engineering standing rules
+
+Apply to every answer, regardless of phrasing:
+
+1. **Validate before you assert** — verify any claim about code, system state,
+   config, versions, or facts against a primary source (read the file / run the
+   command / fetch official docs) before answering or proposing; label anything
+   unverified as such.
+2. **Keep docs current** — when you change code/behavior/config, update the
+   affected docs (README, CHANGELOG, comments, runbooks, AGENTS.md) in the same
+   change, unprompted.
+
+For any task that builds, designs, refactors, debugs, reviews, or audits code:
+consult the `sota` router skill first, load the matching `sota-*` skills, and
+apply their rules before acting — even when "SOTA" or "audit" is never said. If a
+stack profile exists (`~/.claude/profiles/*.md`), treat it as the BUILD default
+and AUDIT baseline; stop and ask on security-relevant decisions.
+<!-- <<< sota-skills routing <<< -->
+MD
+}
+
+setup_claude_md() {
+  # shellcheck disable=SC2088  # ~ here is display text shown to the user, not a path
+  local f="$HOME/.claude/CLAUDE.md" tgt="" where="~/.claude/CLAUDE.md"
+  [ -L "$f" ] && tgt="$(readlink "$f")"
+  [ -n "$tgt" ] && where="$where (symlink → $tgt; likely managed by your dotfiles — commit it there)"
+
+  if [ -f "$f" ] && grep -qF "$RT_BEGIN" "$f" 2>/dev/null; then
+    log "routing directive already in ~/.claude/CLAUDE.md — up to date"; return
+  fi
+  if [ -L "$f" ] && [ ! -e "$f" ]; then           # dangling symlink
+    # shellcheck disable=SC2088  # ~ is display text in the prompt, not a path
+    ask_yn "~/.claude/CLAUDE.md is a broken symlink — replace it with a real file holding the directive?" y \
+      && { rm -f "$f"; emit_routing_block >"$f"; log "wrote ~/.claude/CLAUDE.md (real file)"; }
+    return
+  fi
+  if [ -e "$f" ]; then
+    if ask_yn "Append the SOTA routing directive to $where?" y; then
+      backup "$f"; { printf '\n'; emit_routing_block; } >>"$f"; log "appended directive to ~/.claude/CLAUDE.md"
+    else
+      log "skipped — copy the block from README's 'Always-on routing' yourself"
+    fi
+  else
+    ask_yn "Create ~/.claude/CLAUDE.md with the SOTA routing directive?" y \
+      && { mkdir -p "$(dirname "$f")"; emit_routing_block >"$f"; log "created ~/.claude/CLAUDE.md"; }
+  fi
+}
+
+setup_hook() {
+  local s="$HOME/.claude/settings.json" tmp
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "jq not found — skipping hook setup (add the UserPromptSubmit hook manually, or install jq and re-run)"; return
+  fi
+  if [ -f "$s" ] && jq -e '[.hooks.UserPromptSubmit[]?.hooks[]?.command // ""] | any(test("sota";"i"))' "$s" >/dev/null 2>&1; then
+    log "a sota UserPromptSubmit reminder hook already exists — up to date"; return
+  fi
+  ask_yn "Add a UserPromptSubmit hook that re-injects the standing rules each prompt?" y || return
+  tmp="$(mktemp)"
+  if [ -e "$s" ]; then
+    backup "$s"
+    if jq --arg c "$HOOK_CMD" '.hooks.UserPromptSubmit = ((.hooks.UserPromptSubmit // []) + [{hooks:[{type:"command",command:$c}]}])' "$s" >"$tmp" 2>/dev/null; then
+      cat "$tmp" >"$s"   # cat (not mv) so a symlinked settings.json keeps its link
+      log "added UserPromptSubmit hook to ~/.claude/settings.json"
+    else
+      warn "could not parse $s as JSON — left unchanged"
+    fi
+  else
+    mkdir -p "$(dirname "$s")"
+    jq -n --arg c "$HOOK_CMD" '{hooks:{UserPromptSubmit:[{hooks:[{type:"command",command:$c}]}]}}' >"$s"
+    log "created ~/.claude/settings.json with the hook"
+  fi
+  rm -f "$tmp"
+}
+
+maybe_setup_routing() {
+  # personal install only; never for --project or --copy snapshots
+  [ "$TARGET" = "$HOME/.claude/skills" ] && [ "$USE_COPY" -eq 0 ] || return 0
+  local go=0
+  case "$DO_ROUTING" in
+    1) go=1 ;;
+    0) return 0 ;;
+    *) if [ "$INTERACTIVE" -eq 1 ] || [ "$ASSUME_YES" -eq 1 ]; then
+         ask_yn "Set up always-on routing (global directive + prompt hook) so skills apply without trigger words?" y && go=1
+       fi ;;
+  esac
+  [ "$go" -eq 1 ] || return 0
+  setup_claude_md
+  setup_hook
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --update)  DO_UPDATE=1 ;;
-    --copy)    USE_COPY=1 ;;
-    --project) shift; [ $# -gt 0 ] || die "--project needs a directory"; TARGET="$1/.claude/skills" ;;
-    -h|--help) usage 0 ;;
-    *)         die "unknown argument: $1 (try --help)" ;;
+    --update)     DO_UPDATE=1 ;;
+    --copy)       USE_COPY=1 ;;
+    --project)    shift; [ $# -gt 0 ] || die "--project needs a directory"; TARGET="$1/.claude/skills" ;;
+    --routing)    DO_ROUTING=1 ;;
+    --no-routing) DO_ROUTING=0 ;;
+    --yes|-y)     ASSUME_YES=1 ;;
+    -h|--help)    usage 0 ;;
+    *)            die "unknown argument: $1 (try --help)" ;;
   esac
   shift
 done
@@ -96,6 +224,8 @@ if [ "$TARGET" = "$HOME/.claude/skills" ] && [ "$USE_COPY" -eq 0 ]; then
     log "no profile yet — cp profiles/example.md.template profiles/<you>.md, then re-run"
   fi
 fi
+
+maybe_setup_routing
 
 cat <<NEXT
 


### PR DESCRIPTION
`install.sh` now folds in the always-on routing setup (the manual README steps), and does it **safely and dotfiles-aware** — the core of "ask the user what to do if they already have dotfiles."

## Behavior
After linking skills (personal install only), it offers to set up:
- the global `~/.claude/CLAUDE.md` directive, and
- the `UserPromptSubmit` standing-rules hook.

Detection-driven, asks before each change (recommended pre-filled):
- **Symlinked** `CLAUDE.md`/`settings.json` (dotfiles-managed) → writes **through** the link so dotfiles stay authoritative; warns to commit there.
- **Dangling** symlink → offers to replace with a real file.
- **Regular file** → appends a marker-fenced block (CLAUDE.md) / merges the hook into the existing `UserPromptSubmit` array via `jq` (settings.json), preserving other hooks + keys.
- **Absent** → creates it.
- Always backs up first; idempotent via managed markers + a `sota` hook sentinel (re-runs say "up to date", never duplicate).

Flags: `--routing` (force), `--no-routing` (skip), `--yes` (non-interactive). Never runs for `--project` or `--copy`.

## Verification (throwaway HOME)
shellcheck-clean; tested: fresh create, idempotent re-run (no dup block/hook), append-to-existing-CLAUDE.md (content + backup preserved), **symlinked** CLAUDE.md & settings.json (link preserved, dotfiles content kept), dangling-symlink replacement, existing **non-sota** hook merge (theirs + `tui` preserved), and `--no-routing` touches nothing.

README "Always-on routing" now leads with the installer; CHANGELOG `[Unreleased]`.
