### PR TITLE
docs(audit): adversarial repository audit report (2026-07-01)

### DIFF
--- a/docs/AUDIT-2026-07-01.md
+++ b/docs/AUDIT-2026-07-01.md
@@ -1,0 +1,340 @@
+# Repository audit — 2026-07-01
+
+Adversarial multi-agent audit of SOTA-skills at v1.7.0 (HEAD `d78de36`).
+Method: 8 independent auditors across four lenses (decisions/results, code
+quality, security posture, strategy), every substantive finding independently
+re-derived by a 3-verifier adversarial panel prompted to refute it, then a
+second sweep per lens for issues the first pass missed. 106 agents total;
+findings that did not survive refutation are listed at the end. Both
+high-severity findings were additionally reproduced by hand before this report
+was written. Where a claim could not be verified this session it is marked
+UNVERIFIED with the reason.
+
+## Executive summary
+
+**Overall verdict: healthy.** The library's core claims hold up under hostile
+re-checking: all 16 major release decisions reproduce from the tree (13
+JUSTIFIED, 2 STALE, 1 UNJUSTIFIED — details below), all four invariants pass,
+git history is secret-free (full-history gitleaks scan, 44 commits, clean), CI
+is well-hardened for its size (SHA-pinned actions, checksum-verified tooling,
+read-only token, no PR-context interpolation), and a bidirectional sweep of all
+220 rules files found zero orphaned or dangling rules references. The defects
+are concentrated in the **shell-script layer** (1,123 lines with no lint gate
+and several silent fail-open paths) and in **process gaps** (no freshness
+mechanism for ~52k lines of dated claims, no in-repo release procedure).
+
+Top findings:
+
+1. **HIGH** — `skills/sota-security-compliance/SKILL.md` frontmatter is invalid
+   strict YAML (unquoted `Trigger keywords:` colon in an inline scalar); a
+   spec-conformant loader would skip the newest skill entirely. 34/35 parse
+   clean; this is the only failure. Reproduced with PyYAML.
+2. **HIGH** — `scripts/init-gates.sh` language detection can silently return
+   false negatives under `set -o pipefail` (SIGPIPE from `grep -q`), omitting
+   entire security-gate blocks while exiting 0. Reproduced: a file list with
+   `app/main.py` first + 200k entries yields `USE_PY=0`, exit 0.
+3. **MEDIUM ×6** — installer/gates scripts have silent no-op or corruption
+   paths (`--copy`→symlink switch nests a link inside the stale copy; managed-
+   block markers that drift stop updating forever without any error); the
+   internal-name invariant is case-sensitive; sota-jvm mislabels a GA JDK 25
+   feature as preview.
+4. **Process** — the product promise "fast-moving claims are web-verified"
+   has no supporting mechanism: 21 of 220 rules files carry a verification
+   date, and nothing tracks staleness. This is the roadmap's top item.
+
+Already fixed while the audit ran (PR #37, CI green): CI secret scan now covers
+full git history; `install.sh` checks/installs the contributor pre-commit hook;
+the stale `CLAUDE.md` version pointer is version-less.
+
+## Decision ledger review
+
+Every major decision reconstructed from git history + CHANGELOG, re-verified
+against the current tree this session.
+
+| Decision (release) | Verdict | Re-checked evidence |
+|---|---|---|
+| v1.0.0 first release: 30 skills + invariants + governance | JUSTIFIED | `git ls-tree v1.0.0` = exactly 30 skill dirs; invariants script present and passing |
+| Always-on routing directive + standing-rules lead (#5, #10) | JUSTIFIED | README directive + hook match `install.sh` managed markers (lines 52–56) |
+| v1.1.0 plugin + marketplace packaging (#7) | JUSTIFIED | `.claude-plugin/{plugin,marketplace}.json` match the documented install slug |
+| v1.1.0 installer-as-updater (#6) | JUSTIFIED (with defect) | Flags and idempotent re-link verified; but see the `--copy`→symlink corruption finding |
+| init-gates.sh generator + `--docs-gate` (#11) | JUSTIFIED (with defects) | Flags/helper verified; but see the two silent fail-open findings |
+| gen-agents-md.sh (#9), SDD+BDD rules (#8) | JUSTIFIED | Scripts/files exist with documented flags |
+| statusline.sh (#14); dotfiles-aware routing setup (#15) | JUSTIFIED | jq guard, symlink detection, backup-first all verified at file:line |
+| v1.4.0 plugin first-run notice (#17) | JUSTIFIED | hooks.json → plugin-notice.sh, marker-guarded to fire once |
+| README hero counts "218 files / ~47k lines" (#13) | STALE | Exact when made (218 files, 47,016 lines of skills md); v1.7.0 successor stat silently switched counting basis — see finding Q7 |
+| v1.5.0 description-cap fix (#4) + invariant 4 | JUSTIFIED | All 35 descriptions re-measured ≤1024 (max 1022); the 8 fixed skills measure exactly the claimed 955–1016; pre-fix lengths in CHANGELOG off by 2–3 chars (finding Q6) |
+| Gap-closing PRs #19–#29 (OWASP/ANSSI/WSTG batches) | JUSTIFIED | All ten commits touched exactly the claimed files; 12 representative content claims verified in-tree (CSPRNG, WebRTC §6, XSSI, X25519MLKEM768, APF, RFC 9207, slopsquatting, Redis EVAL, …) |
+| v1.6.0 four new skills "30→34" | JUSTIFIED | Dirs + rules counts (7/6/7/6) match CHANGELOG exactly |
+| v1.7.0 35th skill + update-aware installer | JUSTIFIED (with defect) | 5 rules files + router refs verified; old write-once behavior confirmed at `2ffd9f5`; but the new skill's frontmatter is the invalid-YAML HIGH finding |
+| Version bookkeeping across 8 releases | JUSTIFIED | VERSION = plugin.json = tag v1.7.0 at HEAD; all 8 tags match CHANGELOG dates (UTC) |
+| CLAUDE.md operational guide (#3) | STALE | Invariant/workflow text accurate, but "(current: v1.0.0)" survived seven releases (fixed in PR #37) |
+| Internal-name denylist invariant | UNJUSTIFIED as implemented | The mechanism works, but the tracked public script hard-codes the private names it exists to suppress — see finding S1 |
+
+## Findings — Lens 1: correctness of decisions & results
+
+- **Q6 · low** `CHANGELOG.md:130` — seven of eight published pre-fix
+  description lengths in the v1.5.0 entry are 2–3 chars higher than what
+  invariant 4's own parser measures at the pre-fix commit (e.g. 1632 vs 1629);
+  substance (all >1024, now 955–1016) confirmed. Fix: correct the counts or
+  state the counting method.
+- **Q7 · low** `README.md:20` — "35 skills, 279 files, ~53k lines" silently
+  changed basis: 279 counts *all tracked files* (PNG, scripts, CI) while ~53k
+  matches markdown lines; no single basis yields both. Prior stat (#13) was
+  skills-markdown (218/47k, exact). Fix: restore one stated basis, e.g.
+  "255 skill files, ~52k lines" (and mirror in `CHANGELOG.md:43`).
+- **Q8 · low** `README.md:50` — "150–320 lines each" for rules files never
+  matched any release: current range 77–342 (v1.0.0: 102–340). Fix: "~80–350"
+  or drop the numbers. Same for `CONTRIBUTING.md`'s "150–340" (47 of 220 files
+  are under 150; the v1.6.0 skills run 77–140 by design).
+- **Q9 · low** `.claude-plugin/plugin.json:5` + `marketplace.json` — "across 35
+  domains and languages … with a master router" double-counts: the 35 includes
+  the router the same sentence lists separately (34 + router). Fix: "34 domains
+  and languages" or reuse "35 skills".
+
+## Findings — Lens 2: code quality (scripts & content structure)
+
+**HIGH**
+
+- **Q1** `skills/sota-security-compliance/SKILL.md:3` — description is an
+  inline scalar containing `Trigger keywords: …`, invalid under strict YAML
+  (PyYAML: "mapping values are not allowed here"; 34/35 skills parse clean).
+  CONTRIBUTING.md itself mandates a block scalar for descriptions with colons.
+  A strict loader would silently skip the skill. Fix: `description: >-` block
+  scalar; add a YAML-parseability check to invariant 4 (it currently measures
+  length only).
+- **Q2** `scripts/init-gates.sh:88` — `has() { printf '%s\n' "$FILES" | grep
+  -qE "$1"; }` under `set -o pipefail`: `grep -q` exits at first match, printf
+  dies with SIGPIPE(141), the `has … && USE_X=1` guard swallows it, and the
+  language is silently undetected — the script then omits entire gate blocks
+  (ruff/mypy, govulncheck, clippy, …) and exits 0. Reproduced (200k-path list,
+  match first). Fix: avoid the pipe (`grep -qE "$1" <<<"$FILES"`).
+
+**MEDIUM**
+
+- **Q3** `scripts/init-gates.sh:357` — with an existing config whose `repos:`
+  key isn't on a bare line (`repos: []`), the awk insert matches nothing, yet
+  the script prints "wrote .pre-commit-config.yaml" and exits 0 with **no gates
+  written**. Reproduced. Fix: verify the managed block landed, else die.
+- **Q4** `scripts/init-gates.sh:348` — marker *detection* is substring
+  (`grep -qF`) but *replacement* is exact-line (awk `$0==b`): re-indented
+  markers → every re-run silently rewrites the file unchanged; gates never
+  refresh. Reproduced. Same class in `install.sh:97` (routing block: eternal
+  "out of date" prompt loop, no-op refresh) — finding Q12. Fix: one predicate
+  for both (e.g. `index($0,b)`), and verify the refresh changed the file.
+- **Q5** `scripts/install.sh:260` — after a `--copy` install, a plain re-run
+  cannot replace the real directory (`ln -sfn` nests the symlink *inside* it):
+  the user keeps the stale snapshot forever while the script reports success —
+  breaking the "this script is also the updater" contract (README "Updating"
+  doesn't say `--copy` users must re-copy). Reproduced on macOS/BSD ln; GNU
+  coreutils behavior UNVERIFIED (same POSIX corner expected). Fix: detect
+  `-d && ! -L` and prompt/replace or die with a clear message.
+
+**LOW (scripts)**
+
+- `scripts/check-invariants.sh:29` — a tracked `.md` deleted from the worktree
+  aborts check 1 with a raw bash error; checks 2–4 never run (fail-closed but
+  masked coverage). Fix: `[ -f "$f" ] || continue`.
+- `scripts/check-invariants.sh:29` — `wc -l` counts newlines: a 501-line file
+  without trailing newline passes as 500. Fix: `awk 'END{print NR}'`.
+- `scripts/check-invariants.sh:41` — checklist check greps `^## Audit
+  checklist` anywhere (including inside code fences), while docs say files must
+  *end* with it. Fix: anchor + position check, or soften the docs.
+- `scripts/gen-agents-md.sh:152` — BEGIN-marker-without-END falls into the
+  append branch, then the *next* run's splice deletes user content between the
+  orphan and the appended block; `install.sh:127` already guards exactly this.
+  Fix: mirror that guard.
+- `scripts/gen-agents-md.sh:164` — skill count uses `find` without `-L`, so the
+  default symlinked layout reports "0 skills indexed" on a successful run
+  (statusline.sh:62 deliberately uses `-L` for this reason). Fix: `find -L`.
+- `scripts/gen-agents-md.sh:155` — splice matches markers by substring
+  (`index($0,b)`), so an AGENTS.md that merely *quotes* the marker (docs, code
+  fence) splices at the wrong place; init-gates.sh uses exact match. Fix:
+  exact-line match here, substring in init-gates — pick per-file deliberately
+  (see Q4) and consistently.
+- `scripts/init-gates.sh:409` — in a non-git dir (a mode the script's own
+  `find .` fallback supports), unconditional `pre-commit install` aborts the
+  script with a raw third-party FatalError after writing the config.
+  Reproduced. Fix: guard on `git rev-parse`.
+- `scripts/init-gates.sh:113` — Bun detection only matches legacy `bun.lockb`;
+  Bun ≥1.2 (Jan 2025) defaults to `bun.lock`, so modern Bun repos get an
+  `npm audit` gate that fails without package-lock.json. Fix: `bun\.lockb?`.
+- `.github/workflows/ci.yml` — no shellcheck/shfmt job for 1,123 lines of shell
+  that run on end-user machines, contradicting the repo's own
+  sota-shell-scripting guidance. Fix: add shellcheck to CI + pre-commit.
+
+**LOW (content structure)**
+
+- `skills/sota/SKILL.md:116–142` — "Cross-cutting routing rules" numbering runs
+  1–9, 13–16, 10–12 (items appended without renumbering); "routing rule N" is
+  ambiguous. Fix: renumber.
+- `skills/sota/SKILL.md:183` vs `skills/sota/rules/01-audit-methodology.md:182`
+  — the router calls `file:line | rule | severity | effort | fix` canonical;
+  its own rules file drops `effort` from "the library's short finding format"
+  (while telling auditors effort enables the roadmap). Fix: align.
+- Finding-format drift: only 5 of 35 SKILL.md files specify the canonical
+  5-field format; ~25 define `[SEVERITY]`-block formats of which 22 omit
+  `effort` — so the router's "risk-reduction-per-effort" roll-up has no effort
+  input from most domains. Fix: declare the pipe format the cross-domain
+  roll-up format and require an effort field in skill-local formats.
+- `skills/sota-llm-engineering/rules/04-agents-tools.md:71,143,162,185,252` —
+  five bare "rules/08" references actually mean *another skill's*
+  `sota-code-security/rules/08` (own rules stop at 06); will misresolve if
+  rules 07/08 are ever added. Fix: qualify, as lines 9/41 already do.
+- `skills/sota-code-security/rules/09-untrusted-data-ingestion.md:141` —
+  "idempotency in rules/01-adjacent webhook handling" reads as a reference to a
+  nonexistent `01-adjacent` file; the content lives in
+  `sota-api-design/rules/06`. Fix: reword.
+- CI secret-scanning duplication with drift: `sota-secrets-management/rules/04`
+  and `sota-devsecops/rules/05 §5.2` both own gitleaks/CI-gate guidance with
+  zero cross-references and already disagree on CLI form (`detect`/`protect`
+  vs `gitleaks git`). Fix: one owner + cross-refs (devsecops owns the pipeline
+  gate; secrets-management owns leak response).
+
+Positive results worth recording: all 220 rules files have `## Audit
+checklist`; rules-index ↔ rules-file existence is clean in both directions
+across all 35 skills (0 orphans); all 35 frontmatters have exactly
+`name`+`description` with `name` matching the dir; zero broken relative links
+(83 checked); 1,855 prose `rules/NN` references all resolve; no file within 10
+lines of the 500 cap (max rules file: 342).
+
+## Findings — Lens 3: security posture
+
+- **S1 · low (accepted-risk decision needed)** `scripts/check-invariants.sh:52`
+  — the internal-name denylist hard-codes, in the tracked public script, the
+  exact private project/company identifiers it exists to keep out of the tree,
+  and excludes itself from its own scan to allow this. History shows the names
+  entered at the commit introducing CI and appear nowhere else — the control is
+  the sole public source of the disclosure it prevents. Fix: load patterns from
+  a git-ignored local file locally and a CI secret/variable in the workflow;
+  decide explicitly whether the residual history disclosure is accepted (a
+  history rewrite is the only alternative and has its own costs).
+- **S2 · medium** same line — the denylist grep is case-sensitive (no `-i`), so
+  lowercase/mixed-case reintroductions pass CI (verified live: lowercase
+  variant → no match, exit 1). Also: `2>/dev/null … || true` converts grep
+  *errors* into empty results (fail-open), and file/directory *names* plus
+  binary contents are never checked (`grep -I` skips the tracked PNG). Fix:
+  `grep -iInE`, drop the stderr suppression, add a pass over `git ls-files`
+  path names.
+- **S3 · low** `.github/workflows/ci.yml:39` — secret scan was tree-only
+  (`detect --no-git`); history was never scanned by CI. Verified clean today
+  (full-history scan, 44 commits, also clean with the default config's
+  entropy rule enabled). **Fixed in PR #37** (`fetch-depth: 0` + `gitleaks
+  git`). Residual (UNVERIFIABLE from here): secrets pushed to never-merged PR
+  branches would live only on GitHub's server-side refs and forks.
+- **S4 · low** `ci.yml:17,25` — checkout SHA↔tag mapping verified authentic
+  (`git ls-remote` → v4.2.2), but v4.2.2 is Oct 2024 and upstream is at v7.0.0
+  (2026-06-18); the same aging SHA is hard-coded as the teaching exemplar in
+  `sota-devsecops/rules/01:92`. Fix: re-pin both, and make the skill example
+  placeholder-style so it can't age.
+- **S5 · low** `ci.yml:17,25` — `persist-credentials` left default-true in jobs
+  that execute PR-controlled scripts; the repo's own
+  `sota-devsecops/rules/02:232,261` flags exactly this. Impact capped by
+  read-only token. Fix: `persist-credentials: false` on both checkouts.
+- **S6 · low** `scripts/install.sh:242` — premise correction: install is NOT
+  curl|bash (README says clone + run local script; no fetch-and-execute
+  exists). The only network op is `git pull --ff-only` on `--update`, trusting
+  TLS+origin tip — inherent to the model. Optional hardening: `--update` could
+  check out the latest tag instead of branch tip.
+- Verified-clean (for the record): CI has `permissions: contents: read`, uses
+  `pull_request` (not `_target`), zero `${{ }}` interpolation of PR context;
+  gitleaks install is version-pinned + checksum-verified; no
+  command-injection path from untrusted input in any script (transcript JSON
+  flows through grep/sed/printf only; no eval/source of fetched content);
+  hooks.json runs a quoted plugin-root script whose only write is a marker
+  file; personal-data grep over tracked files finds only intended attribution;
+  `profiles/martin.md` untracked and git-ignored by design.
+
+## Findings — Lens 4: content accuracy (web-verified spot-checks)
+
+- **A1 · medium** `skills/sota-jvm/SKILL.md:26` + `rules/03-concurrency.md:46`
+  — WRONG: claims scoped values are "still preview in 25 — don't present them
+  as final". JEP 506 finalized Scoped Values in JDK 25 (openjdk.org/jeps/506,
+  via search-quoted sources; direct fetch got HTTP 403 — see UNVERIFIED note).
+  The structured-concurrency half IS correct (JEP 525 sixth preview; a seventh
+  preview JEP 533 exists, which also undercuts the "~JDK 27 finalization"
+  guess). Fix: split the two features; drop the prediction.
+- **A2 · low** `skills/sota-golang/SKILL.md:9` — "Go 1.24+" baseline permits an
+  out-of-support toolchain: go.dev/doc/devel/release shows 1.26.4 current,
+  support = last two majors, so 1.24 unsupported since Feb 2026. The 1.25/1.26
+  feature notes in the skill are accurate. Fix: raise the floor to 1.25+.
+- Verified CURRENT (no findings): .NET 10 LTS dates (released 2025-11-11,
+  dotnet.microsoft.com); BinaryFormatter throws-on-use since .NET 9
+  (learn.microsoft.com); gitleaks v8.30.0 release exists and its published
+  linux_x64 sha256 matches ci.yml byte-for-byte (latest is 8.30.1, one patch
+  ahead); OWASP ASVS v5.0 still the recommended stable; MASVS v2.1 still
+  latest; checkout SHA↔v4.2.2 authentic.
+
+## Reproduction status
+
+Ran this session (pass unless noted): `./scripts/check-invariants.sh` (4/4),
+`pre-commit run --all-files`, full-history gitleaks (44 commits, clean, both
+configs), `bash -n` + `shellcheck` on all 6 scripts (clean at warning level),
+strict-YAML parse of all 35 frontmatters (34/35 — finding Q1), the Q2 SIGPIPE
+repro, the Q3/Q4/Q5 script repros in scratch dirs, description-length
+re-measurement of all 35 skills (max 1022), skills/rules/link sweeps (255
+files, 83 relative links, 1,855 prose refs), PR #37 CI (both checks green).
+
+UNVERIFIED and why:
+
+- GNU/Linux userland behavior of the scripts (macOS-only session); bash-3.2
+  compatibility checked by reading, not on a real 3.2 binary.
+- GitHub server-side state: releases behind CHANGELOG links, branch-protection
+  settings, PR-branch refs that never merged (S3 residual).
+- ~28 of the ~40 v1.5.0 gap-closing sub-claims (verified at file-touched level
+  only; 12 content-verified).
+- Secondary in-rules version claims (Kotlin 2.x, Node/Python baselines,
+  golangci-lint v2.9.0, K8s versions, NIST/ISO revisions…) — only the six
+  designated claim groups were web-checked; openjdk.org 403'd direct fetches
+  (A1 rests on multiple search-quoted secondary sources).
+- Live end-to-end runs of statusline.sh under Claude Code and the plugin hook
+  under a real `CLAUDE_PLUGIN_ROOT` (inputs verified against docs + real
+  transcripts instead).
+
+Refuted by the adversarial panels (reported round-1, killed — recorded so they
+aren't re-litigated): "gitleaks entropy-rule disable masks real leaks" (masks
+nothing today; disabling it is a documented, reasoned trade-off),
+"install.sh clobbers user skills without asking" (idempotent re-link is the
+documented design), "sandboxing/network-security NetworkPolicy duplication"
+and "privacy/security-compliance one-way boundary" (cross-links exist or
+scope statements disambiguate sufficiently), README hero-count variant
+(subsumed by Q7), plus three duplicates/re-phrasings of surviving findings.
+
+## Unexplored ideas (never tried, worth considering)
+
+1. **Freshness ledger** — per-rules-file `last-verified: YYYY-MM` metadata + a
+   scheduled CI job reporting files past their re-verify window. The single
+   highest-leverage structural investment: the core promise ("web-verified
+   claims") is currently unauditable, and every "2026 baseline" goes silently
+   stale in 2027.
+2. **Consistency/lint gate for the library's own conventions** — YAML-parse
+   frontmatter (would have caught Q1), version-string lockstep
+   (VERSION/plugin.json/README badge), ownership-boundary disclaimer presence,
+   finding-format effort field. Cheap extensions to check-invariants.sh.
+3. **Release procedure in-repo** — 8 releases in 14 days from a procedure that
+   exists only in the maintainer's private assistant memory; a RELEASING
+   section + the lockstep check above ends version-pointer rot permanently.
+4. **Structured feedback intake** — no ISSUE_TEMPLATE, no Discussions: a
+   bad-guidance report template (file:line + primary source, mirroring
+   SECURITY.md's format) is the only adoption signal available to a
+   no-telemetry project.
+5. **Coverage decision: PHP/Ruby/Swift-language + Windows/AD** — zero coverage
+   of Active Directory/Kerberos despite identity and detection skills whose
+   real-world audits are AD-heavy; PHP/Ruby absent while the mission says
+   "across domains and languages". Ship them or publish a non-goals statement.
+
+## Roadmap assessment
+
+There is no roadmap artifact in the repo (confirmed: no docs/, no ROADMAP.md,
+no unreleased/ideas section) — the de-facto plan lives in maintainer memory and
+recent-commit trajectory (new skills + optional-extras scripts). Assessment:
+the *content* trajectory is sound and its claims re-verify; the risk is
+concentrated in (a) unmaintained-by-construction freshness, (b) the untested
+shell layer growing faster than its quality gates (1,123 lines, no shellcheck,
+two HIGH/MEDIUM-class silent failures found on first adversarial look), and
+(c) process knowledge living outside the repo. The extras scripts are also the
+one area where effort ran ahead of user value: plugin users don't get them by
+default, and the audit found more defects there than anywhere else. Proposed
+re-prioritization (concrete patch in `docs/ROADMAP.md`, submitted separately
+for approval): fix the two HIGHs immediately, land the consistency/lint gate
+and freshness ledger before adding further skills, fold the extras layer into
+maintenance mode, and make the language-gap decision explicit.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,63 @@
+# Roadmap
+
+Priorities set by the 2026-07-01 audit ([AUDIT-2026-07-01.md](AUDIT-2026-07-01.md)).
+Ordered; revisit after each release.
+
+## Now — correctness of what's shipped
+
+1. **Fix the audit's HIGH and MEDIUM findings.** The two HIGHs
+   (sota-security-compliance frontmatter invalid under strict YAML;
+   `init-gates.sh` language-detection SIGPIPE fail-open) plus the script
+   silent no-ops, the denylist-check gaps, and the sota-jvm scoped-values
+   correction. *(Landed in the audit-remediation PR, #37.)*
+2. **Library lint gate** (extends `check-invariants.sh`): YAML-parse all
+   SKILL.md frontmatters, VERSION == plugin.json == latest tag lockstep,
+   README count-basis check, shellcheck over `scripts/`. Blocks the whole
+   defect class the audit found. *(Partially landed: YAML-validity check and
+   shellcheck CI job in #37; version-lockstep and count checks still open.)*
+
+## Next — keep the core promise true
+
+3. **Freshness ledger.** Per-rules-file `last-verified: YYYY-MM` metadata plus
+   a scheduled CI job reporting files past their re-verify window. The README
+   promises "fast-moving claims are web-verified against primary sources";
+   today only ~21 of 220 rules files carry any verification date, so the
+   promise is unauditable — and every "2026 baseline" assertion goes silently
+   stale in 2027.
+4. **Release procedure in-repo** (`RELEASING.md` or a CONTRIBUTING section):
+   VERSION + plugin.json + CHANGELOG + tag + GitHub release, plus the
+   version-bearing strings in README/CLAUDE.md. Eight releases shipped in the
+   first 14 days from a procedure that lives outside the repo; the v1.0.0
+   pointer rot in CLAUDE.md was the predictable result.
+5. **Structured feedback intake.** `.github/ISSUE_TEMPLATE` with a
+   bad-guidance report (file:line + primary source, mirroring SECURITY.md's
+   format) and a skill-request template; enable Discussions. A no-telemetry
+   project's only adoption signal is structured issues — currently absent.
+
+## Later — coverage decisions (decide, don't drift)
+
+6. **Close or declare the language/domain gaps.** PHP and Ruby have no skill
+   (incidental mentions only); Swift exists only at sota-mobile's
+   platform/stack level, not as a language-idiom skill; Active
+   Directory/Kerberos/ADCS have zero coverage despite identity and detection
+   skills whose real-world audits are AD-heavy. Ship `sota-php`, `sota-ruby`,
+   a Swift-language rules file, and AD content — or add a README "coverage &
+   non-goals" section stating what is deliberately excluded. The mission
+   statement overclaims until one of the two happens.
+
+## Maintenance mode (de-prioritized by audit evidence)
+
+- **Optional-extras scripts** (`statusline.sh`, `init-gates.sh`,
+  `gen-agents-md.sh`): highest defect density found by the audit, and plugin
+  users don't get them by default. Bug-fix only; no new extras until the
+  plugin path can deliver them natively.
+
+## Explicitly rejected (with reasons, so they aren't re-litigated)
+
+- **History rewrite to purge the pre-2026-07 denylist names** — rejected
+  2026-07-01: the names are low-sensitivity, the repo already has public
+  clones/forks/archives, and a rewrite breaks every clone and all release
+  tags. Going forward the list is externalized (git-ignored locally, CI
+  secret) so the tree no longer discloses it.
+- **Telemetry/analytics in the scripts** — privacy stance; feedback comes
+  from issues (see item 5).


### PR DESCRIPTION
## What

Adds `docs/AUDIT-2026-07-01.md` — the full adversarial audit of the repo at v1.7.0: decision ledger re-verified from git history, findings across four lenses (each finding survived a 3-verifier refutation panel; both HIGHs additionally reproduced by hand), reproduction status with explicit UNVERIFIED items, refuted findings recorded, and a roadmap assessment.

Headlines:
- **HIGH**: `sota-security-compliance/SKILL.md` frontmatter fails strict YAML (34/35 parse clean) — a spec-conformant loader would skip the newest skill.
- **HIGH**: `init-gates.sh` language detection can silently fail open under pipefail/SIGPIPE (reproduced), omitting whole gate blocks while exiting 0.
- 6 medium + ~30 low, concentrated in the shell-script layer and doc/count drift; content and release decisions overwhelmingly re-verify (13/16 JUSTIFIED).

## Notes

- Report is 340 lines (≤500 invariant), passes `check-invariants.sh` + pre-commit, and intentionally describes the denylist findings without quoting the denied strings.
- CHANGELOG entry deliberately omitted here to avoid an Unreleased-section merge conflict with #37 — add one line when cutting the next release.
- Fix PRs for the individual findings to follow separately; #37 already covers the gitleaks history scan and stale version pointer.
