### PR TITLE
fix: audit remediation — CI hardening, script fail-opens, content corrections (+ gitleaks history scan, pre-commit check, stale docs)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     {
       "name": "sota-skills",
       "source": "./",
-      "description": "State-of-the-art engineering skills for building and auditing software across 35 domains and languages, with a master router and BUILD/AUDIT modes."
+      "description": "State-of-the-art engineering skills for building and auditing software across 34 domains and languages, with a master router and BUILD/AUDIT modes (35 skills)."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "sota-skills",
   "displayName": "SOTA Engineering Skills",
   "version": "1.7.0",
-  "description": "State-of-the-art engineering skills (2026) for building and auditing software across 35 domains and languages — security, architecture, APIs, databases, cloud, Kubernetes, observability, testing, LLM engineering, and more — with a master router and BUILD/AUDIT modes.",
+  "description": "State-of-the-art engineering skills (2026) for building and auditing software across 34 domains and languages — security, architecture, APIs, databases, cloud, Kubernetes, observability, testing, LLM engineering, and more — with a master router and BUILD/AUDIT modes (35 skills).",
   "author": { "name": "Martin Holovsky" },
   "homepage": "https://github.com/martinholovsky/SOTA-skills",
   "repository": "https://github.com/martinholovsky/SOTA-skills",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          # Full history so gitleaks scans every commit, not just the checkout.
+          fetch-depth: 0
       - name: Install gitleaks (pinned + checksum-verified)
         run: |
           set -euo pipefail
@@ -35,5 +38,5 @@ jobs:
           tar -xzf "$TARBALL" gitleaks
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
           gitleaks version
-      - name: Scan
-        run: gitleaks detect --no-git --config .gitleaks.toml --redact --verbose
+      - name: Scan (full git history)
+        run: gitleaks git --config .gitleaks.toml --redact --verbose .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,40 @@ jobs:
     name: Repository invariants
     runs-on: ubuntu-latest
     steps:
-      # actions/checkout v4.2.2, pinned by commit SHA (sota-devsecops).
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      # actions/checkout v7.0.0, pinned by commit SHA (sota-devsecops).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          # The build steps run repo scripts and never push.
+          persist-credentials: false
       - name: Check invariants
+        # SOTA_DENYLIST (repository secret) carries the private internal-name
+        # patterns for check 3; fork PRs don't receive it and fall back to the
+        # generic checks — the authoritative scan runs on maintainer branches
+        # and on push to main.
+        env:
+          SOTA_DENYLIST: ${{ secrets.SOTA_DENYLIST }}
         run: ./scripts/check-invariants.sh
+
+  shellcheck:
+    name: Shell lint (shellcheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - name: shellcheck scripts/
+        # shellcheck is preinstalled on ubuntu-latest runners.
+        run: shellcheck -S warning scripts/*.sh
 
   secrets:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           # Full history so gitleaks scans every commit, not just the checkout.
           fetch-depth: 0
+          persist-credentials: false
       - name: Install gitleaks (pinned + checksum-verified)
         run: |
           set -euo pipefail

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 profiles/*
 !profiles/example.md.template
 
+# Private internal-name denylist (check-invariants.sh check 3) — a tracked
+# copy would disclose the names it exists to suppress. CI uses the
+# SOTA_DENYLIST repository secret instead.
+.denylist.local
+
 # OS / editor cruft
 .DS_Store
 *.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,92 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Fixes every confirmed finding of the 2026-07-01 adversarial audit
+(`docs/AUDIT-2026-07-01.md`) except the accepted-risk history disclosure
+(finding S1 — names remain in pre-July-2026 git history by decision).
+
+### Fixed
+
+- **`sota-security-compliance` frontmatter was invalid strict YAML** (HIGH):
+  the inline description contained `Trigger keywords: …`, which strict loaders
+  reject — the skill could be silently skipped. Now a `>-` block scalar
+  (994 chars); invariant 4 additionally rejects unquoted inline descriptions
+  containing `: ` so the class can't recur.
+- **`init-gates.sh` could silently skip whole language gates** (HIGH): the
+  `has()` file-list probe piped `printf` into `grep -q`, which under
+  `pipefail` can die by SIGPIPE on large repos and read as "language not
+  detected". Now a herestring; reproduced before/after with a 200k-file list.
+- **`init-gates.sh` silent no-ops**: a `repos: []`-style config produced
+  "wrote .pre-commit-config.yaml" with no gates inserted (now dies with
+  instructions); altered/re-indented `sota-gates` markers made every re-run a
+  silent unchanged rewrite (now detected exact-line and refused); running in a
+  non-git dir crashed on `pre-commit install` after writing the config (now a
+  warning); Bun ≥ 1.2 text lockfile `bun.lock` now selects `bun audit`.
+- **`install.sh` `--copy` → default-install switch corrupted the target**:
+  `ln -sfn` can't replace a real directory, so the stale snapshot stayed (with
+  a self-named symlink nested inside) while the script reported success. Now
+  detected and replaced after a prompt. Altered routing markers in
+  `~/.claude/CLAUDE.md` are refused instead of looping "out of date" forever.
+- **`gen-agents-md.sh`**: orphaned/altered managed-block markers now refuse to
+  touch the file (previously a lone BEGIN marker set up content loss on the
+  next run); marker splice is exact-line so a *quoted* marker can't misfire;
+  skill count uses `find -L` (symlinked layouts reported "0 skills indexed").
+- **`check-invariants.sh` hardening**: check 1 counts a missing final newline
+  and skips deleted-but-tracked files instead of aborting; check 2 requires
+  the audit checklist to be the file's LAST `## ` heading ("ends with", as
+  documented); check 3 is case-insensitive, also scans file/directory names,
+  and surfaces scan errors instead of failing open.
+- **sota-jvm mislabeled JDK 25 scoped values as preview**: JEP 506 is final in
+  Java 25 (structured concurrency remains preview, JEP 505). SKILL.md body and
+  rules/03 corrected against openjdk.org.
+- **sota-golang baseline raised to Go 1.25+**: 1.24 left security support with
+  1.26's release (go.dev/doc/devel/release); feature notes unchanged.
+- **Count/format drift**: README hero counts restored to the skills-markdown
+  basis (255 files, ~52k lines — "279 files" counted every tracked file);
+  README/CONTRIBUTING rules-file line-range claims now match reality (~80–350);
+  the v1.5.0 pre-fix description lengths corrected to invariant 4's own
+  measurements; plugin/marketplace descriptions say 34 domains + router
+  (35 skills); router cross-cutting rules renumbered sequentially (were
+  1-9, 13-16, 10-12); audit-methodology short finding format regains the
+  `effort` field and 11 skill finding templates gained an `Effort:` line;
+  five bare `rules/08` references in sota-llm-engineering now name
+  sota-code-security; a garbled cross-reference in sota-code-security
+  rules/09 reworded.
+- **Secret-scanning guidance reconciled** (was duplicated with drift):
+  sota-devsecops rules/05 §5.2 owns pipeline gate layering,
+  sota-secrets-management rules/04 owns tool config + leak response — now
+  cross-referenced both ways, and gitleaks commands use the current
+  `gitleaks git` CLI (the official pre-commit hook's own invocation).
+- Stale docs: `CLAUDE.md` pointed at the changelog with "(current: v1.0.0)"
+  seven releases later — the pointer is now version-less; gitleaks scan scope
+  documented accurately in `CLAUDE.md`, `CONTRIBUTING.md`, and `README.md`.
+
 ### Changed
 
 - **CI secret scan now covers the full git history**: the gitleaks job checks
   out with `fetch-depth: 0` and runs `gitleaks git` (every commit) instead of
   `gitleaks detect --no-git` (working tree only). Validated locally first:
   44 commits scanned, no leaks.
+- **CI hardening**: `actions/checkout` re-pinned to v7.0.0 (SHA-pinned;
+  was v4.2.2, three majors old), `persist-credentials: false` on every
+  checkout, and a new `shellcheck` job gates `scripts/*.sh`. The
+  sota-devsecops SHA-pinning example no longer hard-codes an aging SHA.
+- **Internal-name denylist externalized**: the private patterns moved out of
+  the tracked script into a git-ignored `.denylist.local` (pre-commit) and the
+  `SOTA_DENYLIST` repository secret (CI). The tracked script keeps only the
+  generic reader-assumption phrases; fork PRs run those and the maintainer's
+  CI runs the full list. Pre-2026-07 history still contains the old inline
+  list — reviewed and accepted (audit finding S1).
 - **`scripts/install.sh` checks contributor pre-commit hygiene**: when run from
   a git checkout it detects a missing pre-commit hook and offers to install it
   (or prints an install tip when the `pre-commit` tool itself is absent).
   Non-fatal for end users; CI enforces the same checks regardless.
 
-### Fixed
+### Added
 
-- Stale docs: `CLAUDE.md` pointed at the changelog with "(current: v1.0.0)"
-  seven releases later — the pointer is now version-less; gitleaks scan scope
-  documented accurately in `CLAUDE.md`, `CONTRIBUTING.md`, and `README.md`.
+- `docs/AUDIT-2026-07-01.md` — full adversarial audit report (decision ledger,
+  findings, reproduction status), and `docs/ROADMAP.md` — audit-derived
+  priorities.
 
 ## [1.7.0] - 2026-07-01
 
@@ -147,9 +217,11 @@ goes from 30 to 34 skills.
 
 - **Skill descriptions over the 1024-character Agent Skills cap** (issue #4):
   eight `SKILL.md` descriptions exceeded the spec limit — `sota-identity-access`
-  (1632), `sota-detection-engineering` (1369), `sota-architecture` (1317),
-  `sota-kubernetes` (1189), `sota-network-security` (1184), `sota-testing`
-  (1165), `sota-code-security` (1109), `sota-secrets-management` (1105) — so
+  (1629), `sota-detection-engineering` (1366), `sota-architecture` (1314),
+  `sota-kubernetes` (1186), `sota-network-security` (1181), `sota-testing`
+  (1165), `sota-code-security` (1106), `sota-secrets-management` (1103)
+  as measured by invariant 4's own counter (corrected 2026-07-01; the
+  originally published figures were 2–3 higher from a different parser) — so
   loaders (Claude Code, Codex, …) silently skipped them. All condensed to ≤ 1024
   (now 955–1016) by trimming prose while preserving the trigger-keyword routing
   signal. Verified against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **CI secret scan now covers the full git history**: the gitleaks job checks
+  out with `fetch-depth: 0` and runs `gitleaks git` (every commit) instead of
+  `gitleaks detect --no-git` (working tree only). Validated locally first:
+  44 commits scanned, no leaks.
+- **`scripts/install.sh` checks contributor pre-commit hygiene**: when run from
+  a git checkout it detects a missing pre-commit hook and offers to install it
+  (or prints an install tip when the `pre-commit` tool itself is absent).
+  Non-fatal for end users; CI enforces the same checks regardless.
+
+### Fixed
+
+- Stale docs: `CLAUDE.md` pointed at the changelog with "(current: v1.0.0)"
+  seven releases later — the pointer is now version-less; gitleaks scan scope
+  documented accurately in `CLAUDE.md`, `CONTRIBUTING.md`, and `README.md`.
+
 ## [1.7.0] - 2026-07-01
 
 Adds a security & compliance engineering skill — the cybersecurity-regulation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,16 @@ changes are edits to Markdown held to a few hard invariants. See
 `scripts/check-invariants.sh` fails the build on:
 
 1. any tracked `*.md` over **500 lines**;
-2. any `skills/*/rules/*.md` missing an **`## Audit checklist`** heading;
-3. an **internal-name denylist** — the library must stay generic;
+2. any `skills/*/rules/*.md` whose **last `## ` heading isn't
+   `## Audit checklist`** (the checklist must end the file);
+3. an **internal-name denylist** — the library must stay generic. The private
+   patterns are deliberately untracked (git-ignored `.denylist.local` locally,
+   `SOTA_DENYLIST` secret in CI); without them only the generic
+   reader-assumption phrases are checked, e.g. on external fork PRs;
 4. any `skills/*/SKILL.md` **`description` over 1024 characters** — the Agent
-   Skills spec cap; loaders silently skip a skill whose description exceeds it.
+   Skills spec cap; loaders silently skip a skill whose description exceeds it
+   — or an unquoted inline description containing `: ` (invalid YAML; strict
+   loaders reject the skill — use `description: >-`).
    (Needs `python3`; skipped with a warning if absent locally, enforced in CI.)
 
 Secrets are scanned by **gitleaks** (`.gitleaks.toml`, which disables only the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ changes are edits to Markdown held to a few hard invariants. See
 
 Secrets are scanned by **gitleaks** (`.gitleaks.toml`, which disables only the
 noisy entropy-based `generic-api-key` rule so the security skills' intentional
-secret-shaped examples don't false-positive).
+secret-shaped examples don't false-positive). CI scans the **full git history**
+(`gitleaks git` on a `fetch-depth: 0` checkout), not just the working tree; the
+pre-commit hook scans each commit locally.
 
 ## Conventions that matter
 
@@ -53,4 +55,5 @@ secret-shaped examples don't false-positive).
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — full contribution guide and PR checklist
 - [SECURITY.md](SECURITY.md) — reporting bad guidance or a leaked secret
-- [CHANGELOG.md](CHANGELOG.md) — release history (current: v1.0.0)
+- [CHANGELOG.md](CHANGELOG.md) — release history (top entry = current version;
+  also mirrored in `VERSION`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,8 @@ scripts/check-invariants.sh   # the invariants below, enforced
 
 **`rules/NN-topic.md`**
 
-- 150–340 lines of concrete, current guidance with short examples.
+- Roughly 80–350 lines of concrete, current guidance with short examples
+  (a target, not a floor — compact rules files are fine; the hard cap is 500).
 - Ends with an **`## Audit checklist`** — yes/no questions, ideally with
   grep/lint patterns, so the rule can be used to hunt violations.
 
@@ -78,11 +79,16 @@ are marked "needs verification", never asserted.
 `scripts/check-invariants.sh` runs in pre-commit and CI and fails the build on:
 
 1. any tracked `*.md` over **500 lines**;
-2. any `skills/*/rules/*.md` missing an **`## Audit checklist`** heading;
-3. any **internal/private reference** leaking into tracked files;
+2. any `skills/*/rules/*.md` that doesn't **end** with an
+   **`## Audit checklist`** (it must be the file's last `## ` heading);
+3. any **internal/private reference** leaking into tracked files (the private
+   pattern list is intentionally not in the repo; PRs from forks run the
+   generic checks and the maintainer's CI runs the full list);
 4. any `skills/*/SKILL.md` `description` over **1024 characters** (the Agent
-   Skills cap; check 4 needs `python3`, and is skipped with a warning if it is
-   absent locally — CI always enforces it).
+   Skills cap) or written as an unquoted inline scalar containing `: ` —
+   invalid YAML that makes loaders skip the skill; use `description: >-`.
+   (Check 4 needs `python3`, and is skipped with a warning if it is absent
+   locally — CI always enforces it.)
 
 Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`);
 CI scans the full git history, the pre-commit hook scans each commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,8 @@ are marked "needs verification", never asserted.
    Skills cap; check 4 needs `python3`, and is skipped with a warning if it is
    absent locally — CI always enforces it).
 
-Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`).
+Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`);
+CI scans the full git history, the pre-commit hook scans each commit.
 
 [skills-spec]: https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview
 
@@ -94,6 +95,9 @@ Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`).
 pipx install pre-commit     # or: brew install pre-commit
 pre-commit install          # run the same checks on every commit
 ```
+
+(`scripts/install.sh` also checks for the hook when run from a checkout and
+offers to install it, or prints this tip if the `pre-commit` tool is missing.)
 
 Run the invariant checks any time:
 

--- a/README.md
+++ b/README.md
@@ -441,7 +441,8 @@ Naming one (or the `sota` router) just makes the routing explicit. From there:
 See [CONTRIBUTING.md](CONTRIBUTING.md). The short version: keep skills generic,
 verify fast-moving claims against primary sources, keep every file ≤ 500 lines,
 and end each rules file with an audit checklist. These are enforced by
-`scripts/check-invariants.sh` (pre-commit + CI) plus gitleaks. Security issues
+`scripts/check-invariants.sh` (pre-commit + CI) plus gitleaks (full-history
+scan in CI; per-commit via the pre-commit hook). Security issues
 and conduct: [SECURITY.md](SECURITY.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Your assistant is brilliant — it just doesn't know your standards. SOTA-skills
 teaches it: a library of Claude Code skills that encode state-of-the-art (2026)
 practices for building **and** auditing software, and that verify their own
-claims. 35 skills, 279 files, ~53k lines — every file under 500 lines, so the
+claims. 35 skills, 255 skill files, ~52k lines — every file under 500 lines, so the
 right rules load exactly when your task needs them, never bloating the context
 window. Fast-moving claims (versions, specs, regulations) are web-verified
 against primary sources.
@@ -47,7 +47,7 @@ skills/
     SKILL.md                     # when to use, BUILD/AUDIT workflows,
                                  # severity conventions, rules index, top-10
     rules/
-      01-<topic>.md              # 150–320 lines each, ends with an
+      01-<topic>.md              # ~80–350 lines each, ends with an
       02-<topic>.md              # executable Audit checklist
       ...
 profiles/

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -8,7 +8,8 @@
 #   2. Every skills/*/rules/*.md ends with an "## Audit checklist".
 #   3. No internal/private references leak in (the library stays generic).
 #   4. Every skills/*/SKILL.md description is <= 1024 characters (Agent Skills
-#      spec: loaders skip a skill whose description exceeds the cap).
+#      spec: loaders skip a skill whose description exceeds the cap) and is
+#      not YAML-invalid (unquoted ': ' inline — strict loaders reject it).
 #
 # Portable to macOS bash 3.2 (no mapfile/associative arrays). Check 4 needs
 # python3 for correct Unicode character counting; it is skipped with a warning
@@ -26,7 +27,9 @@ note() { printf '    %s\n' "$1"; }
 echo "[1/4] Markdown files <= ${MAX_LINES} lines"
 over=0
 while IFS= read -r f; do
-  n=$(wc -l < "$f")
+  [ -f "$f" ] || { note "SKIPPED (tracked but missing from worktree): $f"; continue; }
+  # awk NR, not `wc -l`: counts a final line without trailing newline too.
+  n=$(awk 'END{print NR}' "$f")
   if [ "$n" -gt "$MAX_LINES" ]; then
     note "OVER ${MAX_LINES} (${n} lines): $f"
     over=1
@@ -34,29 +37,58 @@ while IFS= read -r f; do
 done < <(git ls-files '*.md')
 if [ "$over" -eq 0 ]; then echo "    ok"; else fail=1; fi
 
-# --- 2. Audit checklist in every rules file -------------------------------
-echo "[2/4] Every skills/*/rules/*.md has an '## Audit checklist'"
+# --- 2. Audit checklist ends every rules file ------------------------------
+echo "[2/4] Every skills/*/rules/*.md ends with an '## Audit checklist'"
 missing=0
 while IFS= read -r f; do
-  if ! grep -qE '^## Audit checklist' "$f"; then
-    note "MISSING '## Audit checklist': $f"
-    missing=1
-  fi
+  [ -f "$f" ] || { note "SKIPPED (tracked but missing from worktree): $f"; continue; }
+  # The checklist must be the file's LAST '## ' heading (docs say "ends
+  # with") — a mention inside a code fence or mid-file no longer satisfies.
+  last_h2=$(grep -E '^## ' "$f" | tail -n 1 || true)
+  case "$last_h2" in
+    '## Audit checklist'*) ;;
+    *) note "MISSING/NOT-LAST '## Audit checklist': $f"; missing=1 ;;
+  esac
 done < <(git ls-files 'skills/*/rules/*.md')
 if [ "$missing" -eq 0 ]; then echo "    ok"; else fail=1; fi
 
 # --- 3. No internal/private references -------------------------------------
-# Keep the library generic and shareable. This guards against re-introducing
-# the personal stack/project names that were scrubbed before going public.
+# Keep the library generic and shareable. Two pattern sets:
+#   - generic reader-assumption phrases, tracked right here;
+#   - a PRIVATE denylist of pre-publication internal names, deliberately NOT
+#     tracked: a tracked list would disclose the very names it suppresses.
+#     (The pre-July-2026 list remains in public git history — accepted risk,
+#     decided 2026-07-01; see docs/AUDIT-2026-07-01.md finding S1.)
+# Private patterns load from $SOTA_DENYLIST (CI: repository secret) or
+# .denylist.local (git-ignored, one ERE per line, '#' comments). When neither
+# exists (e.g. an external fork's PR), only the generic phrases are checked —
+# the maintainer's pre-commit hook and this repo's CI carry the full list.
 echo "[3/4] No internal-name leaks"
-DENY='Probably\.Group|dn-platform|dn-go-api|dn-fe|ContextIPS|AethelGard|Vuln-AID|JARVIS|\bMemex\b|the user runs|the user operates'
-# This script necessarily contains the patterns above, so exclude it from its
-# own scan (it is small and reviewed; everything else is checked).
-hits=$(git ls-files -z -- ':(exclude)scripts/check-invariants.sh' \
-       | xargs -0 grep -InE "$DENY" 2>/dev/null || true)
-if [ -n "$hits" ]; then
+DENY='the user runs|the user operates'
+if [ -n "${SOTA_DENYLIST:-}" ]; then
+  DENY="$DENY|$SOTA_DENYLIST"
+elif [ -f .denylist.local ]; then
+  extra=$(grep -vE '^[[:space:]]*(#|$)' .denylist.local | paste -sd'|' - || true)
+  [ -n "$extra" ] && DENY="$DENY|$extra"
+else
+  note "(private denylist unavailable — generic checks only)"
+fi
+# Case-insensitive so casing variants can't slip past; errors are fatal, not
+# swallowed (a scan that can't read a file must not pass). This script holds
+# the generic phrase patterns, so it is excluded from its own scan.
+set +e
+hits=$(git grep -iInE "$DENY" -- ':(exclude)scripts/check-invariants.sh')
+rc=$?
+name_hits=$(git ls-files | grep -iE "$DENY")
+nrc=$?
+set -e
+if [ "$rc" -gt 1 ] || [ "$nrc" -gt 1 ]; then
+  note "ERROR: denylist scan failed (grep exit content=$rc names=$nrc)"
+  fail=1
+elif [ -n "$hits" ] || [ -n "$name_hits" ]; then
   note "Internal reference(s) found — keep the library generic:"
-  printf '%s\n' "$hits" | sed 's/^/      /'
+  { printf '%s\n' "$hits"; printf '%s\n' "$name_hits" | sed 's/$/ (file name)/'; } \
+    | sed '/^ *(file name)$/d; s/^/      /'
   fail=1
 else
   echo "    ok"
@@ -74,9 +106,10 @@ import sys, glob, re
 cap = int(sys.argv[1])
 bad = 0
 def get_desc(text):
+    """Return (description, yaml_error_or_None)."""
     m = re.match(r'---\n(.*?)\n---', text, re.S)
     if not m:
-        return None
+        return None, None
     lines = m.group(1).split('\n')
     for i, ln in enumerate(lines):
         if ln.startswith('description:'):
@@ -87,13 +120,21 @@ def get_desc(text):
                     if cont.strip() and not cont[:1].isspace():
                         break                    # next top-level key ends it
                     buf.append(cont.strip())
-                return ' '.join(x for x in buf if x)
-            return rest.strip('\'"')             # plain / quoted single line
-    return None
+                return ' '.join(x for x in buf if x), None
+            # Plain (unquoted) inline scalar: ': ' inside it, or a trailing
+            # ':', is invalid YAML — strict loaders reject the frontmatter
+            # and silently skip the skill. Quoted scalars are fine.
+            err = None
+            if rest[:1] not in ('"', "'") and (': ' in rest or rest.endswith(':')):
+                err = "unquoted ':' in inline description (invalid YAML — use 'description: >-')"
+            return rest.strip('\'"'), err        # plain / quoted single line
+    return None, None
 for f in sorted(glob.glob('skills/*/SKILL.md')):
-    d = get_desc(open(f, encoding='utf-8').read())
+    d, err = get_desc(open(f, encoding='utf-8').read())
     if not d:
         print(f"MISSING/EMPTY description: {f}"); bad = 1; continue
+    if err:
+        print(f"{err}: {f}"); bad = 1
     if len(d) > cap:
         print(f"OVER {cap} ({len(d)} chars): {f}"); bad = 1
 sys.exit(1 if bad else 0)

--- a/scripts/gen-agents-md.sh
+++ b/scripts/gen-agents-md.sh
@@ -149,19 +149,27 @@ fi
 
 if [ ! -f "$OUTPUT" ]; then
   cp "$block_file" "$OUTPUT"
-elif grep -qF "$BEGIN_MARK" "$OUTPUT" && grep -qF "$END_MARK" "$OUTPUT"; then
+elif grep -qxF "$BEGIN_MARK" "$OUTPUT" && grep -qxF "$END_MARK" "$OUTPUT"; then
+  # Exact-whole-line detection (-x) matching the awk $0== below: a line that
+  # merely QUOTES a marker (docs, code fence) must not trigger a splice.
   cp "$OUTPUT" "$OUTPUT.bak"
   awk -v b="$BEGIN_MARK" -v e="$END_MARK" -v f="$block_file" '
-    index($0, b) { while ((getline line < f) > 0) print line; close(f); skip=1; next }
-    index($0, e) { skip=0; next }
+    $0 == b { while ((getline line < f) > 0) print line; close(f); skip=1; next }
+    $0 == e { skip=0; next }
     skip!=1 { print }
   ' "$OUTPUT.bak" > "$OUTPUT"
+elif grep -qF "$BEGIN_MARK" "$OUTPUT" || grep -qF "$END_MARK" "$OUTPUT"; then
+  # A lone/altered marker: appending would duplicate the block, and the NEXT
+  # run's splice would then eat user content between orphan and copy — refuse.
+  die "$OUTPUT has a sota-skills marker that is unpaired or altered — restore the exact marker lines (or delete the block), then re-run"
 else
   cp "$OUTPUT" "$OUTPUT.bak"
   { printf '\n'; cat "$block_file"; } >> "$OUTPUT"
 fi
 
-count="$(find "$SKILLS_DIR" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')"
+# -L: the default layout symlinks skill dirs (install.sh), which plain -type d
+# would not count — a successful run used to report "0 skills indexed".
+count="$(find -L "$SKILLS_DIR" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')"
 log "wrote $OUTPUT — $count skills indexed, pointing at $SKILLS_DIR"
 log "AGENTS.md is read by Codex, Cursor, Copilot, Gemini CLI, Windsurf, Zed, and more."
 [ -f "$OUTPUT.bak" ] && log "previous version saved to $OUTPUT.bak"

--- a/scripts/init-gates.sh
+++ b/scripts/init-gates.sh
@@ -85,7 +85,10 @@ list_files() {
 }
 FILES="$(list_files)"
 
-has() { printf '%s\n' "$FILES" | grep -qE "$1"; }
+# Herestring, not printf|grep: with `grep -q` exiting at the first match, a
+# pipe can kill printf with SIGPIPE on large file lists and — under pipefail —
+# silently turn a match into "language not detected" (gates never written).
+has() { grep -qE "$1" <<<"$FILES"; }
 
 # --- language detection ------------------------------------------------------
 USE_PY=0; USE_GO=0; USE_RUST=0; USE_JS=0; USE_TS=0; USE_SH=0
@@ -110,7 +113,7 @@ fi
 JS_AUDIT="npm audit --audit-level=high --omit=dev"
 has '(^|/)pnpm-lock\.yaml$' && JS_AUDIT="pnpm audit --audit-level high --prod"
 has '(^|/)yarn\.lock$'      && JS_AUDIT="yarn npm audit --severity high"
-has '(^|/)bun\.lockb$'      && JS_AUDIT="bun audit"
+has '(^|/)bun\.lockb?$'     && JS_AUDIT="bun audit"   # bun.lock (>=1.2 text) or legacy bun.lockb
 
 # --- block generation --------------------------------------------------------
 emit_block() {
@@ -345,19 +348,31 @@ assemble() {
       cat "$block"
       printf '%s\n' "$END_MARK"
     } >"$tmp"
-  elif grep -qF "$BEGIN_MARK" "$CONFIG" && grep -qF "$END_MARK" "$CONFIG"; then
+  elif grep -qxF "$BEGIN_MARK" "$CONFIG" && grep -qxF "$END_MARK" "$CONFIG"; then
     # Replace the existing managed block in place (markers kept, body swapped).
+    # Detection above is exact-whole-line (-x), matching the awk $0== below —
+    # a substring hit with altered markers must not fall through to a silent
+    # no-op rewrite.
     awk -v b="$BEGIN_MARK" -v e="$END_MARK" -v f="$block" '
       $0==b {print; while ((getline line < f) > 0) print line; close(f); skip=1; next}
       $0==e {print; skip=0; next}
       skip!=1 {print}
     ' "$CONFIG" >"$tmp"
+  elif grep -qF "$BEGIN_MARK" "$CONFIG" || grep -qF "$END_MARK" "$CONFIG"; then
+    # Markers present but re-indented/altered, or one of the pair is missing:
+    # any automatic edit here risks a silent no-op or eating user content.
+    die "$CONFIG has sota-gates marker(s) that are altered or unpaired — restore the exact marker lines (or delete the block), then re-run"
   elif grep -qE '^repos:' "$CONFIG"; then
     # Existing config without our markers: insert a fresh marked block after repos:.
     awk -v b="$BEGIN_MARK" -v e="$END_MARK" -v f="$block" '
       /^repos:[[:space:]]*$/ && !done {print; print b; while ((getline line < f) > 0) print line; close(f); print e; done=1; next}
       {print}
     ' "$CONFIG" >"$tmp"
+    # The insert needs `repos:` alone on its line; `repos: []` etc. matches the
+    # branch guard but not the awk pattern — verify the block landed, never
+    # write an unchanged file back while claiming success.
+    grep -qF "$BEGIN_MARK" "$tmp" \
+      || die "$CONFIG has 'repos:' but not on its own bare line (e.g. 'repos: []') — change it to a bare 'repos:' list or merge by hand"
     grep -qE '^default_install_hook_types:' "$CONFIG" \
       || warn "add 'default_install_hook_types: [pre-commit, pre-push]' to $CONFIG so both stages install"
   else
@@ -405,7 +420,10 @@ fi
 log "wrote $CONFIG (previous saved to $CONFIG.bak if it existed)"
 
 if [ "$DO_INSTALL" -eq 1 ]; then
-  if command -v pre-commit >/dev/null 2>&1; then
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    # pre-commit install needs a git repo; the config was still written.
+    warn "not a git repository — after 'git init', run: pre-commit install --hook-type pre-commit --hook-type pre-push"
+  elif command -v pre-commit >/dev/null 2>&1; then
     pre-commit install --hook-type pre-commit --hook-type pre-push >/dev/null
     log "installed git hooks (pre-commit + pre-push)"
   else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -133,6 +133,14 @@ setup_claude_md() {
       warn "~/.claude/CLAUDE.md has the start marker but no end marker — leaving it untouched; fix by hand or delete the block and re-run"
       return
     fi
+    if [ -z "$(extract_block "$f")" ]; then
+      # Markers found by substring, but extract_block (exact whole-line match)
+      # sees nothing: they were re-indented/altered. A refresh would be a
+      # silent no-op loop — refuse instead.
+      # shellcheck disable=SC2088  # ~ is display text in the message, not a path
+      warn "~/.claude/CLAUDE.md has sota routing markers that are altered (indented?) — leaving it untouched; restore the exact marker lines or delete the block and re-run"
+      return
+    fi
     if [ "$(extract_block "$f")" = "$(emit_routing_block)" ]; then
       log "routing directive in ~/.claude/CLAUDE.md — up to date"; return
     fi
@@ -286,6 +294,17 @@ for src in "$SKILLS_SRC"/*/; do
     rm -rf "$dest"
     cp -R "${src%/}" "$dest"
   else
+    if [ -e "$dest" ] && [ ! -L "$dest" ]; then
+      # ln -sfn cannot replace a real directory — it would nest the link
+      # INSIDE it and leave the stale copy in place while we report success
+      # (the --copy → default-install switch). Ask, then replace for real.
+      if ask_yn "$name at $dest is a real directory (previous --copy install?) — replace it with a symlink?" y; then
+        rm -rf "$dest"
+      else
+        warn "kept $dest as-is — it is a snapshot and will NOT update; re-run with --copy to refresh it"
+        continue
+      fi
+    fi
     ln -sfn "${src%/}" "$dest"
   fi
   linked=$((linked + 1))

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,6 +16,10 @@
 # refresh the managed block in place — only the content between the markers, and
 # only a hook it recognizes as its own; hand edits outside the block are kept.
 #
+# Contributor hygiene: when run from a git checkout it also checks that the
+# repo's pre-commit hook (gitleaks + invariants) is installed — offering to
+# install it if the pre-commit tool is available, or printing a tip if not.
+#
 # Usage:
 #   scripts/install.sh                 # link skills into ~/.claude/skills (all projects)
 #   scripts/install.sh --project DIR   # link into DIR/.claude/skills (one project)
@@ -203,6 +207,31 @@ setup_hook() {
   rm -f "$tmp"
 }
 
+# --- contributor hygiene: the repo's own pre-commit hook ---------------------
+# Non-fatal in every branch: end users who never commit to this checkout just
+# get a one-line tip at most; CI enforces the same checks regardless.
+maybe_setup_precommit() {
+  [ -f "$REPO/.pre-commit-config.yaml" ] || return 0
+  git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+  local hook
+  hook="$(git -C "$REPO" rev-parse --git-path hooks/pre-commit 2>/dev/null || true)"
+  case "$hook" in /*) ;; *) hook="$REPO/$hook" ;; esac
+  if [ -n "$hook" ] && [ -f "$hook" ] && grep -q 'pre-commit' "$hook" 2>/dev/null; then
+    log "pre-commit hook in this checkout — already installed"
+    return 0
+  fi
+  if ! command -v pre-commit >/dev/null 2>&1; then
+    log "contributor tip: 'pipx install pre-commit' (or 'brew install pre-commit'), then 'pre-commit install' — runs the gitleaks + invariants gate on each commit (CI enforces it regardless)"
+    return 0
+  fi
+  ask_yn "Install the repo's pre-commit hook (gitleaks + invariants on every commit)?" y || return 0
+  if (cd "$REPO" && pre-commit install >/dev/null); then
+    log "pre-commit hook installed in this checkout"
+  else
+    warn "pre-commit install failed — run 'pre-commit install' in $REPO manually"
+  fi
+}
+
 maybe_setup_routing() {
   # personal install only; never for --project or --copy snapshots
   [ "$TARGET" = "$HOME/.claude/skills" ] && [ "$USE_COPY" -eq 0 ] || return 0
@@ -289,6 +318,7 @@ if [ "$TARGET" = "$HOME/.claude/skills" ] && [ "$USE_COPY" -eq 0 ]; then
 fi
 
 maybe_setup_routing
+maybe_setup_precommit
 
 cat <<NEXT
 

--- a/skills/sota-architecture/SKILL.md
+++ b/skills/sota-architecture/SKILL.md
@@ -70,6 +70,7 @@ this file routes you to the right one.
    Evidence: <what you observed>
    Impact: <what fails and when>
    Fix: <specific, smallest correct remediation>
+   Effort: trivial | small | medium | large
    ```
 
 5. **Severity conventions:**

--- a/skills/sota-c-cpp/SKILL.md
+++ b/skills/sota-c-cpp/SKILL.md
@@ -83,6 +83,7 @@ undefined` and run the test suite — a sanitizer abort is ground truth.
   Evidence: the offending line(s), verbatim
   Impact: one sentence — what corrupts/leaks/races, under what input
   Fix: concrete replacement code or action
+  Effort: trivial | small | medium | large
 ```
 
 Group findings by severity, CRITICAL first. End with: counts per severity, the

--- a/skills/sota-code-security/rules/09-untrusted-data-ingestion.md
+++ b/skills/sota-code-security/rules/09-untrusted-data-ingestion.md
@@ -138,7 +138,8 @@ The cheapest attack on an ingester is volume and amplification. Bound everything
   it does not crash the pipeline, retry-loop forever, or get silently dropped.
 - **Idempotent re-ingest.** Key records by a stable source id so replays and
   retries don't duplicate or corrupt state (cross-ref sota-data-engineering data
-  contracts; idempotency in rules/01-adjacent webhook handling and sota-api-design).
+  contracts; webhook ingress hardening is rules/01, idempotent webhook delivery
+  is sota-api-design rules/06 §4).
 
 ```go
 // BAD                              // GOOD

--- a/skills/sota-devsecops/rules/01-pipeline-security.md
+++ b/skills/sota-devsecops/rules/01-pipeline-security.md
@@ -88,8 +88,9 @@ Tag-pinned consumers ran the malware on their next scheduled job; SHA-pinned con
 did not.
 
 ```yaml
