### PR TITLE
feat(devsecops): close OWASP supply-chain/CI-CD cheat-sheet gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   business-flow state-machine enforcement on API6 in `rules/07`; and
   **double-clickjacking** (bypasses `frame-ancestors`/XFO → needs interaction
   confirmation) in `sota-code-security/rules/05 §5`.
+- **`sota-devsecops`** — closed gaps from the OWASP GitHub Actions / CI-CD /
+  Software Supply Chain / Vulnerable Dependency Management cheat sheets:
+  impostor-commit verification (a SHA pin can point at a fork-network commit —
+  zizmor `impostor-commit`) and CodeQL `actions` workflow analysis in `rules/01`;
+  ban `secrets: inherit` + `::add-mask::` for derived secrets + disable build
+  caching in release/publish workflows in `rules/01`; a no-upstream-patch
+  mitigation playbook and **slopsquatting** (AI-hallucinated packages) in
+  `rules/03`. External facts (zizmor rule, CodeQL `actions` GA Apr 2025) verified.
 
 ## [1.4.0] - 2026-06-27
 

--- a/skills/sota-devsecops/rules/01-pipeline-security.md
+++ b/skills/sota-devsecops/rules/01-pipeline-security.md
@@ -96,6 +96,13 @@ did not.
 ```
 
 - Pin transitively-trusted actions too (composite actions you own should pin their deps).
+- **A SHA pin is necessary but not sufficient — verify the SHA is a real commit in
+  the action's own repo.** GitHub stores a repo and its forks as one commit
+  "network", so a commit that exists only in an attacker's fork can be referenced by
+  the upstream `owner/repo@sha` slug (an "impostor commit"; the `github/dmca@565ece4`
+  case is the classic example). Run zizmor's `impostor-commit` audit (an online check
+  — needs a GitHub API token) in CI, and review external PRs that add/bump a pinned
+  SHA by confirming the commit on the claimant repo.
 - Keep pins fresh with Renovate (`helpers:pinGitHubActionDigests` preset) or Dependabot —
   a stale pin is a vuln-management problem, an unpinned action is a supply chain hole.
 - `actions/*` (GitHub first-party) at a tag is tolerable (Low) but pin anyway for
@@ -196,7 +203,9 @@ name!), `github.event.pull_request.head.ref`, commit messages
 - Cache poisoning: `actions/cache` is scoped, but a cache written by a default-branch
   workflow is trusted by all branches. Never cache across trust boundaries (e.g., don't
   restore caches written by PR workflows into release builds; scope keys by ref where the
-  content influences build output).
+  content influences build output). **For release/publish/signing workflows, disable
+  build caching outright** — a single poisoned cache entry restored into a job that signs
+  or publishes taints the released artifact; the speedup isn't worth the supply-chain risk.
 
 ## 1.7 Protected branches, environments, signed commits
 
@@ -241,14 +250,22 @@ name!), `github.event.pull_request.head.ref`, commit messages
   *current* secrets — relevant after rotating a compromised workflow; revoke environments
   or disable old runs rather than assuming history is inert.
 - Lint the workflow estate continuously: `zizmor` (injection, pwn-requests, unpinned,
-  excessive permissions) and `actionlint` as a required check on `.github/workflows/**`
-  changes — the linters encode most of §§1.1–1.5 and catch regressions humans rubber-stamp.
+  excessive permissions, `impostor-commit`) and `actionlint` as a required check on
+  `.github/workflows/**` changes — the linters encode most of §§1.1–1.5 and catch
+  regressions humans rubber-stamp. Add **CodeQL's `actions` language** (GA April 2025;
+  auto-enabled in code-scanning *default setup* when workflow files are present, or add
+  `actions` to the language matrix in advanced setup) — it does taint/data-flow analysis
+  on workflows that the YAML linters can't.
 
 ## 1.10 Secrets hygiene in CI
 
 - Secrets are masked in logs by value-match only: derived values (base64 of a secret, a
-  URL embedding it) print in cleartext. Never log request bodies/headers in CI; set
-  `ACTIONS_STEP_DEBUG` consciously.
+  URL embedding it) print in cleartext. Register any value you compute from a secret with
+  `echo "::add-mask::$VALUE"` before it can be printed. Never log request bodies/headers
+  in CI; set `ACTIONS_STEP_DEBUG` consciously.
+- **Never `secrets: inherit` when calling a reusable workflow** — it hands the called
+  workflow *every* secret in scope. Pass each secret explicitly with `secrets:`
+  (least privilege), and pin the reusable workflow by SHA (§1.8).
 - Scope: org secret < repo secret < environment secret. Push every prod credential down to
   an environment with required reviewers.
 - No secrets in `if:` conditions or step outputs (outputs are visible to later steps of

--- a/skills/sota-devsecops/rules/03-dependencies.md
+++ b/skills/sota-devsecops/rules/03-dependencies.md
@@ -107,6 +107,11 @@ Review *new* dependencies (human + automated) for:
   default via `onlyBuiltDependencies`.
 - **Name proximity** to a popular package (`lodahs`, `python-dateutil` vs `dateutil`),
   starjacking (README/links pointing at an unrelated popular repo).
+- **Slopsquatting** (OWASP "Secure Coding with AI"): AI coding assistants routinely
+  invent plausible-but-nonexistent package names, and attackers pre-register them.
+  **Verify every AI-suggested dependency actually exists with real history** (downloads,
+  age, repo) before adding it — never `pip install`/`npm i` a name straight from a model.
+  An approved-package allowlist plus the §3.7 cooldown blunts both this and typosquats.
 - **Freshness/maintainer churn**: version published < 5–7 days ago (see cooldown, §3.7),
   brand-new maintainer on an old package, ownership transfer right before a release —
   the xz-utils pattern.
@@ -189,6 +194,12 @@ ignore:
 - BAD patterns to flag: global `--severity-threshold critical` only (blind to exploited
   Highs); scanner runs with `continue-on-error: true`; one giant ignore list dated two
   years ago; scanning only on PR (never re-scanning deployed images).
+- **No upstream patch available** (reachable vuln, no fixed version): triage doesn't stop
+  at "no fix" (OWASP Vulnerable Dependency Management). In order of preference — guard the
+  vulnerable call path with input validation/feature-flag kill-switch; virtual-patch at
+  the edge (WAF/admission, sota-detection-engineering); fork-and-patch with an upstream PR
+  and a regression test reproducing the vuln (§3.8); or replace the dependency. Record the
+  chosen mitigation as VEX and set a re-check date — never just ignore-with-expiry.
 
 ## 3.7 Renovate / Dependabot strategy
 


### PR DESCRIPTION
Diffed `sota-devsecops` against the OWASP **GitHub Actions / CI-CD / Software Supply Chain / Dependency Graph-SBOM / Vulnerable Dependency Management** cheat sheets (validated by a read-only agent against the actual files).

**Already strong (no change):** SLSA L3, keyless cosign with *exact* identity verification, OIDC `sub`-pinning, `pull_request_target`/`workflow_run` pwn-request handling, script-injection via `env:` indirection, frozen lockfiles, dependency-confusion/registry scoping, OpenVEX + KEV/EPSS triage, the Zot registry finding.

**Gaps closed — `rules/01`:**
- **impostor-commit** — a 40-char SHA pin can still reference a commit that exists only in an attacker's fork (GitHub's commit "network"); run zizmor's `impostor-commit` online audit and review pinned-SHA bumps. (`github/dmca@565ece4` is the classic case.)
- **CodeQL `actions`** — taint analysis of workflows the YAML linters miss (GA April 2025; auto-on in default setup).
- Ban **`secrets: inherit`** on reusable-workflow calls; **`::add-mask::`** for derived secret values; **disable build caching in release/publish** workflows.

**Gaps closed — `rules/03`:**
- **No-upstream-patch playbook** (guard → virtual-patch → fork-and-patch+test → replace, recorded as VEX).
- **Slopsquatting** — verify AI-suggested packages actually exist before install.

External facts verified against primary sources: [zizmor impostor-commit](https://docs.zizmor.sh/audits/), [CodeQL Actions GA (2025-04-22)](https://github.blog/changelog/2025-04-22-github-actions-workflow-security-analysis-with-codeql-is-now-generally-available/). Invariants PASS. CHANGELOG updated.
