### PR TITLE
feat(rust): close ANSSI Secure Rust Guidelines gaps (Drop, comparison traits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`sota-rust`** — closed three gaps found by diffing the skill against the
+  ANSSI *Secure Rust Guidelines* (the nearest equivalent to OWASP Go-SCP):
+  no panicking in `Drop` impls (double-panic aborts the process — `rules/02 §5`,
+  `LANG-DROP-NO-PANIC`, verified against the std `Drop` docs); don't rely *only*
+  on `Drop` for secret erasure since `mem::forget`/`Box::leak`/cycles/
+  `panic=abort` skip it (`rules/05 §5`, `LANG-DROP-SEC`); and uphold the
+  `Eq`/`Ord` comparison-trait invariants or `sort`/`BinaryHeap`/`BTreeMap`
+  silently corrupt or panic (`rules/01 §6`, `LANG-CMP-INV`). Added matching
+  audit-checklist greps (clippy lint names verified against clippy 0.1.91);
+  SKILL.md index updated.
+
 ## [1.4.0] - 2026-06-27
 
 ### Added

--- a/skills/sota-rust/SKILL.md
+++ b/skills/sota-rust/SKILL.md
@@ -103,8 +103,8 @@ fixes with outsized value).
 
 | File | Read this when... |
 |---|---|
-| [rules/01-ownership-and-api-design.md](rules/01-ownership-and-api-design.md) | Designing structs/traits/modules/workspaces; fighting the borrow checker; deciding clone vs borrow vs Rc/Arc; newtype, typestate, builder patterns; sealed traits, coherence; exhaustive matching; iterator-chain idioms |
-| [rules/02-errors-and-panics.md](rules/02-errors-and-panics.md) | Choosing thiserror vs anyhow/eyre; designing error enums; unwrap/expect policy and invariant messages; context discipline; panic policy for servers and FFI; Option/Result combinator flow |
+| [rules/01-ownership-and-api-design.md](rules/01-ownership-and-api-design.md) | Designing structs/traits/modules/workspaces; fighting the borrow checker; deciding clone vs borrow vs Rc/Arc; newtype, typestate, builder patterns; sealed traits, coherence; comparison-trait (`Eq`/`Ord`) invariants; exhaustive matching; iterator-chain idioms |
+| [rules/02-errors-and-panics.md](rules/02-errors-and-panics.md) | Choosing thiserror vs anyhow/eyre; designing error enums; unwrap/expect policy and invariant messages; context discipline; panic policy for servers, FFI, and `Drop` (no panic in destructors); Option/Result combinator flow |
 | [rules/03-unsafe-discipline.md](rules/03-unsafe-discipline.md) | Writing or reviewing ANY `unsafe`; SAFETY comment standards; UB catalog (aliasing, uninit, transmute, FFI lifetimes); Miri/sanitizers/loom in CI; cargo-geiger; soundness review protocol |
 | [rules/04-async-tokio.md](rules/04-async-tokio.md) | Anything async: tokio, spawn vs spawn_blocking, Send/Sync bound errors, `select!` and cancellation safety, JoinSet/TaskTracker, channel selection, locks across await, async traits, graceful shutdown |
 | [rules/05-security-supply-chain.md](rules/05-security-supply-chain.md) | Network-facing or deployed code; adding dependencies; cargo audit/deny/vet; integer overflow on untrusted input; panic-DoS; zeroize/constant-time for secrets; serde hardening (untagged enums, size limits); service-edge defaults |

--- a/skills/sota-rust/rules/01-ownership-and-api-design.md
+++ b/skills/sota-rust/rules/01-ownership-and-api-design.md
@@ -183,6 +183,16 @@ impl Backend for Postgres { ... }
   redacting impl for secrets — rules/05), `Default` where a zero-config value
   exists, `Display` + `std::error::Error` on errors, `From` for infallible
   conversions, `TryFrom` for fallible ones. Never impl `Into` directly.