-# GOOD
-- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+# GOOD — resolve the CURRENT release's commit SHA and pin that, tag in comment
+# (gh api repos/actions/checkout/git/ref/tags/<tag> --jq .object.sha)
+- uses: actions/checkout@<full-40-char-commit-sha>  # vN.N.N
 # BAD
 - uses: someorg/some-action@v3        # mutable tag
 - uses: someorg/some-action@main      # tracking a branch — worse

--- a/skills/sota-devsecops/rules/05-analysis-gates.md
+++ b/skills/sota-devsecops/rules/05-analysis-gates.md
@@ -70,7 +70,9 @@ Layered — each layer catches what the previous missed:
 **A committed secret is a rotation event, not a deletion event.** `git filter-repo` after
 the fact cleans the repo, not the forks/clones/caches. Process: revoke/rotate first, then
 clean history, then verify the old credential is dead. Any finding response that ends at
-"removed the file" is incomplete (keep it High until rotation is confirmed).
+"removed the file" is incomplete (keep it High until rotation is confirmed). The full
+leak-response runbook and scanner configuration live in sota-secrets-management rules/04;
+this section owns the pipeline gate layering.
 
 Tuning: enable entropy + provider-pattern rules; maintain an allowlist for test fixtures
 with fake-but-realistic secrets (and mark them clearly, e.g. `TEST_ONLY_` prefixes) so the

