### PR TITLE
feat(kubernetes): API Priority & Fairness + Dashboard notes (OWASP K8s cheat sheet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   silently corrupt or panic (`rules/01 §6`, `LANG-CMP-INV`). Added matching
   audit-checklist greps (clippy lint names verified against clippy 0.1.91);
   SKILL.md index updated.
+- **`sota-kubernetes/rules/01`** — added two items from the OWASP Kubernetes
+  Security cheat sheet that the skill didn't call out: API Priority & Fairness
+  (stable since v1.29, on by default; don't disable it, give high-value
+  controllers a dedicated `PriorityLevelConfiguration`, alert on flowcontrol
+  rejects) and a Kubernetes Dashboard hardening caveat (don't expose it; never
+  bind it to `cluster-admin`). Both with audit-checklist entries. The rest of
+  the cheat sheet was already met or exceeded by the existing rules.
 
 ## [1.4.0] - 2026-06-27
 

--- a/skills/sota-kubernetes/rules/01-control-plane-etcd.md
+++ b/skills/sota-kubernetes/rules/01-control-plane-etcd.md
@@ -38,6 +38,17 @@ These are kube-apiserver flags (or managed-cluster equivalents). Each is a CIS c
 | `--tls-min-version` | `VersionTLS12`+ ; strong cipher suites | Defense in depth on the API. |
 | `--profiling` | `false` in prod | `/debug/pprof` leaks data and is a DoS vector. |
 | `--request-timeout`, `--max-requests-inflight` | tuned | API server DoS resistance. |
+| `--enable-priority-and-fairness` | `true` (the default) | API Priority & Fairness — never set `false`. |
+
+**API Priority & Fairness (APF)** is stable since v1.29 and **on by default**; it
+supersedes the raw `--max-requests-inflight` limits by splitting that total
+concurrency across priority levels via `FlowSchema` + `PriorityLevelConfiguration`,
+with fair queuing so one runaway controller can't starve `leader-election` or
+node heartbeats. Audit: confirm it isn't disabled (`--enable-priority-and-fairness=false`
+is a finding), give a dedicated `PriorityLevelConfiguration` to high-value
+controllers, and alert on `apiserver_flowcontrol_rejected_requests_total`. A
+catch-all FlowSchema that lumps everything into one level re-creates the global-limit
+DoS APF exists to prevent.
 
 **Authentication**: prefer **OIDC** for human users (RBAC-design and SSO are
 `sota-identity-access` territory — wire it there). Never distribute the cluster-admin
@@ -196,6 +207,8 @@ machine:
 ## Audit checklist
 
 - [ ] API server: `--anonymous-auth=false`, `--authorization-mode` includes RBAC and not `AlwaysAllow`, `NodeRestriction` enabled, profiling off, audit configured? (`grep -E 'anonymous-auth|authorization-mode|NodeRestriction|profiling' /etc/kubernetes/manifests/kube-apiserver.yaml`; managed → check provider posture)
+- [ ] API Priority & Fairness left enabled (no `--enable-priority-and-fairness=false`), high-value controllers on a dedicated `PriorityLevelConfiguration`, `apiserver_flowcontrol_rejected_requests_total` alerted?
+- [ ] Kubernetes Dashboard: not deployed unless required; if deployed, NOT exposed publicly (no LoadBalancer/Ingress to it), reached only via `kubectl proxy`/authenticating proxy, and its ServiceAccount is least-privilege (never `cluster-admin`) — a privileged, exposed Dashboard is a one-click takeover (historic Tesla cryptojacking). Talos/DN does not ship it; keep it that way.
 - [ ] Kubelet: anonymous-auth off, authz `Webhook`, `read-only-port=0`? (`curl -sk https://NODE:10250/pods` should 401; `curl http://NODE:10255/pods` should refuse)
 - [ ] etcd encrypted at rest with KMS v2, `identity` not first, all existing Secrets rewritten? (`kubectl get secret -A -o json | head` against an etcd dump; check `EncryptionConfiguration`)
 - [ ] etcd reachable only from control plane, client/peer TLS cert-auth on? (`etcdctl` from a worker should fail)


### PR DESCRIPTION
Gap-checked `sota-kubernetes` against the [OWASP Kubernetes Security cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Kubernetes_Security_Cheat_Sheet.html).

**Verdict:** our skill already meets or exceeds the cheat sheet across all sections (control plane/etcd, RBAC, admission/PSA, supply chain, audit logging) — and is more current (the cheat sheet still references PodSecurityPolicy, removed in 1.25, and `ImagePolicyWebhook`, while we're on PSA + ValidatingAdmissionPolicy + Kyverno `verifyImages`). Two items weren't explicitly called out; added to `rules/01`:

- **API Priority & Fairness** — stable since **v1.29**, enabled by default; don't disable it, give high-value controllers a dedicated `PriorityLevelConfiguration`, alert on `apiserver_flowcontrol_rejected_requests_total`. Verified against the [K8s flow-control docs](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/).
- **Kubernetes Dashboard** hardening — don't deploy/expose it; never bind it to `cluster-admin`. (Talos/DN doesn't ship it.)

Both with audit-checklist entries. CHANGELOG updated. Invariants PASS (rules/01 at 220/500 lines).
