### PR TITLE
docs: sync contributor docs to freshness-sweep + floor-model changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,11 @@ symlinks to it — edit only this file, never the symlinks.
 5. **version drift** — `VERSION`, `plugin.json` `"version"`, and the CHANGELOG
    top entry must agree, and the newest `v*` tag must never be ahead of
    `VERSION` (it may lag during an open release PR);
-6. **count drift** — the README badge/hero/social-alt, the router body's
-   "N domain skills", the plugin + marketplace descriptions, and the
-   social-preview pill must all match a recount of the `skills/` tree.
+6. **count drift** — the README badge/hero, the router body's "N domain
+   skills", and the plugin + marketplace descriptions must match a recount of
+   the `skills/` tree; the social-preview pill and README alt are **"N+"
+   floors** (they fail only if the tree count drops below the floor), so the
+   PNG is not re-rendered per release.
 
 Separately, `scripts/check-freshness.sh` (run monthly by
 `.github/workflows/freshness.yml`) tracks the root `LAST-VERIFIED` stamp —
@@ -68,6 +70,13 @@ pre-commit hook scans each commit locally.
 - **Verify claims.** Fast-moving facts (versions, specs, advisories) are checked
   against a primary source and cited; uncertain items are marked
   "needs verification", never asserted.
+- **No rot-prone version pins.** Skills never claim "the current release is
+  X.Y" — write "latest stable" and tell the reader to verify at the official
+  source. Version numbers mark **semantic boundaries only** ("GA since",
+  "introduced/fixed/removed in", CVE fix versions, spec editions). When a
+  recommended tool goes EOL/unmaintained, replace it with the maintained
+  successor (project-recommended target first, then CNCF), keeping a one-line
+  EOL note for auditors. (Policy since the 2026-07-08 freshness sweep.)
 - **Skill anatomy.** `skills/sota-<domain>/SKILL.md` (two-field frontmatter —
   `name` + `description`; BUILD/AUDIT workflows; top-10 non-negotiables; a rules
   index) plus `rules/NN-topic.md` files, each ≤ 500 lines and ending in an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Contributor docs synced to this cycle's policy changes: AGENTS.md and
+  CONTRIBUTING.md now state the **no-version-pins rule** (latest stable +
+  semantic boundaries only, EOL→successor) as a standing convention and
+  describe invariant 6's exact-count vs "N+"-floor split; RELEASING.md's
+  pre-tag checklist matches the floor model; docs/ROADMAP.md logs
+  `sota-confidential-computing` under coverage additions.
 - **Version-claim policy applied library-wide**: rot-prone "current release is
   X.Y" claims replaced with "use the latest stable release — verify via a
   quick web search"; version numbers that mark semantic boundaries

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,11 @@ By contributing you agree your contribution is licensed under
    regulations) must be checked against a **primary source** — a spec, vendor
    doc, CVE/CWE, or official release — and cited. Prefer "needs verification"
    over a confident guess. The library's value is that its claims hold up.
+   Corollary — **no rot-prone version pins**: never write "the current release
+   is X.Y"; say "latest stable, verify at the official source". Version
+   numbers are for semantic boundaries only ("GA since", "fixed in", CVE fix
+   versions, spec editions). Recommend maintained tools; when one goes EOL,
+   point at its maintained successor and keep a one-line EOL note.
 3. **Stay lean.** Every Markdown file is **≤ 500 lines** so skills load
    incrementally without blowing the context window. If a topic outgrows that,
    split it into another `rules/NN-topic.md`.
@@ -101,10 +106,12 @@ are marked "needs verification", never asserted.
    locally — CI always enforces it.)
 5. **version drift**: `VERSION`, `plugin.json`, and the CHANGELOG top entry
    must agree; the newest `v*` tag must never be ahead of `VERSION`;
-6. **count drift**: every count-bearing surface (README badge/hero/alt, router
-   body, plugin/marketplace descriptions, social-preview pill) must match a
-   recount of the `skills/` tree — adding or removing a skills file means
-   updating those surfaces in the same PR.
+6. **count drift**: the exact-count surfaces (README badge/hero, router body,
+   plugin/marketplace descriptions) must match a recount of the `skills/`
+   tree — adding or removing a skills file means updating them in the same
+   PR. The social-preview pill and README alt carry an **"N+" floor** instead
+   (checked only against dropping below it), so the image needs no per-release
+   re-render.
 
 Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`);
 CI scans the full git history, the pre-commit hook scans each commit.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,9 +72,11 @@ skills.
 - [ ] `./scripts/check-invariants.sh` passes
 - [ ] `VERSION` == `plugin.json` version == the tag you're about to push
 - [ ] CHANGELOG top entry is the new version, dated, with its link ref
-- [ ] If the skill count changed: README badge/hero/alt, router body +
-      description, marketplace.json, social-preview pill + regenerated PNG
-      all show the recounted numbers
+- [ ] If the skill count changed: README badge/hero, router body +
+      description, plugin/marketplace.json show the recounted numbers
+      (the social-preview pill + README alt are "N+" floors — touch them
+      only when deliberately raising the floor, which also means
+      re-rendering the PNG)
 - [ ] New skills appear in the README table and the router's routing table +
       library map
-- [ ] GitHub Settings social-preview re-upload done (or consciously deferred)
+- [ ] GitHub Settings social-preview re-upload — only if the PNG changed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -71,6 +71,13 @@ Ordered; revisit after each release.
   rules/06; XSS-sink names in rules/05). Closes the frontend-framework gap that sat
   between the language skill (`sota-javascript-typescript`) and the design skill
   (`sota-frontend-design`) without overlapping either. 40 skills total.
+- **`sota-confidential-computing`** *(shipped 2026-07-09)* — TEEs
+  (SEV-SNP/TDX/ARM CCA, SGX enclaves, Nitro Enclaves, confidential GPUs),
+  remote attestation (RATS RFC 9334, attest-then-release), confidential
+  Kubernetes (CoCo/Kata/Trustee), and cryptographic PETs (FHE/MPC/ZKP/PSI).
+  Covers the workload-from-host trust direction — the inverse of
+  `sota-sandboxing`; router rule 19 encodes the boundary. Demand-driven
+  (user gap-check found zero prior coverage). 41 skills total.
 
 ## Maintenance mode (de-prioritized by audit evidence)
 


### PR DESCRIPTION
Documentation-currency pass after this cycle's four PRs (#52 sweep, #53 roadmap, #54 confidential-computing + floor model, #55 README diagram). Every statement checked against the current scripts/tree:

- **AGENTS.md / CONTRIBUTING.md** — two gaps: the **no-version-pins policy** (applied library-wide in #52/#54) was enforced but nowhere documented for contributors; invariant 6's description still claimed all count surfaces need an exact match, but `check-invariants.sh` now applies **"N+" floors** to the social-preview pill and README alt. Both fixed; conventions now match the code.
- **RELEASING.md** — pre-tag checklist still required "social-preview pill + regenerated PNG" per count change and an unconditional Settings re-upload; now reflects the floor model (image work only when deliberately raising the floor).
- **docs/ROADMAP.md** — coverage-additions section now logs `sota-confidential-computing` (shipped 2026-07-09, 41 skills) alongside sota-web-frameworks.
- **CHANGELOG** — one `[Unreleased]` line noting the sync.

All 6 invariants pass.