--- a/skills/sota-dotnet/SKILL.md
+++ b/skills/sota-dotnet/SKILL.md
@@ -77,6 +77,7 @@ manually. Check the dependency tree against known-CVE databases.
   Evidence: the offending line(s), verbatim
   Impact: one sentence — what executes/leaks/deadlocks, under what input
   Fix: concrete replacement code or action
+  Effort: trivial | small | medium | large
 ```
 
 Group findings by severity, CRITICAL first. End with: counts per severity, the

--- a/skills/sota-frontend-design/SKILL.md
+++ b/skills/sota-frontend-design/SKILL.md
@@ -87,6 +87,7 @@ A small diff never downgrades severity; a locked-out user never rates "Minor".
   Rule: <rules/NN §section> (+ WCAG SC number if a11y)
   Impact: <who is affected and how>
   Fix: <concrete change, ideally token/pattern-level>
+  Effort: trivial | small | medium | large
 ```
 
 End every audit with: counts per severity, the top 3 highest-leverage fixes, and which checklists

--- a/skills/sota-golang/SKILL.md
+++ b/skills/sota-golang/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: sota-golang
-description: State-of-the-art Go engineering rules (2026 baseline, Go 1.24+) that Claude applies when writing new Go code or auditing existing Go code. Covers error handling, interface/package design, goroutine and channel correctness, net/http hardening, security (SQL, exec, path traversal, CSPRNG, TLS, supply chain), performance (pprof, allocations, GC, PGO), and tooling/CI. Trigger keywords - Go, golang, goroutine, channel, go.mod, errgroup, context.Context, pprof, govulncheck, net/http, slog. Use for BOTH building Go services/libraries/CLIs and reviewing or auditing Go codebases.
+description: State-of-the-art Go engineering rules (2026 baseline, Go 1.25+) that Claude applies when writing new Go code or auditing existing Go code. Covers error handling, interface/package design, goroutine and channel correctness, net/http hardening, security (SQL, exec, path traversal, CSPRNG, TLS, supply chain), performance (pprof, allocations, GC, PGO), and tooling/CI. Trigger keywords - Go, golang, goroutine, channel, go.mod, errgroup, context.Context, pprof, govulncheck, net/http, slog. Use for BOTH building Go services/libraries/CLIs and reviewing or auditing Go codebases.
 ---
 
 # SOTA Go (2026)
 
 Expert-level rules for producing and auditing production Go. Baseline language
