### PR TITLE
feat: execute roadmap items 2, 3, 5, 6 — lint gate, freshness ledger, feedback intake, coverage decision

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bad-guidance.yml
+++ b/.github/ISSUE_TEMPLATE/1-bad-guidance.yml
@@ -1,0 +1,54 @@
+name: Bad guidance report
+description: >-
+  A skill states something wrong, outdated, or misleading (NOT
+  security-sensitive — those go to a private advisory, see SECURITY.md).
+title: "[bad-guidance] "
+labels: ["bad-guidance"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thanks — verified corrections are exactly how this library stays
+        trustworthy. **If the bad guidance is security-sensitive** (insecure
+        pattern, wrong mitigation, understated severity) or you found a real
+        credential, **do not file it here**: use the
+        [private advisory form](https://github.com/martinholovsky/SOTA-skills/security/advisories/new)
+        per [SECURITY.md](../blob/main/SECURITY.md).
+  - type: input
+    id: location
+    attributes:
+      label: File and line
+      description: Repo-relative path plus line number(s).
+      placeholder: skills/sota-databases/rules/03-queries-indexes.md:142
+    validations:
+      required: true
+  - type: textarea
+    id: claim
+    attributes:
+      label: What the guidance currently says
+      description: Quote the claim as written.
+    validations:
+      required: true
+  - type: textarea
+    id: why-wrong
+    attributes:
+      label: Why it is wrong — with a primary source
+      description: >-
+        Cite the spec, vendor doc, release note, CVE/CWE, or regulation that
+        contradicts it (link + relevant quote). The fix will be verified the
+        same way the library asks every claim to be verified; reports without
+        a primary source may be closed as unverifiable.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested correction (optional)
+      description: What the guidance should say instead.
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmations
+      options:
+        - label: This is not security-sensitive (otherwise I will use the private advisory form).
+          required: true

--- a/.github/ISSUE_TEMPLATE/2-skill-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-skill-request.yml
@@ -1,0 +1,38 @@
+name: Skill request
+description: Propose a new skill (or a major gap to close in an existing one).
+title: "[skill-request] "
+labels: ["skill-request"]
+body:
+  - type: input
+    id: domain
+    attributes:
+      label: Domain or language
+      placeholder: e.g. sota-php, Active Directory / Kerberos content, Swift language rules
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why it's needed
+      description: >-
+        What tasks would it serve? What goes wrong today when the assistant
+        works in this domain without it?
+    validations:
+      required: true
+  - type: textarea
+    id: sources
+    attributes:
+      label: Authoritative sources to build from
+      description: >-
+        The primary sources a correct skill would cite — official docs,
+        standards (OWASP/NIST/ISO/CIS), vendor security guides. Every claim
+        in a skill must be verifiable against sources like these.
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmations
+      options:
+        - label: I checked the README skills table and the existing skill doesn't cover this (or I explained the gap above).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security-sensitive report (private)
+    url: https://github.com/martinholovsky/SOTA-skills/security/advisories/new
+    about: >-
+      Dangerous/insecure guidance or a real committed credential — report
+      privately per SECURITY.md, never as a public issue.
+  - name: Questions & discussion
+    url: https://github.com/martinholovsky/SOTA-skills/discussions
+    about: Usage questions, ideas, and anything that isn't a concrete defect.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           # The build steps run repo scripts and never push.
           persist-credentials: false
+          # Invariant 5 compares VERSION against the newest v* tag; a shallow
+          # tagless checkout would silently skip that comparison.
+          fetch-depth: 0
+          fetch-tags: true
       - name: Check invariants
         # SOTA_DENYLIST (repository secret) carries the private internal-name
         # patterns for check 3; fork PRs don't receive it and fall back to the

--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -1,0 +1,27 @@
+# Monthly freshness report (roadmap item 3): lists rules files whose
+# last-verified marker is past the re-verify window, plus the unstamped
+# backlog. A red run means claims need re-verification — see
+# scripts/check-freshness.sh for the marker convention.
+name: Freshness
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'   # 06:00 UTC on the 1st of every month
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  freshness:
+    name: Rules-file freshness
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v7.0.0, pinned by commit SHA (sota-devsecops).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+      - name: Freshness report
+        run: |
+          set -o pipefail
+          ./scripts/check-freshness.sh --list-unstamped | tee -a "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,17 @@ symlinks to it — edit only this file, never the symlinks.
    — or an unquoted inline description containing `: ` (invalid YAML; strict
    loaders reject the skill — use `description: >-`).
    (Needs `python3`; skipped with a warning if absent locally, enforced in CI.)
+5. **version drift** — `VERSION`, `plugin.json` `"version"`, and the CHANGELOG
+   top entry must agree, and the newest `v*` tag must never be ahead of
+   `VERSION` (it may lag during an open release PR);
+6. **count drift** — the README badge/hero/social-alt, the router body's
+   "N domain skills", the plugin + marketplace descriptions, and the
+   social-preview pill must all match a recount of the `skills/` tree.
+
+Separately, `scripts/check-freshness.sh` (run monthly by
+`.github/workflows/freshness.yml`, report-only) tracks each rules file's
+line-1 `<!-- last-verified: YYYY-MM -->` marker — update it whenever you
+re-verify a file's fast-moving claims against primary sources.
 
 Secrets are scanned by **gitleaks** (`.gitleaks.toml`, which disables only the
 noisy entropy-based `generic-api-key` rule so the security skills' intentional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Roadmap items 2, 3, 5, and 6 executed (see `docs/ROADMAP.md` annotations):
+
+- **Invariants 5 & 6** in `check-invariants.sh`: version lockstep (`VERSION`
+  == `plugin.json` == CHANGELOG top; newest tag never ahead) and count-surface
+  drift (README badge/hero/alt, router body, plugin/marketplace descriptions,
+  social-preview pill vs a recount of the tree). CI invariants job now checks
+  out full history so the tag comparison runs.
+- **Freshness ledger**: rules files carry a line-1
+  `<!-- last-verified: YYYY-MM -->` marker (18 files stamped from their
+  existing in-text dates — never retroactively); `scripts/check-freshness.sh`
+  + a monthly `freshness.yml` workflow report stale markers and the unstamped
+  backlog.
+- **Feedback intake**: bad-guidance and skill-request issue forms (primary
+  source required; security-sensitive reports routed to private advisories)
+  and GitHub Discussions enabled.
+- **README "Coverage & non-goals"**: PHP, Ruby, Swift-as-a-language, and
+  Active Directory/Kerberos depth declared out of scope for now and queued as
+  approved follow-up builds.
+
 ## [1.9.0] - 2026-07-03
 
 Cross-tool support: the library now works with Gemini CLI, Codex, and any

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,11 @@ AGENTS.md                     # guidance for AI assistants working on the repo
   (a target, not a floor — compact rules files are fine; the hard cap is 500).
 - Ends with an **`## Audit checklist`** — yes/no questions, ideally with
   grep/lint patterns, so the rule can be used to hunt violations.
+- When you verify (or re-verify) a file's fast-moving claims against primary
+  sources, record it as the file's **first line**:
+  `<!-- last-verified: YYYY-MM -->`. A monthly CI job
+  (`scripts/check-freshness.sh`) reports files whose marker is past the
+  re-verify window and the unstamped backlog.
 
 **Findings format** (AUDIT mode, used throughout):
 
@@ -91,6 +96,12 @@ are marked "needs verification", never asserted.
    invalid YAML that makes loaders skip the skill; use `description: >-`.
    (Check 4 needs `python3`, and is skipped with a warning if it is absent
    locally — CI always enforces it.)
+5. **version drift**: `VERSION`, `plugin.json`, and the CHANGELOG top entry
+   must agree; the newest `v*` tag must never be ahead of `VERSION`;
+6. **count drift**: every count-bearing surface (README badge/hero/alt, router
+   body, plugin/marketplace descriptions, social-preview pill) must match a
+   recount of the `skills/` tree — adding or removing a skills file means
+   updating those surfaces in the same PR.
 
 Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`);
 CI scans the full git history, the pre-commit hook scans each commit.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ performance, API evolvability, per-language idioms, SLOs, test-suite health.
 | `sota-javascript-typescript` | Strict TS, idioms, async, Node hardening, security, bundle/React performance, testing |
 | `sota-dotnet` | C#/.NET idioms (records, NRT, patterns, spans), disposal/DI design, async (ConfigureAwait/cancellation), security (EF/Dapper, deserialization, ASP.NET Core auth, crypto), GC/Span/AOT, NuGet supply chain & analyzers/CI |
 
+### Coverage & non-goals
+
+Deliberately **not covered yet**: **PHP**, **Ruby**, **Swift as a language
+skill** (`sota-mobile` covers platform Swift), and **Active Directory/Kerberos**
+depth. All four are queued — file a *skill request* issue to raise priority.
+
 ## Installation
 
 **Easiest — as a Claude Code plugin** (installs all skills, updates via
@@ -142,29 +148,26 @@ for d in skills/*/; do ln -sfn "$(pwd)/$d" ~/.claude/skills/"$(basename "$d")"; 
 sota-skills@sota-skills` (or `/plugin marketplace update sota-skills`). Git-hosted
 marketplaces also check at session start.
 
-**Clone install:** because linking is symlink-based, **existing skills update the
-moment you pull**
-— the symlinks already point at the live files, no re-install needed:
+**Clone install:** because linking is symlink-based, **existing skills update
+the moment you pull** — the symlinks already point at the live files:
 
 ```sh
 git -C /path/to/SOTA-skills pull
 ```
 
 To also pick up **newly added** skills (a pull alone won't link a brand-new
-skill directory) and prune links to removed ones, re-run the installer — or do
-both at once:
+skill directory) and prune links to removed ones — pull and re-link at once:
 
 ```sh
 ./scripts/install.sh --update        # git pull --ff-only, then re-link
 ```
 
 It's idempotent: re-running only links what's new and prunes what's gone, and
-never touches symlinks it didn't create. (Snapshot installs done with `--copy`
-don't auto-update — re-run the installer to refresh them.) If you enabled
-always-on routing, a re-run also **refreshes the managed routing directive and
-reminder hook in place** when their wording changes upstream — prompting first,
-backing up, and touching only the managed block; a hook you customized (different
-wording) is left untouched.
+never touches symlinks it didn't create (`--copy` snapshots don't auto-update —
+re-run to refresh). With always-on routing enabled, a re-run also **refreshes
+the managed routing directive and reminder hook in place** when their wording
+changes upstream — prompting first, backing up, touching only the managed
+block; a hook you customized is left untouched.
 
 ### Always-on routing (recommended)
 
@@ -174,14 +177,13 @@ regardless of wording, pin the routing instruction where Claude Code always
 sees it.
 
 **The quick path:** `./scripts/install.sh` offers to set this up for you after
-linking the skills — it's interactive and **dotfiles-aware**: it detects an
-existing or symlinked `~/.claude/CLAUDE.md` / `settings.json`, **asks before
-touching anything** (recommended answer pre-filled), backs up first, writes
-*through* a symlink so dotfiles stay in charge, and uses managed markers so
-re-runs never duplicate — and **refresh the managed block in place** (prompting
-first, backing up, touching only what's between the markers) when a newer release
-changes the directive or hook wording. Use `--routing` to force it,
-`--no-routing` to skip, `--yes` for non-interactive. Or wire the three layers by hand:
+linking the skills — interactive and **dotfiles-aware**: it detects an existing
+or symlinked `~/.claude/CLAUDE.md` / `settings.json`, **asks before touching
+anything** (recommended answer pre-filled), backs up first, writes *through* a
+symlink so dotfiles stay in charge, and uses managed markers so re-runs refresh
+the managed block in place and never duplicate it. Use `--routing` to force,
+`--no-routing` to skip, `--yes` for non-interactive. Or wire the three layers
+by hand:
 
 Three layers, strongest last:
 
@@ -214,9 +216,9 @@ when I never say "SOTA" or "audit". Treat `~/.claude/profiles/<you>.md` as the
 BUILD default and AUDIT baseline, and stop-and-ask on security-relevant choices.
 ```
 
-**3. (Optional) A per-prompt reminder.** In long sessions a directive read many
-turns ago can fade from context. A `UserPromptSubmit` hook in
-`~/.claude/settings.json` re-injects it on every prompt:
+**3. (Optional) A per-prompt reminder.** A directive read many turns ago can
+fade from a long context; a `UserPromptSubmit` hook in `~/.claude/settings.json`
+re-injects it on every prompt:
 
 ```json
 {
@@ -229,17 +231,15 @@ turns ago can fade from context. A `UserPromptSubmit` hook in
 }
 ```
 
-No mechanism *forces* a model to run a skill — all three layers feed it
-instructions it then chooses to follow. Together they make routing reliable
-instead of phrasing-dependent.
+No mechanism *forces* a model to run a skill — the three layers feed it
+instructions it chooses to follow, making routing reliable, not phrasing-dependent.
 
 ## Using it
 
-With always-on routing set up (above), you **don't name anything** — describe the
-task in plain language and the right skills load automatically (see
-[How it works](#how-it-works)). Naming a skill or rule is optional: reach for it
-only to *force* a specific skill, *scope* to one rule file, or *stack* an exact
-combo.
+With always-on routing set up (above), you **don't name anything** — describe
+the task in plain language and the right skills load automatically (see
+[How it works](#how-it-works)). Name a skill or rule only to *force* a specific
+skill, *scope* to one rule file, or *stack* an exact combo.
 
 **Building** — plain prompts; routing picks the skills:
 
@@ -290,8 +290,8 @@ combo.
 
 **Maintaining the library:**
 
-> Refresh the library against current versions/advisories — re-verify fast-moving
-> claims and update the rules files (cite sources).
+> Refresh the library — re-verify fast-moving claims against current primary
+> sources and update the rules files' `last-verified` markers.
 
 > Create profiles/<name>.md for my stack: <stores, auth, platform, policies>.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,8 @@ lands through a PR — `main` is protected for everyone, including admins (see
 
 ## 2. Count-bearing surfaces (when the skill count changes)
 
-Recount from the tree — never adjust numbers by memory:
+Recount from the tree — never adjust numbers by memory (invariant 6 fails CI
+on drift among these surfaces, and invariant 5 on version drift):
 
 ```sh
 ls -d skills/*/ | wc -l                          # N skills (incl. router)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,8 +13,9 @@ Ordered; revisit after each release.
 2. **Library lint gate** (extends `check-invariants.sh`): YAML-parse all
    SKILL.md frontmatters, VERSION == plugin.json == latest tag lockstep,
    README count-basis check, shellcheck over `scripts/`. Blocks the whole
-   defect class the audit found. *(Partially landed: YAML-validity check and
-   shellcheck CI job in #37; version-lockstep and count checks still open.)*
+   defect class the audit found. *(Landed: YAML-validity check and shellcheck
+   CI job in #37; version-lockstep (check 5) and count-surface (check 6)
+   invariants on 2026-07-04.)*
 
 ## Next — keep the core promise true
 
@@ -23,7 +24,11 @@ Ordered; revisit after each release.
    promises "fast-moving claims are web-verified against primary sources";
    today only ~21 of 220 rules files carry any verification date, so the
    promise is unauditable — and every "2026 baseline" assertion goes silently
-   stale in 2027.
+   stale in 2027. *(Mechanism landed 2026-07-04: line-1 markers — the 18 files
+   with dated in-text verification stamped from those dates —
+   `scripts/check-freshness.sh`, and a monthly `freshness.yml` report.
+   Remaining: the ~210-file verification backfill; files are stamped only
+   when actually re-verified, never retroactively.)*
 4. **Release procedure in-repo** (`RELEASING.md` or a CONTRIBUTING section):
    VERSION + plugin.json + CHANGELOG + tag + GitHub release, plus the
    version-bearing strings in README/CLAUDE.md. Eight releases shipped in the
@@ -36,6 +41,9 @@ Ordered; revisit after each release.
    bad-guidance report (file:line + primary source, mirroring SECURITY.md's
    format) and a skill-request template; enable Discussions. A no-telemetry
    project's only adoption signal is structured issues — currently absent.
+   *(Landed 2026-07-04: both issue forms — the bad-guidance form requires a
+   primary source and redirects security-sensitive reports to the private
+   advisory flow — plus a contact-link config; Discussions enabled.)*
 
 ## Later — coverage decisions (decide, don't drift)
 
@@ -46,7 +54,11 @@ Ordered; revisit after each release.
    skills whose real-world audits are AD-heavy. Ship `sota-php`, `sota-ruby`,
    a Swift-language rules file, and AD content — or add a README "coverage &
    non-goals" section stating what is deliberately excluded. The mission
-   statement overclaims until one of the two happens.
+   statement overclaims until one of the two happens. *(Decided 2026-07-04 —
+   both: the README "Coverage & non-goals" section is live, and `sota-php`,
+   `sota-ruby`, Swift-language rules, and AD/Kerberos content are approved
+   and queued as follow-up builds, each to be web-verified against primary
+   sources like the v1.6.0 language skills.)*
 
 ## Maintenance mode (de-prioritized by audit evidence)
 

--- a/scripts/check-freshness.sh
+++ b/scripts/check-freshness.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# check-freshness.sh — report the verification freshness of every rules file.
+#
+# The library promises that fast-moving claims are verified against primary
+# sources. This makes that promise auditable: a rules file whose claims have
+# been (re-)verified carries, as its FIRST line, the marker
+#
+#   <!-- last-verified: YYYY-MM -->
+#
+# and this script reports every skills/*/rules/*.md that is either
+#   - STALE:     marker older than the re-verify window (default 12 months), or
+#   - UNSTAMPED: no marker — the file's claims have never been dated.
+#
+# Exit code: 1 if any STAMPED file is past the window (a red scheduled run is
+# the re-verify signal), 0 otherwise. Unstamped files are reported as debt but
+# do not fail the run — they would keep it red forever and train everyone to
+# ignore it; the count trending to zero is the goal.
+#
+# Usage: scripts/check-freshness.sh [--window-months N] [--list-unstamped]
+#
+# Portable to macOS bash 3.2. Run by .github/workflows/freshness.yml monthly.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+WINDOW=12
+LIST_UNSTAMPED=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --window-months) shift; WINDOW="${1:?--window-months needs a number}" ;;
+    --list-unstamped) LIST_UNSTAMPED=1 ;;
+    *) printf 'error: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+now_y=$(date +%Y)
+now_m=$(date +%m)
+now_idx=$((now_y * 12 + ${now_m#0}))
+
+total=0 fresh=0 stale=0 unstamped=0
+stale_list="" unstamped_list=""
+
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  total=$((total + 1))
+  first=$(head -n 1 "$f")
+  case "$first" in
+    '<!-- last-verified: '[0-9][0-9][0-9][0-9]-[0-9][0-9]' -->')
+      ym=${first#'<!-- last-verified: '}
+      ym=${ym%' -->'}
+      y=${ym%-*}; m=${ym#*-}
+      idx=$((y * 12 + ${m#0}))
+      age=$((now_idx - idx))
+      if [ "$age" -gt "$WINDOW" ]; then
+        stale=$((stale + 1))
+        stale_list="${stale_list}    ${f}  (last-verified ${ym}, ${age} months ago)
+"
+      else
+        fresh=$((fresh + 1))
+      fi
+      ;;
+    *)
+      unstamped=$((unstamped + 1))
+      unstamped_list="${unstamped_list}    ${f}
+"
+      ;;
+  esac
+done < <(git ls-files 'skills/*/rules/*.md')
+
+echo "Freshness report (window: ${WINDOW} months) — ${total} rules files"
+echo "  fresh:     ${fresh}"
+echo "  stale:     ${stale}"
+echo "  unstamped: ${unstamped}  (never dated — verification debt)"
+if [ "$stale" -gt 0 ]; then
+  echo
+  echo "STALE — re-verify against primary sources, then update the marker:"
+  printf '%s' "$stale_list"
+fi
+if [ "$LIST_UNSTAMPED" -eq 1 ] && [ "$unstamped" -gt 0 ]; then
+  echo
+  echo "UNSTAMPED:"
+  printf '%s' "$unstamped_list"
+fi
+
+[ "$stale" -eq 0 ] || exit 1

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -10,10 +10,18 @@
 #   4. Every skills/*/SKILL.md description is <= 1024 characters (Agent Skills
 #      spec: loaders skip a skill whose description exceeds the cap) and is
 #      not YAML-invalid (unquoted ': ' inline — strict loaders reject it).
+#   5. Version lockstep: VERSION == plugin.json "version"; CHANGELOG's top
+#      entry is [Unreleased] or [VERSION]; the newest v* tag is never ahead
+#      of VERSION (VERSION may lead during a release PR).
+#   6. Count-bearing surfaces match the tree: README badge/hero/social-alt,
+#      the router's "N domain skills", plugin.json + marketplace.json
+#      descriptions, and the social-preview pill.
 #
 # Portable to macOS bash 3.2 (no mapfile/associative arrays). Check 4 needs
 # python3 for correct Unicode character counting; it is skipped with a warning
 # if python3 is absent locally (CI runs on a runner that always has it).
+# Check 5's tag comparison is skipped with a note when no v* tags are visible
+# (e.g. a shallow CI checkout without tags).
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -24,7 +32,7 @@ fail=0
 note() { printf '    %s\n' "$1"; }
 
 # --- 1. Line budget -------------------------------------------------------
-echo "[1/4] Markdown files <= ${MAX_LINES} lines"
+echo "[1/6] Markdown files <= ${MAX_LINES} lines"
 over=0
 while IFS= read -r f; do
   [ -f "$f" ] || { note "SKIPPED (tracked but missing from worktree): $f"; continue; }
@@ -38,7 +46,7 @@ done < <(git ls-files '*.md')
 if [ "$over" -eq 0 ]; then echo "    ok"; else fail=1; fi
 
 # --- 2. Audit checklist ends every rules file ------------------------------
-echo "[2/4] Every skills/*/rules/*.md ends with an '## Audit checklist'"
+echo "[2/6] Every skills/*/rules/*.md ends with an '## Audit checklist'"
 missing=0
 while IFS= read -r f; do
   [ -f "$f" ] || { note "SKIPPED (tracked but missing from worktree): $f"; continue; }
@@ -63,7 +71,7 @@ if [ "$missing" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # .denylist.local (git-ignored, one ERE per line, '#' comments). When neither
 # exists (e.g. an external fork's PR), only the generic phrases are checked —
 # the maintainer's pre-commit hook and this repo's CI carry the full list.
-echo "[3/4] No internal-name leaks"
+echo "[3/6] No internal-name leaks"
 DENY='the user runs|the user operates'
 if [ -n "${SOTA_DENYLIST:-}" ]; then
   DENY="$DENY|$SOTA_DENYLIST"
@@ -99,7 +107,7 @@ fi
 # Code, Codex, ...) skip any skill that exceeds it. Count Unicode characters
 # (descriptions use em-dashes: 1 char, 3 bytes) via python3, parsing both
 # folded block scalars (`>-`) and plain single-line descriptions.
-echo "[4/4] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
+echo "[4/6] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
 if command -v python3 >/dev/null 2>&1; then
   if desc_out=$(python3 - "$MAX_DESC" <<'PY'
 import sys, glob, re
@@ -148,6 +156,74 @@ PY
 else
   note "SKIPPED: python3 not found (CI enforces this check)"
 fi
+
+# --- 5. Version lockstep ----------------------------------------------------
+# One version, four places: VERSION, plugin.json, the CHANGELOG's top entry,
+# and (after the release lands) the newest v* tag. Drift here shipped a main
+# briefly claiming 1.8.0 with 1.9.0 content (2026-07-03) — hence a hard check.
+echo "[5/6] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
+v5=0
+ver=$(tr -d '[:space:]' < VERSION)
+case "$ver" in
+  *[!0-9.]*|.*|*.|'') note "VERSION is not a plain X.Y.Z semver: '$ver'"; v5=1 ;;
+esac
+pj=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' .claude-plugin/plugin.json | head -n 1)
+[ "$pj" = "$ver" ] || { note "plugin.json version '$pj' != VERSION '$ver'"; v5=1; }
+top=$(grep -m 1 -E '^## \[' CHANGELOG.md | sed 's/^## \[\([^]]*\)\].*/\1/')
+case "$top" in
+  Unreleased|"$ver") ;;
+  *) note "CHANGELOG top entry is [$top] — expected [Unreleased] or [$ver]"; v5=1 ;;
+esac
+# Newest v* tag by semver sort. VERSION may lead the tag (open release PR);
+# a tag ahead of VERSION means VERSION was never bumped — fail.
+tag=$(git tag --list 'v[0-9]*' | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -n 1)
+if [ -z "$tag" ]; then
+  note "(no v* tags visible — tag check skipped; needs a full-depth checkout)"
+else
+  newest=$(printf '%s\n%s\n' "$tag" "$ver" | sort -t. -k1,1n -k2,2n -k3,3n | tail -n 1)
+  if [ "$tag" != "$ver" ] && [ "$newest" = "$tag" ]; then
+    note "newest tag v$tag is AHEAD of VERSION $ver — bump VERSION + plugin.json"
+    v5=1
+  fi
+fi
+if [ "$v5" -eq 0 ]; then echo "    ok"; else fail=1; fi
+
+# --- 6. Count-bearing surfaces match the tree --------------------------------
+# The drift class the 2026-07-01 audit kept finding: skill/file/line counts
+# rot on surfaces nobody recounts (the social preview said "30 skills" for
+# three releases). Recount from the tree and compare every tracked surface;
+# RELEASING.md lists the same surfaces for manual release edits.
+echo "[6/6] Count-bearing surfaces match the tree"
+v6=0
+ck() { # ck <found> <expected> <surface>
+  [ "$1" = "$2" ] || { note "$3: says '${1:-<not found>}', tree says '$2'"; v6=1; }
+}
+n_skills=$(git ls-files 'skills/*/SKILL.md' | wc -l | tr -d ' ')
+n_files=$(git ls-files 'skills/' | grep -c '\.md$' || true)
+n_lines=$(git ls-files 'skills/' | grep '\.md$' | tr '\n' '\0' | xargs -0 cat | awk 'END{print NR}')
+n_klines=$(awk -v l="$n_lines" 'BEGIN{printf "%d", (l + 500) / 1000}')
+n_domains=$((n_skills - 1))   # every skill except the router
+
+ck "$(sed -n 's/.*badge\/skills-\([0-9]*\)-.*/\1/p' README.md | head -n 1)" \
+   "$n_skills" "README badge"
+hero=$(grep -m 1 -E '[0-9]+ skills \([0-9]+ files, ~[0-9]+k lines\)' README.md || true)
+ck "$(printf '%s' "$hero" | grep -oE '[0-9]+ skills \(' | grep -oE '[0-9]+' || true)" \
+   "$n_skills" "README hero skill count"
+ck "$(printf '%s' "$hero" | grep -oE '\([0-9]+ files' | grep -oE '[0-9]+' || true)" \
+   "$n_files" "README hero file count"
+ck "$(printf '%s' "$hero" | grep -oE '~[0-9]+k lines' | grep -oE '[0-9]+' || true)" \
+   "$n_klines" "README hero ~k-lines"
+ck "$(sed -n 's/.*alt="SOTA Engineering Skills — \([0-9]*\) .*/\1/p' README.md | head -n 1)" \
+   "$n_skills" "README social-preview alt"
+ck "$(sed -n 's/^A library of \([0-9]*\) domain skills.*/\1/p' skills/sota/SKILL.md | head -n 1)" \
+   "$n_domains" "router body (skills/sota/SKILL.md)"
+for j in .claude-plugin/plugin.json .claude-plugin/marketplace.json; do
+  ck "$(sed -n 's/.*(\([0-9]*\) skills).*/\1/p' "$j" | head -n 1)" "$n_skills" "$j skill count"
+  ck "$(sed -n 's/.*across \([0-9]*\) domains.*/\1/p' "$j" | head -n 1)" "$n_domains" "$j domain count"
+done
+ck "$(sed -n 's/.*>\([0-9]*\) skills<.*/\1/p' assets/social-preview.html | head -n 1)" \
+   "$n_skills" "social-preview.html pill (re-render the PNG too)"
+if [ "$v6" -eq 0 ]; then echo "    ok"; else fail=1; fi
 
 # --- Result ---------------------------------------------------------------
 echo

--- a/skills/sota-llm-engineering/rules/02-prompt-context-engineering.md
+++ b/skills/sota-llm-engineering/rules/02-prompt-context-engineering.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # Rules 02 — Prompt & Context Engineering
 
 A prompt is production code: versioned, tested, reviewed, and structured for

--- a/skills/sota-llm-engineering/rules/04-agents-tools.md
+++ b/skills/sota-llm-engineering/rules/04-agents-tools.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # Rules 04 — Agents & Tool Use
 
 An agent is a loop where the model decides what happens next. That autonomy is

--- a/skills/sota-llm-engineering/rules/05-production-engineering.md
+++ b/skills/sota-llm-engineering/rules/05-production-engineering.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # Rules 05 — Production Engineering
 
 The model is a remote dependency with variable latency, hard rate limits,

--- a/skills/sota-mobile/rules/01-platform-and-stack.md
+++ b/skills/sota-mobile/rules/01-platform-and-stack.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # 01 — Platform & Stack Choice
 
 Stack choice is a one-way door: migrating a shipped app between stacks is a rewrite, and a half-migrated hybrid is worse than either endpoint. Decide deliberately, record the rationale, and revisit only on major product inflection points.

--- a/skills/sota-mobile/rules/06-release-and-operations.md
+++ b/skills/sota-mobile/rules/06-release-and-operations.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # 06 — Release & Operations
 
 The defining constraint of mobile: **you cannot roll back a shipped binary.** Store review takes hours to days, users update on their own schedule, and a meaningful cohort runs every version you ever shipped — for years. All mobile release engineering is the discipline of designing around that single fact. The toolkit: kill switches instead of rollbacks, staged exposure instead of big bangs, forced updates as the last resort, and a server that never assumes clients are current.

--- a/skills/sota-network-security/rules/01-zero-trust-architecture.md
+++ b/skills/sota-network-security/rules/01-zero-trust-architecture.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # 01 — Zero-Trust Architecture
 
 Scope: the model that frames every other rule — never trust, always verify; policy decision/

--- a/skills/sota-network-security/rules/03-k8s-network-policy.md
+++ b/skills/sota-network-security/rules/03-k8s-network-policy.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # 03 — Kubernetes Network Policy Depth
 
 Scope: Kubernetes `NetworkPolicy`, `CiliumNetworkPolicy` (CNP/CCNP), the namespaced default-deny

--- a/skills/sota-network-security/rules/04-service-mesh-mtls.md
+++ b/skills/sota-network-security/rules/04-service-mesh-mtls.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # 04 — Service Mesh & mTLS / Internal Encryption
 
 Scope: the plaintext-internal-traffic problem and how mesh/mTLS solves it structurally; choosing and

--- a/skills/sota-network-security/rules/05-edge-ingress-egress.md
+++ b/skills/sota-network-security/rules/05-edge-ingress-egress.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # 05 — Edge, Ingress & Egress
 
 Scope: WAF (OWASP CRS, Coraza/ModSecurity), ingress/API-gateway hardening, DDoS posture, TLS

--- a/skills/sota-network-security/rules/06-dns-tls-pki.md
+++ b/skills/sota-network-security/rules/06-dns-tls-pki.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # 06 — DNS, TLS & PKI
 
 Scope: DNS security (DNSSEC, DNS firewall / RPZ, DoH/DoT, split-horizon, registrar/CAA hygiene,

--- a/skills/sota-privacy-compliance/rules/04-regulatory-landscape.md
+++ b/skills/sota-privacy-compliance/rules/04-regulatory-landscape.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # 04 — Regulatory Landscape: Engineering Obligations
 
 What each major regime actually demands from the codebase and infrastructure.

--- a/skills/sota-privacy-compliance/rules/05-audit-ready-engineering.md
+++ b/skills/sota-privacy-compliance/rules/05-audit-ready-engineering.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # 05 — Audit-Ready Engineering (SOC 2 / ISO 27001)
 
 The goal: evidence as a byproduct of normal engineering, not a quarterly scramble.

--- a/skills/sota-security-compliance/rules/01-control-frameworks-as-code.md
+++ b/skills/sota-security-compliance/rules/01-control-frameworks-as-code.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-07 -->
 # 01 — Control Frameworks as Code (NIST CSF 2.0 spine)
 
 The reusable engine under every regime in this skill: pick an organizing spine,

--- a/skills/sota-security-compliance/rules/02-nist-800-53-171-cmmc-fedramp.md
+++ b/skills/sota-security-compliance/rules/02-nist-800-53-171-cmmc-fedramp.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-07 -->
 # 02 — NIST 800-53 / 800-171 / CMMC / FedRAMP
 
 The US federal control stack. These four are one lineage: **SP 800-53** is the

--- a/skills/sota-security-compliance/rules/03-ssdf-secure-sdlc.md
+++ b/skills/sota-security-compliance/rules/03-ssdf-secure-sdlc.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-07 -->
 # 03 — Secure SDLC: NIST SSDF (SP 800-218)
 
 The framework that turns "we develop securely" from a claim into an assessable set

--- a/skills/sota-security-compliance/rules/04-eu-cyber-resilience-act.md
+++ b/skills/sota-security-compliance/rules/04-eu-cyber-resilience-act.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-07 -->
 # 04 — EU Cyber Resilience Act (CRA)
 
 The first horizontal EU law that makes **product cybersecurity** a legal

--- a/skills/sota-security-compliance/rules/05-iec-62443-ot-ics.md
+++ b/skills/sota-security-compliance/rules/05-iec-62443-ot-ics.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-07 -->
 # 05 — ISA/IEC 62443 for OT / ICS / Embedded
 
 The cybersecurity standard for **operational technology**: industrial control

--- a/skills/sota/rules/01-audit-methodology.md
+++ b/skills/sota/rules/01-audit-methodology.md
@@ -1,3 +1,4 @@
+<!-- last-verified: 2026-06 -->
 # Audit Methodology — Process, Tooling, Severity, Evidence & Reporting
 
 Scope: this file governs **how** an audit is run and reported — scoping,


### PR DESCRIPTION
Executes every remaining item from `docs/ROADMAP.md` (annotations updated in-file). No version bump — next release picks these up from `[Unreleased]`.

## Item 2 — library lint gate (now complete)
- **Check 5, version lockstep**: `VERSION` == `plugin.json` == CHANGELOG top entry (`[Unreleased]` allowed); newest `v*` tag must never be ahead of `VERSION`. Would have caught the 2026-07-03 incident where main briefly carried 1.9.0 content at version 1.8.0.
- **Check 6, count surfaces**: recounts skills/files/lines from the tree and verifies README badge + hero + social alt, router body, plugin.json + marketplace.json descriptions, and the social-preview pill. Would have caught the "30 skills for three releases" rot.
- CI invariants job checks out full history + tags so the tag comparison actually runs. Both checks negative-tested (perturbed VERSION/badge → precise failures → restored).

## Item 3 — freshness ledger (mechanism complete; backfill open)
- Convention: line-1 `<!-- last-verified: YYYY-MM -->` in rules files.
- 18 files stamped **from their existing in-text verification dates** — the other 210 are deliberately left unstamped rather than fabricating dates; the report tracks that backlog.
- `scripts/check-freshness.sh` (12-month window; exits red only when a *stamped* file goes stale, so the signal can't fatigue) + monthly `freshness.yml` writing a step summary.

## Item 5 — structured feedback intake
- Bad-guidance form (file:line, quoted claim, **primary source required**, security-sensitive reports redirected to the private advisory flow per SECURITY.md) + skill-request form + contact-link config. Discussions enabled via API.

## Item 6 — coverage decision (user chose: both)
- README **"Coverage & non-goals"**: PHP, Ruby, Swift-as-a-language, AD/Kerberos declared not-covered-yet; all four queued as approved follow-up builds (roadmap annotated).
- README held at 499/500 by tightening existing prose.

Docs updated in the same change: AGENTS.md + CONTRIBUTING invariant lists (4 → 6) and the marker convention, RELEASING note, ROADMAP annotations, CHANGELOG `[Unreleased]`.
