### PR TITLE
feat(api-design,code-security): close OWASP API/web cheat-sheet gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verify, don't leak raw similarity scores (`sota-llm-engineering/rules/03 §7`);
   strip invisible/bidi/Trojan-Source Unicode at ingest
   (`sota-code-security/rules/09 §4`).
+- **API & web skills** — closed gaps from the OWASP REST/GraphQL/WebSocket/
+  Clickjacking cheat sheets: per-route method allowlist + `405` + per-method
+  authz and content-negotiation hygiene (`406`, never reflect `Accept` into
+  `Content-Type`) in `sota-api-design/rules/01`; `wss://`-only + disable
+  `permessage-deflate` (CRIME/BREACH) in `rules/05`; GraphQL alias/batch as an
+  auth **brute-force** (not just cost-DoS) vector in `rules/03`; server-side
+  business-flow state-machine enforcement on API6 in `rules/07`; and
+  **double-clickjacking** (bypasses `frame-ancestors`/XFO → needs interaction
+  confirmation) in `sota-code-security/rules/05 §5`.
 
 ## [1.4.0] - 2026-06-27
 

--- a/skills/sota-api-design/rules/01-rest-http-design.md
+++ b/skills/sota-api-design/rules/01-rest-http-design.md
@@ -40,6 +40,11 @@ workflow, contract testing.
   create-or-replace for free — often better than `POST` + idempotency key.
 - Don't tunnel everything through POST "because firewalls". If a gateway blocks
   PATCH, use `POST` + `X-HTTP-Method-Override` only as a documented escape hatch.
+- **Per-route method allowlist** (OWASP REST): each route permits an explicit set
+  of methods and returns `405` for the rest — don't let the framework expose
+  `PUT`/`DELETE`/`TRACE` on a read-only route by default. Re-check authorization
+  **per method**, not just per path (a user allowed to `GET` an order is not
+  thereby allowed to `DELETE` it).
 
 ## 3. Status codes — the ones that matter
 
@@ -55,7 +60,12 @@ workflow, contract testing.
   permanently (deprecated endpoint after sunset).
 - `412` precondition failed (ETag mismatch); `428` precondition required (you demand
   `If-Match` and it's missing).
-- `429` rate limited + `Retry-After`; `413` body too large; `415` wrong content type.
+- `429` rate limited + `Retry-After`; `413` body too large; `415` wrong content type
+  (request); `406` when you can't satisfy the client's `Accept` (response negotiation).
+- **Content negotiation hygiene** (OWASP REST): validate `Content-Type` on writes,
+  honour `Accept` for the response and `406` when unsupported — but **never reflect
+  the client's `Accept` value into the response `Content-Type`** (a path to XSS /
+  content sniffing). Serve JSON as `application/json`, never `application/javascript`.
 - `500` your bug; `502/503/504` upstream/overload/timeout. **Never** return `200`
   with `{"error": ...}` in the body — it breaks retries, monitoring, caching, and
   every generic client.

--- a/skills/sota-api-design/rules/03-graphql.md
+++ b/skills/sota-api-design/rules/03-graphql.md
@@ -92,7 +92,11 @@ friends ... }}}}`). Layered defenses, all of them:
 6. **Disable introspection and GraphiQL in production** for non-public schemas;
    disable field suggestions ("Did you mean `creditCard`?") which leak schema.
 7. **Reject batched arrays of operations** or cap batch size — batching multiplies
-   everything above and bypasses per-request rate limits.
+   everything above and bypasses per-request rate limits. Beyond cost-DoS this is a
+   **rate-limit-bypass brute-force vector**: aliases/batches let one HTTP request
+   carry hundreds of `login`/OTP/token/password-reset attempts past per-request
+   throttles. Disable aliasing/batching on auth operations and rate-limit those
+   fields **per object/account**, not just per request.
 
 ## 5. Persisted queries
 

--- a/skills/sota-api-design/rules/05-realtime-websockets-sse.md
+++ b/skills/sota-api-design/rules/05-realtime-websockets-sse.md
@@ -35,6 +35,13 @@ Decision rules:
 
 ### 2.1 Auth before (or immediately after) upgrade
 
+- **`wss://` only in production** — never `ws://`. A plaintext socket leaks
+  tokens/session data and is trivially MITM'd; treat `ws://` carrying credentials
+  as a High finding (mirrors the mTLS-internal baseline).
+- **Disable `permessage-deflate` compression** when the stream can carry secrets
+  alongside attacker-influenced data — compression-ratio side channels are the
+  CRIME/BREACH class applied to WebSockets. Leave it off unless you've reasoned
+  about what shares the frame.
 - The upgrade request is a GET: **no custom `Authorization` header from browser
   `WebSocket()`**. Your options, in order of preference:
   1. **Cookie auth** (same-origin apps): session cookie rides the upgrade; **must**