-version: Go 1.24+ (loop-var scoping from 1.22, `b.Loop`/`os.Root`/tool
-directives from 1.24, `testing/synctest` and container-aware GOMAXPROCS from
-1.25, `errors.AsType` and the default-on Green Tea GC from 1.26 — released
-2026-02 — noted where relevant). Every rule states the *why*; every rules file
+version: Go 1.25+, the oldest release still in security support (Go fixes the
+last two majors; 1.24 left support with 1.26's release, 2026-02). Feature
+notes: loop-var scoping from 1.22, `b.Loop`/`os.Root`/tool directives from
+1.24, `testing/synctest` and container-aware GOMAXPROCS from 1.25,
+`errors.AsType` and the default-on Green Tea GC from 1.26 — noted where
+relevant. Every rule states the *why*; every rules file
 ends with an audit checklist of grep/vet/lint patterns.
 
 ## Purpose
@@ -65,6 +67,7 @@ reporting (greps are recall-oriented, expect false positives).
   Evidence: the offending line(s), verbatim
   Impact: one sentence — what goes wrong, under what conditions
   Fix: concrete replacement code or action
+  Effort: trivial | small | medium | large
 ```
 
 Group findings by severity, CRITICAL first. End the audit with: counts per

--- a/skills/sota-jvm/SKILL.md
+++ b/skills/sota-jvm/SKILL.md
@@ -23,8 +23,9 @@ Expert-level rules for producing and auditing production JVM code. The JVM is
 memory-safe (no buffer overflows/UAF), so the risk shifts to **deserialization
 and injection RCE, concurrency correctness, and dependency supply chain**.
 Baseline: **Java 25 LTS** (records, sealed types, pattern matching, virtual
-threads finalized in 21 via JEP 444; structured concurrency and scoped values
-are still *preview* in 25 — don't present them as final), **Kotlin 2.x**.
+threads finalized in 21 via JEP 444; scoped values finalized in 25 via JEP 506;
+structured concurrency is still *preview* — JEP 505 in 25 — don't present it
+as final), **Kotlin 2.x**.
 Per-language idioms differ; shared concerns (the JMM, the JCA, the build/
 supply-chain story) are unified here. Every rule states the *why*; every rules
 file ends with an audit checklist of grep/analyzer patterns.
@@ -83,6 +84,7 @@ manually. Check the dependency tree against known-CVE databases.
   Evidence: the offending line(s), verbatim
   Impact: one sentence — what executes/leaks/races, under what input
   Fix: concrete replacement code or action
+  Effort: trivial | small | medium | large
 ```
 
 Group findings by severity, CRITICAL first. End with: counts per severity, the

--- a/skills/sota-jvm/rules/03-concurrency.md
+++ b/skills/sota-jvm/rules/03-concurrency.md
@@ -43,9 +43,10 @@ coroutines. References:
   call pins the carrier thread (improved in 24+, but still prefer
   `ReentrantLock` around blocking sections). Avoid heavy `ThreadLocal` use.
 - CPU-bound work still wants a bounded platform-thread pool sized to cores.
-- **Structured concurrency** (`StructuredTaskScope`) and **scoped values** are
-  *preview* in Java 25 (JEP 505 / 506-class), finalization expected ~JDK 27 —
-  use behind a preview flag and note it's not yet stable; don't recommend it as
+- **Scoped values** (`ScopedValue`) are **final in Java 25** (JEP 506) — safe
+  to recommend as GA. **Structured concurrency** (`StructuredTaskScope`) is
+  still *preview* (JEP 505 in 25; previews continue in later JDKs) — use
+  behind a preview flag, note it's not yet stable, and don't recommend it as
   GA.
 
 ## 4. Kotlin coroutines

--- a/skills/sota-llm-engineering/rules/04-agents-tools.md
+++ b/skills/sota-llm-engineering/rules/04-agents-tools.md
@@ -68,7 +68,7 @@ are tool-design failures, not model failures.
   auditing, and parallelizing impossible — promote an action to a dedicated
   tool when you need to gate it (§6), validate it, render it, or mark it
   parallel-safe. Server-side scoping (tenant from session, not from model
-  args) is the security half — rules/08.
+  args) is the security half — sota-code-security rules/08.
 - **Strict schemas:** enums, formats, `additionalProperties: false`, examples
   in descriptions; use provider strict/validated tool modes where available.
   Validate arguments in code anyway — schema conformance ≠ semantic validity.
