### PR TITLE
feat(api-design): add WebRTC security section (ASVS v5.0 V17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`sota-api-design/rules/05` — WebRTC security** (`## 6`): the one technical
+  area an OpenCRE/ASVS-v5.0 coverage check found missing. Self-hosted TURN
+  (relay-abuse = SSRF over UDP; allowlist non-special IPv4+IPv6, cap allocations),
+  media servers (DTLS-SRTP cipher/key policy, SRTP auth vs RTP injection,
+  malformed/flood resilience, DTLS `ClientHello` race DoS, DTLS-cert↔SDP-fingerprint
+  binding), and signaling (rate-limit + malformed-input-safe). Scoped to
+  self-hosted infra — CPaaS-SDK consumers are provider-owned. Grounded in OWASP
+  ASVS v5.0 V17 + RFC 8826/8827. SKILL.md index/triggers updated.
+
 ### Changed
 
 - **`sota-golang/rules/05-security.md`** — closed two OWASP Go-SCP gaps that are

--- a/skills/sota-api-design/SKILL.md
+++ b/skills/sota-api-design/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   (endpoints, schemas, protos, realtime channels, webhook senders/receivers)
   AND when auditing/reviewing existing APIs for correctness, evolvability,
   security, and operational robustness. Trigger keywords: API, REST, GraphQL,
-  gRPC, endpoint, websocket, SSE, realtime, webhook, versioning, OpenAPI,
+  gRPC, endpoint, websocket, SSE, realtime, WebRTC, webhook, versioning, OpenAPI,
   pagination, idempotency, rate limit, problem+json, protobuf, deprecation.
 ---
 
@@ -107,7 +107,7 @@ without evidence in code or spec.
 | `rules/02-versioning-evolution.md` | Changing an existing API, adding/removing fields, choosing URL vs header versioning, planning deprecation (Sunset/Deprecation headers), enum/schema evolution, tolerant readers, CI breaking-change gates. |
 | `rules/03-graphql.md` | Any GraphQL work: schema/nullability/connections design, N+1 and dataloaders, depth/cost/alias limits, persisted-query allowlists, error channels (userErrors vs errors), resolver authz, when GraphQL is the wrong choice. |
 | `rules/04-grpc-protocols.md` | gRPC/protobuf work or protocol selection: field-number/reserved evolution rules, deadlines and cancellation propagation, streaming patterns, rich error details, gRPC-Web/Connect, L7 load balancing, REST vs GraphQL vs gRPC decision table. |
-| `rules/05-realtime-websockets-sse.md` | WebSocket/SSE/realtime features: transport choice (WS vs SSE vs WebTransport), upgrade auth & CSWSH, heartbeats, reconnect backoff + resume tokens, ordering/delivery guarantees, backpressure, close codes, SSE replay, pub/sub fanout scaling, presence. |
+| `rules/05-realtime-websockets-sse.md` | WebSocket/SSE/realtime features: transport choice (WS vs SSE vs WebTransport), upgrade auth & CSWSH, heartbeats, reconnect backoff + resume tokens, ordering/delivery guarantees, backpressure, close codes, SSE replay, pub/sub fanout scaling, presence; WebRTC server hardening (TURN relay abuse, DTLS-SRTP, signaling) when self-hosted. |
 | `rules/06-webhooks.md` | Sending or receiving webhooks: HMAC signing + timestamp + rotation, replay protection, retry/backoff design, ordering caveats, idempotent consumers, outbox dispatch, reconciliation APIs, SSRF defenses for user-supplied URLs. |
 | `rules/07-security-operations.md` | Cross-cutting security/ops on any API: authn scheme selection (keys/OAuth2/mTLS), rate limiting + 429/Retry-After, quotas, request size limits, timeout budgets, CORS, audit logging, multi-tenant isolation, cross-tenant testing. |
 

--- a/skills/sota-api-design/rules/05-realtime-websockets-sse.md
+++ b/skills/sota-api-design/rules/05-realtime-websockets-sse.md
@@ -240,9 +240,37 @@ which transport is active.
   the publisher side (max N msgs/sec, latest-wins), shard the channel across
   backplane partitions, and never fan out faster than your slowest tier absorbs.
 
+## 6. WebRTC (when you self-host the infrastructure)
+
+WebRTC is the path for peer-to-peer audio/video/data channels. **Scope first:** if
+you only consume a CPaaS SDK/API (Twilio, LiveKit Cloud, Daily…), the provider owns
+most of this — these rules apply when you **run your own TURN, media, or signaling
+servers**. Media itself is encrypted by mandate (DTLS-SRTP); the risks are in the
+*servers* around it. (ASVS v5.0 V17; RFC 8826/8827 security architecture.)
+
+- **TURN server — relay abuse is SSRF over UDP/TCP.** A TURN relay forwards packets
+  on behalf of a client; an open one lets an attacker reach your internal network
+  and reserved ranges. **Allowlist relay peers to non-special addresses only** —
+  deny loopback/RFC1918/link-local/broadcast/CGNAT, IPv4 **and** IPv6 (same blocklist
+  as SSRF, sota-code-security rules/01 §5). Bound per-user port/allocation counts so
+  one client can't exhaust the relay (resource exhaustion).
+- **Media servers (SFU/MCU/recording) — only if you host them.** Pure browser-to-
+  browser P2P is out of scope here. Use **approved DTLS-SRTP cipher suites + protection
+  profiles**, manage the DTLS cert key under your key-management policy (rules/04),
+  and **verify SRTP authentication** so an attacker can't inject RTP (media insertion
+  or DoS). The server must **survive malformed and flooded SRTP** (input validation,
+  bounded buffers, drop excess packets) and must not be vulnerable to the **DTLS
+  `ClientHello` race-condition DoS** (Enable Security, 2020). Bind the DTLS cert to the
+  **SDP fingerprint** and terminate the stream on mismatch (authenticity).
+- **Signaling server.** Signaling carries no media but sets up the session — **rate-limit
+  it** and **handle malformed messages gracefully** (integer-overflow/buffer-safe parsing)
+  so a flood or a bad frame can't deny session setup. Authenticate and authorize
+  signaling like any other API channel (the WS/§2 rules apply if signaling rides WS).
+
 ## Audit checklist
 
 - [ ] Transport choice justified; server-push-only features use SSE, not a WS with one direction unused.