+- **`Eq`/`Ord`/`PartialEq`/`PartialOrd`: `#[derive]` them; hand-write only with
+  care.** The std library *assumes* their invariants — `PartialEq` symmetry and
+  transitivity, `Eq` reflexivity, `Ord` a total order consistent with `Eq`, and
+  `PartialOrd`/`Ord` agreement. A manual impl that breaks them is not a compile
+  error but silently corrupts `sort`, `binary_search`, `BinaryHeap`,
+  `BTreeMap`/`Set`, and dedup — wrong results, lost entries, or a panic
+  (`sort_unstable` may panic on a non-total `Ord`). If you must hand-roll,
+  define the minimal method (`Ord::cmp`, then `PartialOrd` via `Some(self.cmp)`)
+  so the others stay consistent, and never derive `Ord` on a type whose `f32`/
+  `f64` field makes the order partial. (ANSSI `LANG-CMP-INV`/`-DERIVE`)
 
 ## 7. Exhaustive matching & `#[non_exhaustive]`
 
@@ -288,6 +298,11 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 - [ ] Raw primitive IDs in public signatures: `rg 'fn .*\b(id|user|key)\w*: (u32|u64|i64|String)'`.
 - [ ] Public trait intended to be closed but unsealed — can a downstream crate
       impl it? If yes and that's unintended, seal it.
+- [ ] Hand-written comparison impls: `rg 'impl (PartialEq|Eq|PartialOrd|Ord)' -t rust`
+      — verify invariants (total order, consistency with `Eq`, symmetry); a
+      broken `Ord` corrupts `sort`/`BinaryHeap`/`BTreeMap` or panics. Prefer
+      `#[derive]`. `LANG-CMP-INV`. `clippy::derive_ord_xor_partial_ord`,
+      `clippy::non_canonical_partial_ord_impl`.
 - [ ] Multi-crate repo without `[workspace.dependencies]` → version drift;
       `cargo tree -d` to find duplicate dependency versions.
 - [ ] Clippy gates for this file's concerns: `clippy::needless_pass_by_value`,

--- a/skills/sota-rust/rules/02-errors-and-panics.md
+++ b/skills/sota-rust/rules/02-errors-and-panics.md
@@ -115,6 +115,13 @@ bad input, missing files, network failure, or anything an attacker controls.
 - **FFI**: unwinding across `extern "C"` is UB. Wrap Rust callbacks invoked
   from C in `std::panic::catch_unwind` (or use `extern "C-unwind"` only when
   both sides genuinely support it).
+- **`Drop` impls must not panic.** `drop()` itself runs during unwinding from
+  another panic; a panic there is a *double panic* that — per the std `Drop`
+  docs — "will likely abort the program." So a panicking destructor turns one
+  recoverable failure into process death (DoS). Destructors clean up and return
+  normally; if a Drop genuinely must signal misuse, gate it on
+  `std::thread::panicking()` first. This applies to RAII guards, buffer
+  flushers, and `Zeroize`-on-drop types alike. (ANSSI `LANG-DROP-NO-PANIC`)
 - Poisoned mutexes (`std::sync::Mutex`): a panic while holding the lock poisons
   it. Decide policy once: propagate (`lock().expect("not poisoned: …")`) or
   recover (`unwrap_or_else(PoisonError::into_inner)`) — document which.
