### PR TITLE
feat(golang): cover CSPRNG and output encoding in security rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`sota-golang/rules/05-security.md`** — closed two OWASP Go-SCP gaps that are
+  Go-language-specific: a CSPRNG section (`crypto/rand`/`rand.Text` vs the
+  predictable `math/rand`/`math/rand/v2`, plus the deprecated-`math/rand.Read`
+  import footgun) folded into the cryptography section, and an output-encoding
+  note (`html/template` contextual auto-escaping vs `text/template`, and the
+  `template.HTML`/`JS`/`URL` escape-hatch sinks) cross-referencing
+  sota-code-security `05`. Added matching audit greps and severity guidance.
+  SKILL.md index and description updated to match.
+
 ## [1.4.0] - 2026-06-27
 
 ### Added

--- a/skills/sota-golang/SKILL.md
+++ b/skills/sota-golang/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sota-golang
-description: State-of-the-art Go engineering rules (2026 baseline, Go 1.24+) that Claude applies when writing new Go code or auditing existing Go code. Covers error handling, interface/package design, goroutine and channel correctness, net/http hardening, security (SQL, exec, path traversal, TLS, supply chain), performance (pprof, allocations, GC, PGO), and tooling/CI. Trigger keywords - Go, golang, goroutine, channel, go.mod, errgroup, context.Context, pprof, govulncheck, net/http, slog. Use for BOTH building Go services/libraries/CLIs and reviewing or auditing Go codebases.
+description: State-of-the-art Go engineering rules (2026 baseline, Go 1.24+) that Claude applies when writing new Go code or auditing existing Go code. Covers error handling, interface/package design, goroutine and channel correctness, net/http hardening, security (SQL, exec, path traversal, CSPRNG, TLS, supply chain), performance (pprof, allocations, GC, PGO), and tooling/CI. Trigger keywords - Go, golang, goroutine, channel, go.mod, errgroup, context.Context, pprof, govulncheck, net/http, slog. Use for BOTH building Go services/libraries/CLIs and reviewing or auditing Go codebases.
 ---
 
 # SOTA Go (2026)
@@ -78,7 +78,7 @@ severity, the three highest-leverage fixes, and which checklists were run.
 | `rules/02-design.md` | Designing packages or APIs: interface placement and size, package layout and `internal/`, naming, zero values, generics restraint, embedding, functional options, `context.Context` discipline |
 | `rules/03-concurrency.md` | Anything with `go`, `chan`, `sync`, or `select`: goroutine lifecycle ownership, leak catalog, errgroup fan-out, channels-vs-mutex decision, race patterns, worker pools, semaphores, `time.After` traps |
 | `rules/04-http-services.md` | Building or auditing HTTP servers/clients: all five server timeouts, client timeouts and body hygiene, connection reuse, graceful shutdown, middleware, `slog` structured logging, request-scoped values |
-| `rules/05-security.md` | Any input crossing a trust boundary: SQL parameterization, `os/exec` safety, path traversal and `os.Root`, integer overflow (G115), TLS config, `unsafe`/cgo policy, govulncheck, supply chain and go.sum |
+| `rules/05-security.md` | Any input crossing a trust boundary: SQL parameterization, `os/exec` safety, path traversal and `os.Root`, integer overflow (G115), output encoding (`html/template`), CSPRNG (`crypto/rand` vs `math/rand`), TLS config, `unsafe`/cgo policy, govulncheck, supply chain and go.sum |
 | `rules/06-performance.md` | Latency/memory work: pprof workflow, `testing.B` + `b.Loop`, allocation reduction, `strings.Builder`, `sync.Pool` criteria, escape analysis, GOGC/GOMEMLIMIT, PGO |
 | `rules/07-tooling-ci.md` | Setting up or auditing CI and tests: golangci-lint curated config, staticcheck/gofumpt/vet, table tests, `t.Parallel` correctness, testcontainers, golden files, fuzzing, go.mod hygiene and `tool` directives. **Test *strategy* — suite shape, TDD, doubles, test data, flake policy — lives in `sota-testing`; load it for any build that writes logic. This file owns Go runner mechanics only.** |
 