@@ -140,7 +140,7 @@ the harness pauses, a human (or policy engine) approves:
   for an hour" is not a gate. Batch *similar* low-risk actions for one
   review where volume demands it.
 - Authorization (can this principal do this at all) is enforced in code
-  regardless of approval UX — rules/08; the prompt is never the boundary.
+  regardless of approval UX — sota-code-security rules/08; the prompt is never the boundary.
 
 ## 5. Context management across turns
 
@@ -159,7 +159,7 @@ window, costs grow quadratically with history, and quality drops.
   product surface: schema/format guidance in the prompt, size limits,
   expiry/decay, user-visible and erasable where it holds user data
   (rules/06 §5), and protected from poisoning via untrusted content
-  (rules/08). Current frontier models measurably improve with an explicit
+  (sota-code-security rules/08). Current frontier models measurably improve with an explicit
   memory file + instructions on when to consult/update it — but only if you
   tell them when.
 - **Don't resend what you can reference:** large artifacts go to files/object
@@ -182,7 +182,7 @@ deprecation policy). Engineering consequences:
   use maintained official SDKs that absorb revision churn.
 - **Treat third-party MCP servers as untrusted dependencies:** version-pin,
   review tool descriptions before exposing them to your model (description
-  text is prompt input — injection surface, rules/08), and apply your own
+  text is prompt input — injection surface, sota-code-security rules/08), and apply your own
   allowlist/gating layer over their tools rather than mounting everything.
 - **Your own tools don't have to be MCP.** In-process tool definitions are
   simpler, faster, and easier to test; MCP earns its overhead when you need