+- [ ] WebRTC (self-hosted only): TURN relay allowlists non-special IPs (v4+v6) and caps per-user allocations; media server uses approved DTLS-SRTP + SRTP auth, survives malformed/flooded SRTP, not ClientHello-race vulnerable, checks DTLS cert vs SDP fingerprint; signaling rate-limited + malformed-input-safe. (CPaaS-only consumers: provider-owned — N/A.)
 - [ ] WS auth: Origin checked server-side (CSWSH), or one-time short-lived tickets, or first-message auth with timeout; no long-lived tokens in query strings; nothing smuggled via `Sec-WebSocket-Protocol`.
 - [ ] Per-channel/per-action authorization after connect, not handshake-only; token expiry mid-connection handled (close code or refresh frame).
 - [ ] Server pings with pong timeout; intervals < LB idle timeout; half-open detection on client.


### PR DESCRIPTION
## Why
Analyzed **OpenCRE** ([opencre.org](https://www.opencre.org/)) for coverage gaps. OpenCRE is a meta-catalog that cross-links security standards; its technical backbone is **OWASP ASVS**. Mapping ASVS **v5.0** (2025) — 17 categories, read from the [OWASP/ASVS repo](https://github.com/OWASP/ASVS) — against our skills showed **16 of 17 already covered**; the one genuinely-absent technical area was **V17 WebRTC** (verified absent: no `webrtc`/`SRTP`/`STUN`/`TURN`/`datachannel` anywhere in the skills). Added at the user's request.

## What
New `## 6. WebRTC` in `sota-api-design/rules/05`, **scoped to self-hosted infra** (CPaaS-SDK consumers are explicitly out — the provider owns it):
- **TURN** — relay abuse is SSRF over UDP: allowlist non-special IPv4+IPv6, cap per-user allocations.
- **Media (SFU/MCU/recording)** — approved DTLS-SRTP cipher/protection profiles + key policy, verify SRTP auth (anti-RTP-injection), survive malformed/flooded SRTP, not `ClientHello`-race-DoS-vulnerable, bind DTLS cert ↔ SDP fingerprint.
- **Signaling** — rate-limit + malformed-input-safe parsing.

Plus an audit-checklist line; SKILL.md index + `WebRTC` trigger keyword; CHANGELOG.

## Validation
Grounded in primary sources read verbatim this session: **OWASP ASVS v5.0 V17** requirements (17.1.x TURN, 17.2.x media, 17.3.x signaling) from the OWASP/ASVS repo, plus RFC 8826/8827 and the Enable Security DTLS `ClientHello` DoS. Invariants PASS (rules/05 at 288/500).

## Note
Everything else OpenCRE maps (Proactive Controls C1–C10, NIST 800-63b, Testing Guide, the Cheat Sheets from PRs #22–27) is already covered. WebRTC isn't currently in the DN stack — this is forward-looking coverage.