--- a/skills/sota-golang/rules/05-security.md
+++ b/skills/sota-golang/rules/05-security.md
@@ -23,6 +23,12 @@ misconfiguration are entirely yours.
   (`%.100q`) — log injection and PII leak.
 - Don't reflect internal errors to clients (`rules/01 §7`): stack traces,
   SQL text, and file paths in responses are recon gifts — MEDIUM.
+- Output encoding is contextual and separate from input validation: render
+  HTML through `html/template` (it auto-escapes per context), never
+  `text/template` or `fmt.Fprintf` into a page — that's stored/reflected XSS.
+  The `template.HTML`/`JS`/`URL`/`CSS`/`HTMLAttr` cast types switch escaping
+  off; each is a sink that must be independently sanitized. Full
+  XSS/CSP/output-encoding rules live in sota-code-security `05`.
 
 ## 2. SQL — parameterized always
 
@@ -166,7 +172,44 @@ n := int32(req.Length)
 - Durations: `time.Duration(n) * time.Second` where `n` is attacker-supplied
   can overflow int64 — bound first.
 
-## 6. TLS configuration
+## 6. Cryptographic practices: CSPRNG & TLS
+
+### Randomness — `crypto/rand`, never `math/rand`
+
+Security-bearing randomness — tokens, session IDs, password-reset codes, API
+keys, salts, nonces, IVs — MUST come from `crypto/rand`. `math/rand` *and*
+`math/rand/v2` are PRNGs whose "outputs might be easily predictable regardless
+of how it's seeded" (package docs); using either for anything an attacker must
+not guess is HIGH (CRITICAL when it gates auth — a guessable reset token is
+account takeover).
+
+```go
+// BAD — predictable; applies to math/rand and math/rand/v2 alike
+token := strconv.FormatInt(mrand.Int63(), 36)
+
+// GOOD — Go 1.24+: ready-made secret string (RFC 4648 base32, ≥128 bits)
+token := rand.Text()                  // crypto/rand.Text
+
+// GOOD — raw bytes; Read never errors and always fills b entirely
+b := make([]byte, 32)
+rand.Read(b)                          // crypto/rand.Read
+```
+
+- `crypto/rand.Read`/`Text` cannot hand back a short or weak read — on a
+  failing source they crash the program rather than degrade. Don't wrap them in
+  `if err != nil` logic that silently falls back to `math/rand`.
+- Watch the import line, not just the call: `math/rand.Read` is **deprecated**
+  precisely because an unqualified `rand.Read` under `import "math/rand"`
+  reads like the crypto one but isn't. Grep imports, then call sites.
+- `math/rand/v2` is the right tool — and the better PRNG API — for *non-secret*
+  work: jitter, load distribution, sampling, test fixtures. The dividing line
+  is "does predictability help an attacker", not "which package is newer".
+- Keys, signing, AEAD: use `crypto/*` (`ed25519`, `crypto/ecdsa`,
+  `crypto/aes` + `cipher.NewGCM`) drawing from `crypto/rand.Reader`; never
+  hand-roll. Password hashing is `golang.org/x/crypto/bcrypt`/`argon2` —
+  algorithm choice and parameters are owned by sota-code-security `04`.
+
+### TLS configuration
 
 Go's `crypto/tls` defaults are good (1.22+ defaults to strong suites; 1.24+
 enables post-quantum X25519MLKEM768 key exchange, and 1.26 also enables
@@ -268,6 +311,14 @@ gosec -include=G115,G118,G201,G202,G204,G304,G401,G402 ./...
 # gosec 2.24+ adds G113 (request smuggling via conflicting headers),
 # G118 (ctx-propagation goroutine leaks), G408 (SSH PublicKeyCallback bypass)
 
