### PR TITLE
feat(plugin): one-time first-run notice + optional-extras docs (option B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Plugin first-run notice** (`hooks/hooks.json` + `scripts/plugin-notice.sh`)
+  — a one-time `SessionStart` notice for plugin installs that points users at the
+  opt-in extras a sandboxed plugin can't auto-configure (always-on routing, status
+  line, pre-commit gates, AGENTS.md). Shows once (marker-guarded); clone users get
+  the same from `install.sh`.
+- **README "Optional extras (for plugin users)"** — documents how plugin users
+  turn on the routing hook, status line, and generators (which ship with the
+  plugin) to match the clone experience.
+
 ## [1.3.0] - 2026-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ Every skill works in two modes:
 /plugin install sota-skills@sota-skills
 ```
 
+The plugin installs the skills; a few extras (routing reminder, status line,
+pre-commit gates, AGENTS.md) aren't auto-enabled — see
+[Optional extras for plugin users](#optional-extras-for-plugin-users). On first
+run the plugin shows a one-time notice pointing there.
+
 **Or clone + link** (best if you want a local checkout to read, hack on, or pin).
 Skills are discovered from `.claude/skills/` (per project) or `~/.claude/skills/`
 (personal, all projects). Clone the repo, then run the installer — it symlinks
@@ -285,6 +290,26 @@ falling back to a count of installed skills before any are used. Wire it up in
 ```json
 "statusLine": { "type": "command", "command": "/path/to/SOTA-skills/scripts/statusline.sh" }
 ```
+
+### Optional extras (for plugin users)
+
+The plugin installs the skills; it deliberately does **not** touch your global
+config or status line — plugins are sandboxed by design, so the imperative setup
+the clone installer does can't be automated. To match the clone experience, opt
+in to any of these (the scripts ship *with* the plugin, under its cache dir):
+
+- **Always-on routing** — add the `UserPromptSubmit` hook from
+  [Always-on routing](#always-on-routing-recommended) so the skills apply without
+  trigger words.
+- **Status line** — point `settings.json` `statusLine` at the bundled
+  `scripts/statusline.sh` (see [Status line](#status-line-optional)).
+- **Pre-commit gates** / **AGENTS.md** — run the bundled `scripts/init-gates.sh`
+  or `scripts/gen-agents-md.sh` against a project (see
+  [Enforcing the gates](#enforcing-the-gates) and
+  [Other AI agents](#other-ai-agents-codex-copilot-gemini-)).
+
+The quickest path: just ask Claude to **"set up the SOTA optional extras"** — the
+first-run notice prompts for exactly this, and Claude will walk you through them.
 
 ## How it works
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/plugin-notice.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/plugin-notice.sh
+++ b/scripts/plugin-notice.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# plugin-notice.sh — one-time first-run notice for sota-skills PLUGIN users.
+#
+# Run by the plugin's SessionStart hook (hooks/hooks.json). Plugins are sandboxed
+# and deliberately cannot set up the imperative extras (a global CLAUDE.md
+# directive, the status line, per-project generators), so this points users at
+# them — once. The notice goes to stdout, which Claude Code adds to context; it
+# asks the model to relay the options to the user on the first turn.
+#
+# Guarded by a marker in the plugin's persistent data dir so it shows only once.
+# Clone users get the same information from install.sh, so in practice this only
+# fires for plugin installs.
+#
+set -euo pipefail
+
+data="${CLAUDE_PLUGIN_DATA:-${HOME}/.claude/sota-skills-data}"
+marker="${data}/.extras-notice-shown"
+[ -e "$marker" ] && exit 0
+mkdir -p "$data" 2>/dev/null || true
+: > "$marker" 2>/dev/null || true
+
+cat <<'MSG'
+[sota-skills plugin — first-run notice. Relay this to the user once, briefly, then continue with their request.]
+The SOTA engineering skills are installed and route automatically. A few extras are NOT enabled by the plugin (by design — a plugin can't change your global config or status line). Offer to set up any the user wants:
+  - Always-on routing reminder (a UserPromptSubmit hook) — applies the skills without trigger words.
+  - Status line showing which skills were used this session.
+  - Pre-commit gates for the current repo (scripts/init-gates.sh).
+  - AGENTS.md so Codex/Copilot/Gemini/Cursor use the skills too (scripts/gen-agents-md.sh).
+The scripts ship with the plugin. Steps: https://github.com/martinholovsky/SOTA-skills#optional-extras-for-plugin-users
+MSG


### PR DESCRIPTION
Implements **option B** for plugin/clone parity: don't bundle a mandatory routing hook; instead **tell plugin users about the opt-in extras at install** and document how to enable them.

## Why not full parity (verified against plugin docs)
Plugins are sandboxed/declarative — they can't write your global `~/.claude/CLAUDE.md`, set the main `statusLine`, or run post-install scripts. So the imperative setup the clone installer does can't be automated. ([plugins-reference](https://code.claude.com/docs/en/plugins-reference.md))

## What this adds
- **`hooks/hooks.json` + `scripts/plugin-notice.sh`** — a one-time `SessionStart` notice (the only plugin-native way to surface info at install). It lists the opt-in extras (routing reminder, status line, pre-commit gates, AGENTS.md) and links to the docs, then never shows again (marker in `${CLAUDE_PLUGIN_DATA}`). Clone users get the same from `install.sh`, so this effectively only fires for plugin installs.
- **README "Optional extras (for plugin users)"** + a pointer under the plugin install block. The generator scripts ship with the plugin, so plugin users can run them — or just ask "set up the SOTA optional extras."

Deliberately **not** a per-prompt routing hook (that stays opt-in, per your call).

## Verification
- `scripts/plugin-notice.sh` shellcheck-clean; one-time guard tested (prints once, silent after).
- `hooks/hooks.json` valid JSON; notice target anchor present.
- Invariants + gitleaks pass; README 443/500.

Ships to plugin users on the next version bump.