@@ -249,7 +249,7 @@ budget bounds the sum of its children).
       complete.
 - [ ] Consequential actions behind per-action human/policy gates that
       suspend durably and feed deny-reasons back; authorization additionally
-      code-enforced (rules/08).
+      code-enforced (sota-code-security rules/08).
 - [ ] Context management present for long sessions: pruning/compaction with
       eval coverage, memory with limits/expiry/erasability, artifacts by
       reference not by paste.

--- a/skills/sota-ml-engineering/SKILL.md
+++ b/skills/sota-ml-engineering/SKILL.md
@@ -89,6 +89,7 @@ category. Confirm claims against the code and pipeline config, not the diagram.
   Evidence: code/config/metric, verbatim
   Impact: one sentence — what predicts wrong / fails / leaks, under what condition
   Fix: concrete change or control
+  Effort: trivial | small | medium | large
 ```
 
 Group by severity, CRITICAL first. End with: counts per severity, an ML Test

--- a/skills/sota-python/SKILL.md
+++ b/skills/sota-python/SKILL.md
@@ -87,6 +87,7 @@ Confidence accompanies severity: **confirmed** (you traced the data flow) vs **s
   Issue: what is wrong, in one or two sentences, with the data-flow if security-relevant
   Evidence: the offending line(s), quoted
   Fix: concrete change — code snippet or exact rule reference (rules/05 §2)
+  Effort: trivial | small | medium | large
 ```
 
 Group findings by severity, CRITICAL first. End with: counts per severity, the mechanical