+# CSPRNG misuse — HIGH (security-bearing randomness from a PRNG)
+grep -rn 'math/rand' --include='*.go' .                 # any import: verify each call site is non-secret
+grep -rnE '\brand\.(Int|Intn|Int31|Int63|Uint|Float|Perm|Shuffle|N)\b' --include='*.go' . # PRNG calls — crypto context?
+
+# Output encoding / XSS — HIGH
+grep -rn 'text/template' --include='*.go' . | grep -iv _test   # HTML rendered via text/template?
+grep -rnE 'template\.(HTML|JS|URL|CSS|HTMLAttr)\(' --include='*.go' . # escaping bypass — verify sanitized
+
 # unsafe / cgo
 grep -rn 'unsafe.Pointer\|go:linkname' --include='*.go' .
 grep -rln 'import "C"' --include='*.go' .
@@ -284,7 +335,8 @@ go mod tidy && git diff --exit-code go.mod go.sum
 grep -rnE '(api[_-]?key|secret|password|token)\s*[:=]\s*"[A-Za-z0-9+/_-]{16,}"' --include='*.go' .
 ```
 
-Severity guide: string-built SQL / `sh -c` with input / InsecureSkipVerify
-CRITICAL; traversal-reachable file ops, disabled sumdb, unchecked narrowing on
-attacker-controlled sizes HIGH; raw error echo to clients, silent `replace`
-MEDIUM.
+Severity guide: string-built SQL / `sh -c` with input / InsecureSkipVerify /
+`math/rand` for an auth-gating token CRITICAL; traversal-reachable file ops,
+disabled sumdb, unchecked narrowing on attacker-controlled sizes, `math/rand`
+for other secrets, HTML via `text/template` MEDIUM-to-HIGH; raw error echo to
+clients, silent `replace` MEDIUM.


### PR DESCRIPTION
## What

Closes two **Go-language-specific** OWASP Go-SCP topics that were missing from `sota-golang/rules/05-security.md`, found by comparing the OWASP/Checkmarx *Go Web Application Secure Coding Practices* checklist against our Go skill.

### 1. Pseudo-Random Generators (Go-SCP §1.7.1) — genuine gap
The skill said nothing about `crypto/rand` vs `math/rand`. Added a CSPRNG subsection under the cryptography section:
- `crypto/rand.Read` / `rand.Text` (Go 1.24) for tokens, IDs, salts, nonces.
- `math/rand` **and** `math/rand/v2` are predictable — never for secrets.
- The deprecated-`math/rand.Read` import footgun (unqualified `rand.Read`).
- Pointer to sota-code-security `04` for password-hashing parameters.

### 2. Output Encoding / XSS (Go-SCP §1.3.1) — partial gap
Added a note in §1 on `html/template` contextual auto-escaping vs `text/template`, and the `template.HTML`/`JS`/`URL`/`CSS`/`HTMLAttr` escape-hatch sinks, cross-referencing the fuller treatment in sota-code-security `05`.

Plus matching audit greps and severity-guide updates.

## Claim validation
Every API/version claim checked against a primary source (GOROOT `api/*.txt` + `go doc`, toolchain go1.26.1):
- `crypto/rand.Text() string` → Go **1.24** (`go1.24.txt`, #67057)
- `math/rand/v2` → Go **1.22**; package docs: "should not be used for security-sensitive work… outputs might be easily predictable regardless of how it's seeded"
- `math/rand.Read` → **Deprecated** in favor of `crypto/rand.Read`
- `html/template` → contextual auto-escaping, "used instead of text/template whenever the output is HTML"

## Non-breaking
Folded into existing §6 (no renumbering), so intra-skill references to `rules/05 §7`/`§8` in `06-performance.md` and `07-tooling-ci.md` stay valid.

## Docs kept current
SKILL.md rules index + frontmatter description and CHANGELOG updated in the same change.

## Checks
- `./scripts/check-invariants.sh` → PASS (05 at 342/500 lines)
- gitleaks → no leaks
