### PR TITLE
docs: RELEASING.md — release procedure in-repo (roadmap item 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Added **`RELEASING.md`** — the release procedure in-repo (roadmap item 4):
+  version- and count-bearing surfaces, PNG re-render, pre-tag checklist.
+- Fixed **social-preview image saying "30 skills"** (stale through three
+  releases): regenerated at 37; tagline now count-free by design (PR #41).
+
 ## [1.8.0] - 2026-07-02
 
 Two new user-facing-words skills (37 skills total) plus a README overhaul for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,9 @@ pre-commit hook scans each commit locally.
 ## Pointers
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — full contribution guide and PR checklist
+- [RELEASING.md](RELEASING.md) — how to cut a release, including every
+  version- and count-bearing surface (README, router, manifests, social
+  preview)
 - [SECURITY.md](SECURITY.md) — reporting bad guidance or a leaked secret
 - [CHANGELOG.md](CHANGELOG.md) — release history (top entry = current version;
   also mirrored in `VERSION`)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,78 @@
+# Releasing
+
+How to cut a SOTA-skills release. Adding a skill is a **minor** bump (the
+library only ever adds); fixes to existing content are a **patch**. Everything
+lands through a PR — `main` is protected for everyone, including admins (see
+[CLAUDE.md](CLAUDE.md)).
+
+## 1. Version-bearing files (every release)
+
+| File | What changes |
+|---|---|
+| `VERSION` | the new semver, single line |
+| `.claude-plugin/plugin.json` | `"version"`; also the skill/domain counts in `"description"` if they changed |
+| `CHANGELOG.md` | new `## [X.Y.Z] - YYYY-MM-DD` section at the top **and** a `[X.Y.Z]: …/releases/tag/vX.Y.Z` link ref at the bottom (top entry = current version — no `[Unreleased]` left behind) |
+
+## 2. Count-bearing surfaces (when the skill count changes)
+
+Recount from the tree — never adjust numbers by memory:
+
+```sh
+ls -d skills/*/ | wc -l                          # N skills (incl. router)
+find skills -name '*.md' | wc -l                 # M files
+find skills -name '*.md' -exec cat {} + | wc -l  # ~L lines
+```
+
+Then update every surface that carries a count:
+
+- **README**: badge `skills-N`, hero sentence "N Claude Code skills (M files,
+  ~Lk lines)", social-preview `alt` text, and a table row per new skill.
+- **Router** (`skills/sota/SKILL.md`): body "A library of N domain skills"
+  (N = total − 1), a routing-table row + library-map entry per new skill, and
+  the domain list in the frontmatter description — which must stay
+  **≤ 1024 characters** (invariant 4; it hit the cap at v1.8.0 and needed a
+  trim).
+- **`.claude-plugin/marketplace.json`**: counts in the plugin `description`.
+- **`assets/social-preview.html`**: the "N skills" pill — the *only* count in
+  the image by design (the tagline is deliberately count-free; the pill sat
+  stale at "30 skills" for three releases before v1.8.0). Re-render the PNG:
+  serve the directory over localhost (`python3 -m http.server`) and
+  screenshot at exactly **1280×640** with a headless browser — `file://` is
+  typically blocked. Commit both files.
+- GitHub **Settings → Social preview** is a separate manual upload — updating
+  `assets/social-preview.png` in the repo does **not** refresh it; re-upload
+  the new PNG there.
+
+## 3. Land the PR
+
+```sh
+./scripts/check-invariants.sh        # same checks as CI
+git checkout -b <branch> && git commit && git push
+# open the PR; both required checks green → squash-merge
+```
+
+## 4. Tag and publish (after the squash-merge)
+
+```sh
+git checkout main && git pull --ff-only
+git tag -a vX.Y.Z -m vX.Y.Z && git push origin vX.Y.Z
+# release notes = the [X.Y.Z] section of CHANGELOG.md
+gh release create vX.Y.Z --title vX.Y.Z --notes-file <notes>
+```
+
+Plugin installs pick the release up because the `plugin.json` version bumped
+(`/plugin update sota-skills@sota-skills`); symlinked clone installs update on
+`git pull`, and `./scripts/install.sh --update` also links any brand-new
+skills.
+
+## Pre-tag checklist
+
+- [ ] `./scripts/check-invariants.sh` passes
+- [ ] `VERSION` == `plugin.json` version == the tag you're about to push
+- [ ] CHANGELOG top entry is the new version, dated, with its link ref
+- [ ] If the skill count changed: README badge/hero/alt, router body +
+      description, marketplace.json, social-preview pill + regenerated PNG
+      all show the recounted numbers
+- [ ] New skills appear in the README table and the router's routing table +
+      library map
+- [ ] GitHub Settings social-preview re-upload done (or consciously deferred)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,7 +28,10 @@ Ordered; revisit after each release.
    VERSION + plugin.json + CHANGELOG + tag + GitHub release, plus the
    version-bearing strings in README/CLAUDE.md. Eight releases shipped in the
    first 14 days from a procedure that lives outside the repo; the v1.0.0
-   pointer rot in CLAUDE.md was the predictable result.
+   pointer rot in CLAUDE.md was the predictable result. *(Landed 2026-07-02:
+   [RELEASING.md](../RELEASING.md), incl. the count-bearing surfaces — the
+   v1.8.0 release found the social-preview image still saying "30 skills",
+   the same rot class again.)*
 5. **Structured feedback intake.** `.github/ISSUE_TEMPLATE` with a
    bad-guidance report (file:line + primary source, mirroring SECURITY.md's
    format) and a skill-request template; enable Discussions. A no-telemetry


### PR DESCRIPTION
## What

- **`RELEASING.md`** — closes roadmap item 4 (release procedure in-repo): version-bearing files, count-bearing surfaces with recount commands (README badge/hero/alt, router body + ≤1024-char description, manifests, social-preview pill + 1280×640 PNG re-render + the manual Settings re-upload), tag/publish steps, pre-tag checklist.
- ROADMAP item 4 annotated *landed*, citing the fresh evidence: the v1.8.0 cut found the social-preview image still saying "30 skills" — exactly the rot class the item predicted.
- CLAUDE.md Pointers section links RELEASING.md.
- CHANGELOG gains an `[Unreleased]` section covering this and the PR #41 social-preview fix (which had landed without an entry). Kept compact — CHANGELOG.md is at 493/500 lines and will need an archive split within a release or two.

## Verification

Every procedural claim reproduces this session's actual v1.8.0 cut (PR #40/#41): the 1024-char router-description cap was hit and trimmed, file:// was blocked for the PNG render (localhost serve used), counts recounted from the tree. `./scripts/check-invariants.sh` passes.
