### PR TITLE
feat(llm,code-security): close OWASP AI/LLM cheat-sheet gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rejects) and a Kubernetes Dashboard hardening caveat (don't expose it; never
   bind it to `cluster-admin`). Both with audit-checklist entries. The rest of
   the cheat sheet was already met or exceeded by the existing rules.
+- **AI/LLM skills** — closed gaps found by diffing against the new OWASP
+  AI/LLM cheat sheets (MCP Security, RAG Security, AI Agent Security, Secure AI
+  Model Ops): MCP **server-operator** hardening — bind localhost, validate
+  `Origin`/`Host` (DNS-rebinding), context-bound session IDs, narrow scopes
+  (`sota-llm-engineering/rules/04`); self-hosted vector DBs ship auth-OFF
+  (Qdrant) — require API key/TLS/internal network, restrict writes, hash chunks
+  (`sota-code-security/rules/08 §4`); RAG corpus integrity — content-hash +
+  verify, don't leak raw similarity scores (`sota-llm-engineering/rules/03 §7`);
+  strip invisible/bidi/Trojan-Source Unicode at ingest
+  (`sota-code-security/rules/09 §4`).
 
 ## [1.4.0] - 2026-06-27
 

--- a/skills/sota-code-security/rules/08-llm-ai-security.md
+++ b/skills/sota-code-security/rules/08-llm-ai-security.md
@@ -184,6 +184,12 @@ results = vstore.search(
 - Membership/extraction: embeddings are not anonymization — vectors can be
   inverted approximately; protect vector stores like the source documents
   (encryption, access control, no public endpoints).
+- **Self-hosted vector DBs ship auth-OFF by default** (Qdrant, among others):
+  set an API key / JWT, enable TLS, and bind to an internal-only network — an
+  exposed keyless vector endpoint is full corpus read/write (poisoning + theft).
+  Restrict *write* access to the ingestion pipeline identity only, and hash each
+  ingested document (e.g. SHA-256) so tampered/poisoned chunks are detectable
+  and excludable at retrieval.
 - Cache keyed on prompts must be principal-scoped (semantic caches returning
   user A's answer — containing A's data — to user B).
 

--- a/skills/sota-code-security/rules/09-untrusted-data-ingestion.md
+++ b/skills/sota-code-security/rules/09-untrusted-data-ingestion.md
@@ -154,6 +154,13 @@ body, _ := io.ReadAll(r.Body)       body, err := io.ReadAll(io.LimitReader(r.Bod
   signal and a mass-assignment vector (rules/07) — reject, don't ignore.
 - **Allowlist** values, formats, ranges, enums. **Canonicalize then validate**
   (rules/01 §1) — normalize unicode/encoding once before checking.
+- **Strip/flag invisible and deceptive Unicode** on text bound for an LLM context
+  or a UI (RAG-corpus and feed text especially): zero-width characters
+  (U+200B–200D, U+FEFF), bidirectional overrides (U+202A–202E, U+2066–2069 —
+  *Trojan-Source*, CVE-2021-42574), and tag characters (U+E0000–E007F) hide
+  injected instructions a reviewer can't see. Normalize (NFKC), drop the
+  format/control categories you don't expect, and flag homoglyph-heavy strings.
+  This is the ingest-side complement to the prompt-injection boundary (rules/08).
 - **Determine type from bytes, not declaration.** Sniff the real MIME from magic
   bytes and reject when it disagrees with the declared/extension type. Beware
   **polyglot files** (valid GIF *and* valid HTML/JS — "GIFAR"): a file that is two

--- a/skills/sota-llm-engineering/rules/03-rag-retrieval.md
+++ b/skills/sota-llm-engineering/rules/03-rag-retrieval.md
@@ -157,6 +157,14 @@ tell you which stage failed (rules/01 §6).
   Track and alert on index lag (source `updated_at` vs index `indexed_at`);
   surface document dates to the model so it can prefer current sources and
   caveat stale ones.
+- **Corpus integrity (OWASP RAG Security):** the vector store is attacker-
+  reachable if anyone can write to it. Restrict writes to the ingestion
+  identity, store a content hash (SHA-256) per chunk and verify it before
+  serving (exclude + alert on mismatch — poisoning/tamper detection), and
+  **don't return raw similarity/distance scores to end users or sub-agents** —
+  they let an attacker probe and reconstruct corpus contents. Rate-limit
+  retrieval per identity. Vector-DB auth/network hardening is in
+  sota-code-security rules/08 §4.
 
 ## 8. Agentic retrieval vs one-shot
 

--- a/skills/sota-llm-engineering/rules/04-agents-tools.md
+++ b/skills/sota-llm-engineering/rules/04-agents-tools.md
@@ -191,7 +191,16 @@ deprecation policy). Engineering consequences:
   most public MCP servers ship vague descriptions and unbounded outputs;
   wrap or fix them before production.
 - Credentials for MCP servers belong in a secrets/vault layer, never in
-  prompts or agent-visible config (sota-secrets-management).
+  prompts or agent-visible config (sota-secrets-management). Request the
+  **narrowest scope per server** (`mail.readonly`, not `mail.full`) and prefer
+  short-lived tokens over long-lived PATs.
+- **When you *operate* an MCP server (DN self-hosts them), harden the server,
+  not just the client** (OWASP MCP Security): bind local HTTP/SSE transports to
+  `127.0.0.1`, not `0.0.0.0`; **validate the `Origin`/`Host` header on every
+  request** to block DNS-rebinding from a browser tab; use non-guessable session
+  IDs bound to user context (`<user_id>:<session_id>`), never a bare sequence;
+  put remote servers behind TLS with verified server identity and auth. An
+  unauthenticated MCP server on `0.0.0.0` is an open tool-execution endpoint.
 
 ## 7. Multi-agent: patterns and their real costs
 


### PR DESCRIPTION
Diffed the AI/LLM skills against the **new OWASP AI/LLM cheat sheets** (MCP Security, RAG Security, AI Agent Security, Secure AI Model Ops, LLM Prompt Injection, Secure Coding with AI) — relevant to DN's LLM-core projects (ContextIPS, AethelGard, Memex). A read-only agent validated each gap against the actual files.

**Already strong (no change):** prompt-injection boundaries (dual-LLM/quarantine, lethal trifecta), tool-call authz vs the human principal, output-as-untrusted + markdown-exfil/CSP, ACL-at-retrieval + cross-tenant warnings, the MCP attack taxonomy (tool poisoning/rug-pull/shadowing/line-jumping), agent budgets + HITL, safetensors pinning.

**Four DN-relevant gaps closed:**
1. **MCP server-operator hardening** (DN self-hosts MCP) — bind `127.0.0.1`, validate `Origin`/`Host` (DNS-rebinding), context-bound non-guessable session IDs, narrow per-server scopes → `sota-llm-engineering/rules/04 §6`.
2. **Self-hosted vector DBs ship auth-OFF** (Qdrant) — require API key/TLS/internal network, restrict writes, hash chunks → `sota-code-security/rules/08 §4`.
3. **RAG corpus integrity** — content-hash + verify before serving, don't return raw similarity scores → `sota-llm-engineering/rules/03 §7`.
4. **Invisible/bidi/Trojan-Source Unicode** (CVE-2021-42574) stripped at ingest → `sota-code-security/rules/09 §4`.

**Deferred (intentional):** inter-agent message signing (conditional — Low for in-process personas like AethelGard); GPU/accelerator isolation (→ sota-sandboxing); slopsquatting/hallucinated deps (→ supply-chain batch PR).

Invariants PASS (all files <500 lines). CHANGELOG updated.
