### PR TITLE
feat(code-security,databases): close OWASP server-side-attack cheat-sheet gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`sota-code-security/rules/04`); session renewal timeout + `Clear-Site-Data`/
   `no-store` on logout (`rules/02`); hybrid PQ KEX `X25519MLKEM768` and
   trust-store-injection control (`sota-network-security/rules/06`).
+- **Server-side attack coverage** — closed gaps from the OWASP Business Logic,
+  SSRF, Injection, and Deserialization cheat sheets. The injection/IDOR/mass-
+  assignment/upload/DoS families were already strong; added the under-covered
+  **business-logic** doctrine: semantic/cross-field validation + treat
+  hidden/disabled/echoed fields as adversarial (`sota-code-security/rules/01`),
+  server-side re-derivation of prices/totals/quotas (`rules/07`), and full
+  workflow state-machine integrity — consume one-time ops, expire partial state,
+  no client-side workflow position (`rules/03`). Plus SSRF blocklist broadened to
+  all multicast + CGNAT 100.64/10 (`rules/01`), serialized-payload (pickle/Java/
+  PHP) signature detection at ingest (`rules/09`), and Redis `EVAL`/Qdrant-filter
+  injection guidance (`sota-databases/rules/06`).
 
 ## [1.4.0] - 2026-06-27
 

--- a/skills/sota-code-security/rules/01-input-injection.md
+++ b/skills/sota-code-security/rules/01-input-injection.md
@@ -23,6 +23,14 @@ without a structural boundary. Fix the boundary; never "sanitize" your way out.
 - Validate server-side. Client-side validation is UX, not security.
 - Length-limit every string input. Unbounded input is a DoS primitive even when
   syntactically valid.
