### PR TITLE
feat(identity,secrets,crypto): close OWASP authn/secrets/crypto cheat-sheet gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   caching in release/publish workflows in `rules/01`; a no-upstream-patch
   mitigation playbook and **slopsquatting** (AI-hallucinated packages) in
   `rules/03`. External facts (zizmor rule, CodeQL `actions` GA Apr 2025) verified.
+- **Identity, secrets & crypto skills** — closed gaps from the OWASP
+  Authentication/Authorization/OAuth2/Session/Secrets/Key-Management/TLS cheat
+  sheets: OAuth **mix-up** defense via the RFC 9207 `iss` authorization-response
+  parameter for multi-AS brokers (`sota-identity-access/rules/01`); log
+  authorization decisions/denials (`rules/03`); treat the vault as tier-0 — HA,
+  off-box snapshot + DR-restore drill, break-glass (`sota-secrets-management/rules/02`);
+  design for key **loss** — escrow/back up data keys, never signing keys
+  (`sota-code-security/rules/04`); session renewal timeout + `Clear-Site-Data`/
+  `no-store` on logout (`rules/02`); hybrid PQ KEX `X25519MLKEM768` and
+  trust-store-injection control (`sota-network-security/rules/06`).
 
 ## [1.4.0] - 2026-06-27
 

--- a/skills/sota-code-security/rules/02-authentication.md
+++ b/skills/sota-code-security/rules/02-authentication.md
@@ -55,6 +55,10 @@ if ph.check_needs_rehash(hash): store(ph.hash(attempt))
   **server-side**, not just clear the cookie.
 - On password change or "log out everywhere": revoke all of the user's sessions.
   Maintain a session registry to make this possible.
+- **Renewal timeout**: regenerate the session ID periodically mid-session (e.g. every
+  few hours) even without a privilege change, capping the window a stolen ID is useful.
+- On logout/sensitive responses, send `Clear-Site-Data: "cookies", "storage"` and
+  `Cache-Control: no-store` so the session artifact isn't left in the browser/proxy cache.
 - Bind nothing secret into URLs: session tokens in query strings leak via logs,
   referrers, and browser history (CWE-598).
 - "Remember me" done right: a separate long-lived token, never an extended

--- a/skills/sota-code-security/rules/04-cryptography.md
+++ b/skills/sota-code-security/rules/04-cryptography.md
@@ -99,6 +99,12 @@ token = secrets.token_urlsafe(32)                                  # 256-bit URL
 - Envelope encryption for data at rest: KMS master key wraps per-object data
   keys; plaintext data keys held only in memory, zeroized where the language
   allows.
+- **Design for key *loss*, not just compromise** (OWASP Key Management): a root key
+  with no recovery path means every ciphertext it protects is gone (the SOPS+age root
+  is exactly this risk — back it up to hardware/escrow). **Back up / escrow
+  data-encryption keys** so encrypted data stays recoverable; **never escrow signing or
+  authentication keys** — a second copy destroys non-repudiation. Store key backups
+  under the same KMS/HSM control as the originals, with their own access audit.
 - Key material in memory: avoid copies (immutable strings in GC languages spread
   copies — prefer byte arrays you can zero); never in logs, exceptions, or
   serialized debug output.

