### PR TITLE
docs(router): cryptography fan-out routing rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Router (`skills/sota/SKILL.md`): added cross-cutting routing rule 18,
+  **"Cryptography fans out"** — a single lookup that maps a crypto task to its
+  distributed owners (algorithm/AEAD/key-handling/TLS-client/PQC →
+  `sota-code-security` rules/04; key material/storage/rotation →
+  `sota-secrets-management`; TLS server/PKI/cert lifecycle →
+  `sota-network-security` rules/06; FIPS-validated-module →
+  `sota-security-compliance` rules/02). Documents the deliberate no-single-crypto-skill
+  design; no content moved.
+
 ## [1.11.0] - 2026-07-06
 
 ### Added

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -153,6 +153,16 @@ rules files that match the code in front of you. Never load all skills at once.
 17. **Shell scripts hide everywhere** — CI run blocks, Dockerfile RUN lines,
     Makefiles, entrypoints. Audit them with `sota-shell-scripting` even when
     the repo's "language" is something else.
+18. **Cryptography fans out — there is no single crypto skill (by design).**
+    Algorithm choice, AEAD/nonce discipline, CSPRNG, in-code key handling, TLS
+    client config, constant-time comparison, crypto agility, and post-quantum
+    migration → `sota-code-security` rules/04. The key *material* — storage
+    backends (KMS/HSM, Vault, SOPS+age), lifecycle, rotation, per-credential-type
+    handling → `sota-secrets-management`. Transport/PKI — TLS server config, cert
+    lifecycle/ACME, private CA, mTLS → `sota-network-security` rules/06.
+    FIPS-140-3-validated-module requirements → `sota-security-compliance`
+    rules/02. Language-specific APIs (JCA, `crypto/*`, .NET) stay in the language
+    skill. The stance throughout is **use a vetted library, don't roll your own**.
 
 ## BUILD mode — workflow
 


### PR DESCRIPTION
Adds cross-cutting **routing rule 18 — "Cryptography fans out"** to the master router, per the assessment that a dedicated `sota-cryptography` skill isn't warranted (the coverage already exists, is high quality, and is discoverable via existing `crypto`/`TLS` trigger keywords).

The rule turns "where's the crypto guidance?" into a one-line lookup mapping each facet to its owner:

- algorithms / AEAD / nonce / CSPRNG / in-code key handling / TLS-client / constant-time / crypto-agility / PQC → `sota-code-security` rules/04
- key material — storage backends (KMS/HSM, Vault, SOPS+age), lifecycle, rotation → `sota-secrets-management`
- TLS server / PKI / cert lifecycle / mTLS → `sota-network-security` rules/06
- FIPS-140-3 validated modules → `sota-security-compliance` rules/02
- language APIs (JCA, `crypto/*`, .NET) → the language skill

Doc-only: **no content moved**, no skill added, no count/version surface touched. CHANGELOG `[Unreleased]` notes it (picked up at the next release cut). All six invariants pass.