--- a/skills/sota-rust/SKILL.md
+++ b/skills/sota-rust/SKILL.md
@@ -92,6 +92,7 @@ build-time) and **blast radius** (process death > request failure > slow).
   What:  the defect, in one or two sentences
   Why:   concrete consequence (exploit path, failure mode, cost)
   Fix:   specific change — code sketch or named pattern from rules/NN
+  Effort: trivial | small | medium | large
   Refs:  rules/NN §M; clippy lint or RUSTSEC id if applicable
 ```
 

--- a/skills/sota-secrets-management/SKILL.md
+++ b/skills/sota-secrets-management/SKILL.md
@@ -115,6 +115,7 @@ Report every finding as:
   Evidence: the offending line, with the secret value REDACTED (show prefix + length only)
   Why: one sentence of impact
   Fix: concrete remediation (rotate first, then remove; target pattern to adopt)
+  Effort: trivial | small | medium | large
 ```
 
 Order findings Critical → Low. End the audit with: counts per severity, whether git history is

--- a/skills/sota-secrets-management/rules/04-detection-and-remediation.md
+++ b/skills/sota-secrets-management/rules/04-detection-and-remediation.md
@@ -2,7 +2,9 @@
 
 Scope: secret scanning (gitleaks, trufflehog), pre-commit hooks, CI gates, git history hygiene,
 the post-leak runbook (rotate-first), and honeytokens. Read this when setting up scanning, when
-running an AUDIT sweep, or the moment a leak is discovered.
+running an AUDIT sweep, or the moment a leak is discovered. Pipeline-gate *layering* and
+org-wide push protection are owned by sota-devsecops rules/05 §5.2; this file owns tool
+configuration and leak **response** (rotation, history cleanup).
 
 ## 1. Scanning layers
 
@@ -10,7 +12,7 @@ Defense in depth — each layer catches what the previous missed:
 
 | Layer | Tool/mechanism | Blocks? |
 |---|---|---|
-| Editor/local | gitleaks `protect` via pre-commit hook | Yes — before commit exists |
+| Editor/local | gitleaks pre-commit hook (`gitleaks git --pre-commit --staged`) | Yes — before commit exists |
 | Push | server-side pre-receive hook / GitHub push protection | Yes — before history is shared |
 | CI | gitleaks/trufflehog job on every PR + full-history scan scheduled weekly | Yes — fail the build |
 | Platform | GitHub Advanced Security / GitLab secret detection, partner-program auto-revocation | Detect + sometimes auto-revoke |
@@ -27,7 +29,7 @@ repos:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.x
     hooks:
-      - id: gitleaks            # runs `gitleaks protect --staged`
+      - id: gitleaks   # runs `gitleaks git --pre-commit --redact --staged --verbose`
 ```
 
 ```toml