+- **Validate semantics, not just syntax** (OWASP Business Logic): enforce cross-field
+  and business invariants the type system can't (`checkout` after `checkin`,
+  `quantity ≥ 1`, end-date after start-date, currency matches account). A
+  well-formed-but-nonsensical request is still an attack.
+- **Anything the client can set is adversary-controlled** — hidden form fields,
+  disabled inputs, pre-filled values, and data you returned last response included.
+  Re-validate and re-authorize them server-side; never trust them because "the UI
+  doesn't allow changing it".
 
 ```python
 # BAD: denylist, validates pre-decoding
@@ -135,8 +143,9 @@ transport := &http.Transport{
         if err != nil { return nil, err }
         for _, ip := range ips {
             if ip.IP.IsLoopback() || ip.IP.IsPrivate() || ip.IP.IsLinkLocalUnicast() ||
-               ip.IP.IsLinkLocalMulticast() || ip.IP.IsUnspecified() {
-                return nil, errors.New("blocked address")
+               ip.IP.IsMulticast() || ip.IP.IsUnspecified() || isCGNAT(ip.IP) {
+                return nil, errors.New("blocked address") // IsMulticast covers 224/4 + ff00::/8;
+                // isCGNAT blocks 100.64.0.0/10 (carrier-grade NAT, reaches internal hosts)
             }
         }
         return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))

--- a/skills/sota-code-security/rules/03-authorization.md
+++ b/skills/sota-code-security/rules/03-authorization.md
@@ -86,7 +86,12 @@ if doc is None: abort(404)                # don't leak existence with 403 vs 404
   (`X-Admin: true`).
 - State-machine authorization: actions valid only in certain states (approve own
   expense report, re-trigger completed payment) need state checks server-side —
-  workflow bypass is an authz bug.
+  workflow bypass is an authz bug. Enforce the full doctrine (OWASP Business Logic):
+  validate the current state on every step and reject out-of-order transitions;
+  **mark one-time operations consumed** so a captured request can't be replayed
+  (payment capture, coupon redemption, password-reset token); expire abandoned
+  partial-workflow state; and **never store the workflow position in a client-readable/
+  writable field** — keep it server-side keyed to the session/resource.
 
 ## 4. Model choice: RBAC / ABAC / ReBAC
 

--- a/skills/sota-code-security/rules/07-data-exposure.md
+++ b/skills/sota-code-security/rules/07-data-exposure.md
@@ -126,6 +126,12 @@ user.apply(UpdateProfile(**request.json))
   `User.update(req.body)`, GraphQL input types mirroring DB models.
 - Separate create/update/admin schemas — "writable at signup" ≠ "writable
   forever" (e.g. `email` writable at create, verified-flow-only later).
+- **Re-derive security-sensitive values server-side; never accept them from the
+  client** (OWASP Business Logic). Prices, subtotals, taxes, totals, balances,
+  discounts, quotas, role/tier — take only identifiers + quantities and recompute
+  from your own store/price book. `{"price": 0}` and `{"items": 5, "total": 0}` are
+  the canonical e-commerce logic exploits; the same applies to credit/quota balances
+  in any multi-tenant or metered system.
 - Same bug, query side: client-controlled `fields`/`include`/`expand`/`sort`
   params must resolve through allowlists, or they become column-level IDORs
   and join-amplification DoS.

--- a/skills/sota-code-security/rules/09-untrusted-data-ingestion.md
+++ b/skills/sota-code-security/rules/09-untrusted-data-ingestion.md
@@ -200,7 +200,11 @@ if sniff_mime(blob) not in ALLOWED_MIME: raise Reject  # bytes, not declared
   sota-network-security.
 - **Detection on the ingest path.** Anomalies — sudden volume spikes, ratio-bomb
   rejects, schema-violation bursts, AV hits — are signals; emit them as events for
-  sota-detection-engineering, don't just drop them.
+  sota-detection-engineering, don't just drop them. Flag **serialized-payload
+  signatures** on inputs that should be plain data — base64 Python pickle prefixes
+  (`gASV`, `gAJ`, `gAR`), Java serialization magic (`rO0`/`0xACED`), PHP
+  `O:<n>:` object markers: their presence in a feed/field is a deserialization-RCE
+  probe, not legitimate content.
 - **No lateral trust.** Data validated for one purpose isn't validated for
   another; re-validate at each new boundary it crosses (a value safe for storage
   may be unsafe for a shell, a query, or a prompt — see §6).

--- a/skills/sota-databases/rules/06-security-and-compliance.md
+++ b/skills/sota-databases/rules/06-security-and-compliance.md
@@ -137,6 +137,14 @@ for app-side review. Database-layer obligations:
   RLS caps which rows; `statement_timeout` caps exfil-by-batch.
 - LIKE inputs: escape `%`/`_` even when parameterized (DoS/filter-bypass, not
   injection, but same review).
+- NoSQL/operator injection isn't only a SQL problem — parameterize for every
+  engine DN runs. **Redis/Valkey:** never build `EVAL`/`EVALSHA` Lua bodies or
+  `KEYS`/command names from untrusted input; pass user data only as `ARGV`/key
+  args (the client builds the command as an arg vector, so values stay inert).
+  **Qdrant:** assemble filters from a typed allowlist of fields/operators, never
+  by templating user JSON into the filter — a client-controlled `must`/`should`
+  is a cross-tenant read if it can overwrite the server's tenant filter
+  (server-enforced tenant filter is non-negotiable, rules/07).
 
 ## PII handling
 


### PR DESCRIPTION
Diffed `sota-code-security` + `sota-databases` against the OWASP **Injection / SQLi / Command Injection / Deserialization / XXE / SSRF / Mass Assignment / IDOR / File Upload / DoS / Business Logic** cheat sheets (validated by a read-only agent against the actual files).

**Already strong (confirmed, no change):** parameterization + identifier allowlisting + LIKE escaping, argv-exec + leading-dash argument injection, defusedxml + billion-laughs cap, DNS-rebinding/IMDSv2 SSRF, allowlist DTOs + `extra=forbid`, IDOR 404-not-403, decompression/pixel-bomb caps, load-shedding/slowloris DoS.

**Gaps closed — the under-covered Business Logic cluster + edges:**
- **Semantic/cross-field validation**; treat hidden/disabled/echoed fields as adversarial → `code-security/rules/01`.
- **Server-side value re-derivation** (prices/totals/taxes/quotas; the `{"price":0}` class) → `rules/07`.
- **Workflow state-machine integrity** — consume one-time ops (replay), expire partial state, no client-side workflow position → `rules/03`.
- **SSRF blocklist broadened** — all multicast (`IsMulticast`) + CGNAT `100.64.0.0/10` → `rules/01`.
- **Serialized-payload signature detection** (pickle `gASV`/`gAJ`, Java `rO0`, PHP `O:n:`) at ingest → `rules/09`.
- **Redis `EVAL`/Qdrant-filter injection** (typed allowlist; server-enforced tenant filter) → `databases/rules/06`.

**Deferred (intentional):** file-upload abuse/takedown reporting (trust-and-safety, not code-security) and abuse-case anti-automation (primarily `sota-threat-modeling`).

Invariants PASS. CHANGELOG updated. This is the last of the OWASP-cheat-sheet batches you selected.