--- a/skills/sota-identity-access/rules/01-federation-protocols.md
+++ b/skills/sota-identity-access/rules/01-federation-protocols.md
@@ -84,6 +84,13 @@ claims = verify(token,
 assert claims.get("azp", claims["aud"]) == "web-app"
 ```
 
+- **Mix-up defense when the RP/broker talks to more than one AS** (Kanidm *plus* any
+  upstream/social IdP): validate the `iss` **authorization-response** parameter
+  (RFC 9207), not just the ID-token `iss`. Without it, an attacker who can make the
+  user start a login at an honest AS can swap in a malicious AS's authorization
+  response and have the code/token redeemed at the wrong endpoint. Single-AS
+  deployments are unaffected, but wire it in before adding a second IdP.
+
 - **Discovery & JWKS**: configure from `/.well-known/openid-configuration` (OpenID
   Connect Discovery 1.0), cache the `jwks_uri` keys, and honor key rotation by `kid`
   (re-fetch on unknown `kid`; do not pin a single key forever). Cache JWKS with a sane

--- a/skills/sota-identity-access/rules/03-authorization-models.md
+++ b/skills/sota-identity-access/rules/03-authorization-models.md
@@ -82,6 +82,11 @@ role := "viewer"  # <-- default low role for ANY authenticated user regardless o
   High finding depending on the blast radius.
 - **Just-in-time elevation** rather than standing privilege (rules/05): a user requests a
   permission for a bounded window instead of holding it permanently.
+- **Log authorization decisions** (OWASP Authorization): the decision point emits a
+  structured event — `who`, `action`, `resource`, `decision`, `policy/rule id` — for at
+  least every *deny* and every privileged *allow*. Denies are a primary detection signal
+  (enumeration, broken-object-level-auth probing); without them an authz bypass is
+  invisible. Feed them to sota-detection-engineering; never log the token/credential.
 
 ## 5. Policy-as-code engines
 

--- a/skills/sota-network-security/rules/06-dns-tls-pki.md
+++ b/skills/sota-network-security/rules/06-dns-tls-pki.md
@@ -51,6 +51,13 @@ sensible max-age (and `includeSubDomains` once you're sure) so browsers refuse p
 short-lived certs (R1) reduce reliance on revocation anyway — a 47-day cert that's compromised
 expires fast. Prefer ECDSA (P-256) certs for performance; RSA-2048+ acceptable.
 
+**R3.1 — Enable hybrid post-quantum key exchange where the stack supports it.** Offer the
+`X25519MLKEM768` hybrid group on TLS 1.3 (already default-on in modern stacks, e.g. Go 1.24+;
+configurable in current OpenSSL/BoringSSL and major CDNs). It defends *confidentiality* against
+harvest-now-decrypt-later — relevant for EU/long-lived-sensitive traffic — at negligible cost,
+and being hybrid it's no weaker than X25519 if the PQ part is ever broken. (Signatures/PKI stay
+classical for now.) See sota-code-security rules/04 §1.
+
 ## 3. DNS security
 
 **R4 — Registrar & issuance hygiene.** (Setup is cloud-infra rules/03; the *security* controls:)
@@ -98,6 +105,10 @@ sota-detection-engineering — feed it your resolver logs.
   recurring bug: a service can't validate internal certs because the root isn't distributed →
   someone "fixes" it with `InsecureSkipVerify`/`--insecure` (R11). Distribute the root, never skip
   verification.
+- **Control what gets *into* the trust store** (OWASP Key Management): adding a root to a
+  workload's trust bundle is a privileged, audited change — a rogue/extra CA is silent MITM for
+  everything that workload talks to. Ship trust bundles as immutable, version-controlled artifacts
+  (baked into the image / GitOps-managed), not mutated at runtime; alert on drift in the bundle.
 - **Protect the CA key** (sota-secrets-management): the private CA's signing key is a crown jewel —
   HSM/KMS-backed or tightly access-controlled; its compromise mints trusted certs for everything.
 - **Separate intermediates** per purpose/environment so one can be rotated/revoked without

--- a/skills/sota-secrets-management/rules/02-storage-backends.md
+++ b/skills/sota-secrets-management/rules/02-storage-backends.md
@@ -46,6 +46,12 @@ Non-negotiables:
 - **Short token/lease TTLs** (≤1h default, renewable) so a stolen token expires; audit devices
   enabled and shipped off-box; auto-unseal via cloud KMS, recovery keys Shamir-split among ≥3
   officers and never stored together.
+- **Treat the vault itself as a tier-0 asset** (same bar as the IdP, identity-access rules/02):
+  run it **HA** (Raft ≥3 nodes / clustered) so one node loss isn't an outage; take **encrypted
+  Raft/storage snapshots on a schedule, ship them off-box, and DR-restore-drill** them — an
+  unrecoverable secrets store is a total outage *and* the place every dynamic credential dies;
+  define a **break-glass** path (sealed root token / extra recovery-key quorum, stored offline)
+  for when auth backends or the network are down, and **log + alert on every use** of it.
 
 ```hcl
 # BAD — god policy bound to a token pasted into CI variables


### PR DESCRIPTION
Diffed `sota-identity-access`, `sota-secrets-management`, `sota-code-security` (02/04), and `sota-network-security/06` against the OWASP **Authentication / Authorization / OAuth2 / Session Management / MFA / Secrets Management / Key Management / TLS** cheat sheets (validated by a read-only agent against the actual files).

**Already strong (no change):** Auth-Code+PKCE-only, full ID-token claim validation incl. RS256→HS256 confusion, exact redirect URIs, refresh rotation + reuse detection, JML/deprovisioning, Kanidm break-glass, passkeys + CAEP/SSF, argon2id, AEAD+nonce discipline, envelope encryption, ACME/cert-lifetime, step-ca internal PKI.

**Gaps closed:**
- **OAuth mix-up** — validate the RFC 9207 `iss` *authorization-response* parameter when a broker talks to >1 AS (Kanidm + upstream IdP) → `identity-access/rules/01`.
- **Log authz decisions/denials** as a detection signal → `identity-access/rules/03`.
- **Vault as tier-0** — HA, off-box snapshots + DR-restore drill, break-glass with alerting → `secrets-management/rules/02`.
- **Design for key loss** — escrow/back up *data* keys, never *signing* keys → `code-security/rules/04`.
- **Session** renewal timeout + `Clear-Site-Data`/`no-store` on logout → `code-security/rules/02`.
- **Hybrid PQ KEX** `X25519MLKEM768` (default-on Go 1.24+) + **trust-store-injection** control → `network-security/rules/06`.

Excluded as not-DN: FIPS 140-3 validation (US-centric; DN is EU), security-question deprecation (passkeys-first). Invariants PASS. CHANGELOG updated.