@@ -231,6 +238,9 @@ fn main() -> ExitCode {
       undebuggable errors.
 - [ ] FFI: `extern "C"` functions whose bodies can panic without
       `catch_unwind` → UB, Critical.
+- [ ] `Drop` impls that can panic: `rg -A15 'impl Drop' -t rust` then scan for
+      `unwrap`/`expect`/`panic!`/indexing/`?` inside `fn drop` — double-panic
+      aborts the process (DoS), High. `LANG-DROP-NO-PANIC`.
 - [ ] Retry loops: `rg 'retry|backoff' -t rust -i` — retries without
       classification (retrying 4xx), without jitter/cap, or around
       non-idempotent operations.

--- a/skills/sota-rust/rules/05-security-supply-chain.md
+++ b/skills/sota-rust/rules/05-security-supply-chain.md
@@ -122,6 +122,14 @@ struct DbConfig { url: String, password: SecretString }
   Zeroize is best-effort (moves/reallocations copy bytes — avoid resizing
   buffers holding secrets; `Box::pin` long-lived keys), but it shrinks the
   window and kills the "secret in a core dump / Debug log" class.
+- **Don't rely *only* on `Drop` for security erasure.** `Drop` is skipped
+  entirely by `mem::forget`, `Box::leak`, reference cycles (`Rc`/`Arc`), a
+  panic mid-drop, and `panic = "abort"` / process exit — so Drop-based
+  zeroization is a window-shrinker, not a guarantee. Don't structure a security
+  argument ("the key is erased after use") on the destructor running; minimize
+  the secret's lifetime, avoid leaking/forgetting secret-bearing values, and
+  keep Drop impls panic-free (rules/02 §5) so the erasure path isn't skipped by
+  an abort. (ANSSI `LANG-DROP-SEC`; soundness corollary in rules/03.)
 - **No `Debug`/`Display`/`Serialize` leaking secrets**: manual `Debug` impls
   redacting sensitive fields; never `#[derive(Debug)]` on a struct holding a
   raw key. Audit `tracing` events for token/password fields.


### PR DESCRIPTION
## What

Diffed `sota-rust` against the **ANSSI Secure Rust Guidelines** — the nearest equivalent to OWASP Go-SCP, since no OWASP Rust-SCP exists. I pulled ANSSI's 75 formal rules (verbatim from the repo's raw markdown) and mapped each to our coverage. Most were already covered; **three** Rust-specific, security-relevant gaps were not, and this PR closes them.

| ANSSI rule | Fix | File |
|---|---|---|
| `LANG-DROP-NO-PANIC` — Drop impls must not panic (double-panic → process abort, DoS) | new bullet + audit grep | `rules/02 §5` |
| `LANG-DROP-SEC` — don't rely *only* on Drop for secret erasure (`mem::forget`/`Box::leak`/cycles/`panic=abort`/exit skip it) | new bullet | `rules/05 §5` |
| `LANG-CMP-INV` — uphold `Eq`/`Ord` invariants (broken `Ord` corrupts `sort`/`BinaryHeap`/`BTreeMap` or panics) | new bullet + audit grep | `rules/01 §6` |

Already-covered ANSSI rules (no change): integer overflow (`LANG-ARITH`), panic-limit/array-indexing (`LANG-LIMIT-PANIC*`, `LANG-ARRINDEXING`), unsafe/UB/encapsulation (`UNSAFE-NOUB`, `LANG-UNSAFE*`), `mem::forget` soundness + `into_raw`/`from_raw` + `MaybeUninit` (`MEM-*`), FFI unwinding (`FFI-NOPANIC`), dep audit/vet/geiger (`LIBS-*`), `Cargo.lock`/fmt/clippy/toolchain (`DENV-*`). The 21 granular FFI rules and niche tooling rules (`DENV-TIERS`, `cargo-outdated`) are deliberately **not** duplicated — `rules/03` covers FFI at the principle level and cites ANSSI for depth.

## Claim validation (per the repo's verify-before-asserting rule)
- ANSSI rule text read from the **raw source** (`github.com/ANSSI-FR/rust-guide`, `master`), not a summary.
- Double-panic→abort claim verified against the **std `Drop` docs**: *"`drop()` may itself be called during unwinding due to a panic, and if the `drop()` panics in that situation (a 'double panic'), this will likely abort the program."*
- Clippy lint names run against **clippy 0.1.91**: `derive_ord_xor_partial_ord` valid; `incorrect_partial_ord_impl_on_ord_type` is **renamed** → used the current `non_canonical_partial_ord_impl`.

## Checks
- `./scripts/check-invariants.sh` → PASS (01=310, 02=252, 05=251 lines; all <500)
- gitleaks → no leaks

## Note
Independent of #19 (Go CSPRNG). This branch is cut from `main` and touches only `sota-rust` + a rust-only CHANGELOG entry; the two PRs both add an `## [Unreleased]` heading, so whichever merges second will need a trivial CHANGELOG merge.