--- a/skills/sota-api-design/rules/07-security-operations.md
+++ b/skills/sota-api-design/rules/07-security-operations.md
@@ -208,7 +208,7 @@ Cross-tenant data leakage is the worst API bug class. Defense in depth:
 | API3 Object Property Level Auth | rules/01 §1 (explicit DTOs — no mass assignment/ORM dumps), §1 authz |
 | API4 Unrestricted Resource Consumption | §2–4 — rate limits, quotas, size limits, timeout budgets; rules/03 §4 |
 | API5 Broken Function Level Auth | §1 — deny-by-default policy, admin surface separation |
-| API6 Unrestricted Access to Sensitive Business Flows | §2 cost-weighted limits + flow-specific throttles |
+| API6 Unrestricted Access to Sensitive Business Flows | §2 cost-weighted limits + flow-specific throttles; **enforce multi-step flow order server-side** — model the flow as a state machine, validate the current state on every step, reject out-of-order/replayed steps (don't trust client sequencing). Business-logic depth: sota-code-security |
 | API7 SSRF | rules/06 §8 — webhook/user-URL egress controls |
 | API8 Security Misconfiguration | §5 CORS, §8 gateway/TLS; rules/03 §4 introspection |
 | API9 Improper Inventory Management | rules/02 §5 — versioned, measured, sunset surfaces; spec-as-truth (rules/01 §10) |

--- a/skills/sota-code-security/rules/05-web-security.md
+++ b/skills/sota-code-security/rules/05-web-security.md
@@ -128,6 +128,13 @@ request: X-CSRF-Token header must equal the cookie value, verified server-side
   `frame-ancestors`.
 - For OAuth consent screens, payment confirmations, and account-change pages,
   framing protection is mandatory, not optional.
+- **Double-clickjacking** (2024-class) bypasses `frame-ancestors`/XFO entirely —
+  it uses a timed window swap during a double-click rather than a persistent
+  frame, so framing headers never fire. Defend sensitive one-click actions
+  (OAuth "Authorize", account/payment/permission changes) with an
+  interaction-gated confirmation step (re-auth, an explicit second action, or a
+  short delay before the control is live), not framing headers alone. Disabling
+  unintended same-window opener access (`SameSite` cookies, `noopener`) helps.
 
 ## 6. Security headers (baseline set)
 


### PR DESCRIPTION
Diffed `sota-api-design` + `sota-code-security/05` against the OWASP **REST / GraphQL / gRPC / WebSocket / CSP / HTTP Headers / Clickjacking** cheat sheets (validated by a read-only agent against the actual files).

**Already strong (no change):** CSWSH `Origin` check + heartbeats + resume (WS), GraphQL depth/cost/alias/introspection caps, gRPC deadlines/mTLS/reflection/size limits, full CSP (nonce + strict-dynamic + Trusted Types) + header baseline + `__Host-` cookies + COOP/COEP/CORP.

**Gaps closed:**
- **REST** — per-route method allowlist + `405` + per-method authz; content-negotiation hygiene (`406`; never reflect `Accept` into `Content-Type`) → `rules/01`.
- **WebSocket** — `wss://`-only; disable `permessage-deflate` (CRIME/BREACH side channel) → `rules/05`.
- **GraphQL** — alias/batch as a rate-limit-bypass **brute-force** vector for auth operations, not only cost-DoS → `rules/03 §4`.
- **REST API6** — enforce multi-step business-flow order server-side as a state machine → `rules/07 §9` (business-logic depth lands in the server-side-attacks batch).
- **Clickjacking** — **double-clickjacking** bypasses `frame-ancestors`/XFO; sensitive one-click actions need an interaction-confirmation step → `sota-code-security/rules/05 §5`.

Excluded as not-DN: XXE/XML cheat-sheet items (JSON/protobuf stack). Invariants PASS. CHANGELOG updated.