@@ -42,9 +44,10 @@ regex = '''myapp_(sk|pat)_[A-Za-z0-9_\-]{32,}'''
 paths = ['''testdata/fake_keys\.json''']     # narrow, path-based; never allowlist by rule id
 ```
 
-CI: `gitleaks detect --source . --redact --exit-code 1` on PRs (diff-aware via
-`--log-opts="origin/main.."` for speed), plus a scheduled full scan with no log-opts so the
-whole history is rechecked as rules improve.
+CI (gitleaks ≥ 8.19 subcommands): `gitleaks git --redact .` on PRs — diff-aware via
+`--log-opts="origin/main.."` for speed — plus a scheduled full-history scan without log-opts
+(needs a `fetch-depth: 0` checkout) so old commits are rechecked as rules improve. The legacy
+`detect`/`protect` spellings still run but are deprecated aliases.
 
 ### trufflehog
 

--- a/skills/sota-security-compliance/SKILL.md
+++ b/skills/sota-security-compliance/SKILL.md
@@ -1,6 +1,20 @@
 ---
 name: sota-security-compliance
-description: State-of-the-art security & compliance engineering (2026) for the cybersecurity control frameworks and product-security regulations that drive architecture, code, and CI gates — not the organizational policy binder. Use when work must satisfy or be audited against NIST CSF 2.0, SP 800-53, SP 800-171 / CMMC, the Secure Software Development Framework (SSDF, SP 800-218), FedRAMP, the EU Cyber Resilience Act (CRA), or ISA/IEC 62443 (OT/ICS/embedded). Covers control-framework-as-code crosswalks (control → engineering mechanism → evidence), CUI boundaries, FIPS-validated crypto, SBOM + coordinated vulnerability disclosure + security-update obligations, secure-SDLC gates, and OT zones/conduits & security levels. Complements sota-privacy-compliance (personal data, GDPR, SOC 2, ISO 27001). Trigger keywords: compliance, NIST, CSF, 800-53, 800-171, CMMC, CUI, SSDF, FedRAMP, CRA, Cyber Resilience Act, SBOM, VEX, CVD, IEC 62443, OT security, ICS, security levels, zones and conduits, FIPS 140.
+description: >-
+  State-of-the-art security & compliance engineering (2026) for the
+  cybersecurity control frameworks and product-security regulations that drive
+  architecture, code, and CI gates — not the organizational policy binder. Use
+  when work must satisfy or be audited against NIST CSF 2.0, SP 800-53, SP
+  800-171 / CMMC, the Secure Software Development Framework (SSDF, SP 800-218),
+  FedRAMP, the EU Cyber Resilience Act (CRA), or ISA/IEC 62443
+  (OT/ICS/embedded). Covers control-framework-as-code crosswalks (control →
+  engineering mechanism → evidence), CUI boundaries, FIPS-validated crypto,
+  SBOM + coordinated vulnerability disclosure + security-update obligations,
+  secure-SDLC gates, and OT zones/conduits & security levels. Complements
+  sota-privacy-compliance (personal data, GDPR, SOC 2, ISO 27001). Trigger
+  keywords: compliance, NIST, CSF, 800-53, 800-171, CMMC, CUI, SSDF, FedRAMP,
+  CRA, Cyber Resilience Act, SBOM, VEX, CVD, IEC 62443, OT security, ICS,
+  security levels, zones and conduits, FIPS 140.
 ---
 
 # SOTA Security & Compliance Engineering

--- a/skills/sota-shell-scripting/SKILL.md
+++ b/skills/sota-shell-scripting/SKILL.md
@@ -74,6 +74,7 @@ Finding format:
   Evidence: the offending line(s), verbatim
   Impact: what input/condition triggers it and what breaks
   Fix: concrete replacement code
+  Effort: trivial | small | medium | large
 ```
 
 ## Rules index

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -119,27 +119,27 @@ rules files that match the code in front of you. Never load all skills at once.
    `sota-kubernetes`; pod/container/workload isolation mechanics →
    `sota-sandboxing`; CI/CD and supply chain → `sota-devsecops`. A K8s cluster
    audit loads `sota-kubernetes` + `sota-network-security` + `sota-sandboxing`.
-13. **Identity is its own layer.** App-level login/session/JWT-validation code →
+10. **Identity is its own layer.** App-level login/session/JWT-validation code →
    `sota-code-security` rules/02-03; identity *infrastructure* (IdP, OIDC/SAML
    config, RBAC/role-mapping design, provisioning, break-glass, SPIFFE) →
    `sota-identity-access`; the credentials themselves → `sota-secrets-management`.
-14. **Network: setup vs security.** Cloud VPC/DNS/CDN provisioning →
+11. **Network: setup vs security.** Cloud VPC/DNS/CDN provisioning →
    `sota-cloud-infrastructure` rules/03; segmentation, zero-trust, NetworkPolicy
    depth, service mesh/mTLS, egress/DNS/PKI posture → `sota-network-security`.
-15. **Prevention vs detection.** Building the control → the relevant domain
+12. **Prevention vs detection.** Building the control → the relevant domain
    skill; verifying you'd *catch* the attack at runtime (logs, rules, hunting,
    IR) → `sota-detection-engineering`. Ops telemetry plumbing stays in
    `sota-observability`; design-time threat enumeration in `sota-threat-modeling`.
-16. **Ingesting untrusted/attacker-authored data** (feeds, scraping, uploads,
+13. **Ingesting untrusted/attacker-authored data** (feeds, scraping, uploads,
    webhooks, RAG corpora, hostile parsers) → `sota-code-security` rules/09,
    with `sota-sandboxing` rules/04 for parser isolation.
-10. **Data: OLTP vs analytics.** App databases → `sota-databases`; pipelines,
+14. **Data: OLTP vs analytics.** App databases → `sota-databases`; pipelines,
     streaming, warehouse/lakehouse → `sota-data-engineering`; anything touching
     personal data → add `sota-privacy-compliance`.
-11. **Any handling of user/personal data** (new fields, exports, logs,
+15. **Any handling of user/personal data** (new fields, exports, logs,
     analytics, ML training) → check `sota-privacy-compliance` minimization and
     retention rules, even when the task isn't "about" privacy.
-12. **Shell scripts hide everywhere** — CI run blocks, Dockerfile RUN lines,
+16. **Shell scripts hide everywhere** — CI run blocks, Dockerfile RUN lines,
     Makefiles, entrypoints. Audit them with `sota-shell-scripting` even when
     the repo's "language" is something else.
 
@@ -179,8 +179,10 @@ For a **full project audit**, work in passes:
    applicable. For an infrastructure/cluster audit the heavy hitters are
    `sota-kubernetes`, `sota-network-security`, `sota-identity-access`,
    `sota-sandboxing`, and `sota-detection-engineering`.
-4. **Findings.** Emit every finding in the canonical format
-   (`file:line | rule | severity | effort | fix`), deduplicate across domains,
+4. **Findings.** Emit every finding in the canonical cross-domain format
+   (`file:line | rule | severity | effort | fix`) — skill-local block formats
+   are fine within a domain pass but must carry an effort field so the
+   roll-up can be sequenced — deduplicate across domains,
    and roll up into the report structure from `rules/01-audit-methodology.md`:
    executive summary → scope & methodology → findings by severity →
    remediation roadmap sequenced by risk-reduction-per-effort → positive

--- a/skills/sota/rules/01-audit-methodology.md
+++ b/skills/sota/rules/01-audit-methodology.md
@@ -179,9 +179,11 @@ not ready to ship:
 8. **Effort estimate** — trivial / small / medium / large. Severity says
    what hurts; effort enables the roadmap in §6.
 
-The library's short finding format (`file:line | rule | severity | fix`) is
-the working format during passes; expand each surviving finding into the
-full evidence block for the report.
+The library's short finding format (`file:line | rule | severity | effort | fix`)
+is the working format during passes; expand each surviving finding into the
+full evidence block for the report. Skill-local block formats are fine during
+a single-domain pass, but they must carry the effort field — §6's roadmap is
+sequenced by risk-reduction-per-effort and can't be built without it.
 
 ## 6. Report structure
 


### PR DESCRIPTION
## What

1. **CI secret scan now covers git history.** The gitleaks job checked out at depth 1 and ran `gitleaks detect --no-git`, which scans only the working tree — a secret committed and later removed would never be caught. Now: `fetch-depth: 0` + `gitleaks git`.
2. **`install.sh` checks contributor pre-commit hygiene.** When run from a git checkout it detects a missing pre-commit hook and offers to install it (tool present), or prints an install tip (tool absent). Non-fatal in every branch — end users are unaffected and CI enforces the same checks regardless.
3. **Stale docs fixed.** `CLAUDE.md` said "release history (current: v1.0.0)" seven releases later — the pointer is now version-less so it can't rot again. gitleaks scan scope is documented accurately in CLAUDE.md / CONTRIBUTING.md / README.md, plus a CHANGELOG `Unreleased` entry.

## How the claims were verified

- Full-history scan run locally with the same pinned gitleaks 8.30.0: **44 commits scanned, no leaks** — so the stricter CI gate lands green.
- `bash -n` + `shellcheck -S warning` clean on `install.sh`; all three new branches exercised against a scratch `--project` install (already-installed → log, tool missing → tip, hook missing → installs).
- `pre-commit run --all-files` and `./scripts/check-invariants.sh` pass on the final tree.
- README's "35 skills, 279 files, ~53k lines" re-counted (`git ls-files`: 279 files, 52,658 md lines) — accurate, left unchanged.
