### PR TITLE
feat(network-security): self-hosted L3/4 DDoS hardening (rules/05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`sota-network-security` rules/05 — self-hosted / bare-metal DDoS
+  hardening** (R8.1): the one gap in the library's DDoS coverage. Existing
+  guidance assumed a scrubbing edge (Cloudflare/Shield/Cloud Armor); this
+  adds the L3/4 kernel layer for edges with no provider in front — TCP SYN
+  cookies + nftables synproxy (prereqs per the nftables wiki), conntrack-table
+  exhaustion sizing/alerting, reverse-path filtering (RFC 3704), and
+  not-being-an-amplifier hygiene (BCP 38 / RFC 2827 — no open DNS/NTP/
+  memcached/SSDP/chargen reflectors). R8 reframed to name edge scrubbing
+  generically (Anycast/provider tiers), with cross-refs to
+  sota-cloud-infrastructure rules/03 §10. Two audit-checklist items + SKILL
+  index/scope/trigger updates. All claims primary-sourced (nftables wiki,
+  kernel.org ip-sysctl, RFC 2827/3704).
+
 ## [1.12.0] - 2026-07-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 **Make your AI coding assistant build and audit like your most senior engineer.**
 
 Your assistant is brilliant — it just doesn't know your standards. SOTA-skills teaches
-it: 41 skills (295 files, ~59k lines) encoding state-of-the-art 2026 practices for
+it: 41 skills (295 files, ~60k lines) encoding state-of-the-art 2026 practices for
 building **and** auditing software, fast-moving claims web-verified against primary
 sources. Native on Claude Code; works with Gemini CLI, Codex, and any agent that reads
 `AGENTS.md`. Every file stays under 500 lines, so the right rules load when needed.

--- a/skills/sota-network-security/SKILL.md
+++ b/skills/sota-network-security/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   Hubble, service mesh, mTLS, Istio, Linkerd, SPIFFE, ingress, egress, WAF,
   CRS, Coraza, egress gateway, FQDN allowlist, IMDS, 169.254.169.254, DNS
   firewall, DNSSEC, DoH, TLS 1.3, ACME, step-ca, private CA, WireGuard,
-  bastion, identity-aware proxy, segmentation audit. Owns SECURITY posture on
+  bastion, identity-aware proxy, DDoS, segmentation audit. Owns SECURITY posture on
   top of cloud network setup (sota-cloud-infrastructure owns VPC/subnet/DNS
   setup).
 ---
@@ -111,7 +111,7 @@ Group repeated instances (e.g. 12 namespaces with no egress policy) into one fin
 | rules/02-segmentation-blast-radius.md | Designing/auditing zones and tiers, north-south vs east-west, the flat-network and over-broad-rule (`any`/`0.0.0.0/0`/`world`) traps, microsegmentation, lateral-movement containment, firewall/SG default-deny, remote access (WireGuard, bastion vs IAP) |
 | rules/03-k8s-network-policy.md | Writing/auditing Kubernetes NetworkPolicy, CiliumNetworkPolicy, the namespaced default-deny (ingress AND egress) pattern, the "default-deny that isn't" trap, ANP/BANP, L7/identity policy, DNS-aware egress, egress gateways, Hubble visibility |
 | rules/04-service-mesh-mtls.md | The plaintext-internal-traffic problem, choosing/auditing a mesh (Istio sidecar vs ambient, Linkerd, Cilium mesh), mTLS everywhere, mesh authorization policy, SPIFFE identity, and deciding mesh vs plain TLS |
-| rules/05-edge-ingress-egress.md | WAF (CRS/Coraza), ingress/API-gateway hardening, TLS termination + re-encryption, trusted-IP handling behind Cloudflare, egress as a first-class control, FQDN allowlisting, blocking the metadata endpoint, the SSRF-meets-egress chain |
+| rules/05-edge-ingress-egress.md | WAF (CRS/Coraza), ingress/API-gateway hardening, TLS termination + re-encryption, trusted-IP handling behind Cloudflare, DDoS posture (edge scrubbing + self-hosted kernel hardening: SYN cookies/synproxy, conntrack, rp_filter, no open UDP reflectors), egress as a first-class control, FQDN allowlisting, blocking the metadata endpoint, the SSRF-meets-egress chain |
 | rules/06-dns-tls-pki.md | DNS security (DNSSEC, RPZ/DNS firewall, DoH/DoT, split-horizon, CAA, tunneling), TLS posture (1.3, ciphers, HSTS, OCSP), shrinking cert lifetimes + ACME automation, internal PKI (step-ca), short-lived certs, pinning tradeoffs |
 
 Cross-cutting tasks read multiple files: a full network audit touches all six; "lock down our

--- a/skills/sota-network-security/rules/05-edge-ingress-egress.md
+++ b/skills/sota-network-security/rules/05-edge-ingress-egress.md
@@ -1,6 +1,7 @@
 # 05 — Edge, Ingress & Egress
 
-Scope: WAF (OWASP CRS, Coraza/ModSecurity), ingress/API-gateway hardening, DDoS posture, TLS
+Scope: WAF (OWASP CRS, Coraza/ModSecurity), ingress/API-gateway hardening, DDoS posture (edge
+scrubbing + self-hosted L3/4 kernel hardening), TLS
 termination + re-encryption to backends, reverse-proxy trusted-IP / allowlist handling (behind
 Cloudflare), Cloudflare-tunnel / identity-aware-proxy patterns, and **egress as a first-class
 control**: default-deny egress, egress gateways/proxies, FQDN allowlisting, preventing C2/exfil, and
@@ -99,11 +100,36 @@ authenticated proxy.
 
 ## 5. DDoS posture
 
-**R8 — Absorb at the edge, rate-limit per-identity, cap autoscaling.** Cloudflare absorbs L3/4 and
-much L7; add WAF rate-limiting rules and per-route/per-identity limits (design owned by
-sota-api-design rules/07). Cap autoscaling so a flood can't scale your bill or cluster infinitely.
-"We never considered DDoS" is the finding; record the stance. Best DDoS surface is none — keep
-non-public surfaces non-public (tunnels, IAP).
+**R8 — Absorb at the edge, rate-limit per-identity, cap autoscaling.** A scrubbing edge (e.g.
+Cloudflare, a cloud provider's DDoS tier, or an Anycast scrubbing provider) absorbs L3/4 and much
+L7; add WAF rate-limiting rules and per-route/per-identity limits (design owned by
+sota-api-design rules/07). Cap autoscaling so a flood can't scale your bill or cluster infinitely
+(economic/"yo-yo" DoS). "We never considered DDoS" is the finding; record the stance. Best DDoS
+surface is none — keep non-public surfaces non-public (tunnels, IAP). Cloud L3/4 mitigation posture
+(Shield/Cloud Armor/Azure DDoS tiers) is sota-cloud-infrastructure rules/03 §10; this rule owns the
+edge you operate.
+
+**R8.1 — Self-hosted / bare-metal edge: harden the kernel, you are the scrubber.** When there is no
+Anycast provider in front (e.g. a bare-metal or Talos edge exposed directly), L3/4 defense is yours.
+Baseline, matched to the exposed protocols:
+- **SYN floods:** enable TCP **SYN cookies** (`net.ipv4.tcp_syncookies=1`) — the kernel answers with
+  a cryptographic cookie instead of holding half-open state when the SYN backlog overflows. For a
+  high-rate edge, add a **synproxy** (nftables) in front of the listener so flood SYNs never create
+  conntrack entries: it needs `tcp_syncookies` **and** `tcp_timestamps` on, `notrack` on SYNs in the
+  raw table, `nf_conntrack_tcp_loose=0`, and a rule matching `ct state invalid,untracked`
+  (per the nftables synproxy wiki). Note syncookies disable some TCP options — expected trade-off
+  under attack, not a steady-state default concern.
+- **Conntrack exhaustion** is its own DoS: a stateful firewall drops new flows once
+  `nf_conntrack_max` fills. Size it (and the hashsize) to expected concurrency, alert on
+  `nf_conntrack_count` / "table full" drops, and `notrack` high-volume stateless traffic so it never
+  consumes a slot.
+- **Anti-spoofing:** enable **reverse-path filtering** (`rp_filter`, strict where routing allows;
+  RFC 3704) so spoofed-source packets are dropped at ingress.
+- **Don't be an amplifier (BCP 38 / RFC 2827):** never expose an **open** UDP reflector — recursive
+  DNS resolver, NTP `monlist`, memcached, SSDP, chargen — to the internet; bind them internally or
+  require auth. An exposed open resolver makes you a weapon in someone else's reflection attack and a
+  target for the return traffic. Prefer TCP or authenticated protocols on the public edge; rate-limit
+  or drop unsolicited UDP you don't serve.
 
 ## 6. Egress as a first-class control
 
@@ -158,3 +184,8 @@ logging beats either alone: the allowlist blocks the easy path, the logs catch t
 - [ ] Is egress funneled through an inspectable choke point and are egress/proxy logs exported to
       detection?
 - [ ] DDoS stance recorded; per-identity rate limits and autoscale caps set?
+- [ ] Self-hosted/bare-metal edge with no scrubbing provider in front: `tcp_syncookies` on,
+      `rp_filter` enabled, `nf_conntrack_max` sized + drops alerted, synproxy on high-rate TCP
+      listeners? (`sysctl net.ipv4.tcp_syncookies net.ipv4.conf.all.rp_filter`)
+- [ ] No open UDP reflector (recursive DNS, NTP monlist, memcached, SSDP, chargen) exposed to the
+      internet — you are not an amplification source (BCP 38)?


### PR DESCRIPTION
Closes the single gap found when auditing the library's DDoS coverage. The existing guidance is strong on **edge-scrubbed** (Cloudflare/Shield/Cloud Armor) and **application-layer** DoS (rate limits, cost-weighting, slowloris timeouts, decompression/parser bombs, ReDoS, retry storms/load shedding) — but had **nothing for a self-hosted bare-metal/Talos edge with no provider in front**, where L3/4 defense is the operator's job.

## Added (`rules/05` §5, new R8.1)

- **SYN floods** — `tcp_syncookies`, plus nftables **synproxy** for high-rate listeners with its exact prerequisites (verified against the nftables synproxy wiki: needs `tcp_syncookies` + `tcp_timestamps`, `notrack` on SYNs, `nf_conntrack_tcp_loose=0`, `ct state invalid,untracked`).
- **Conntrack exhaustion** as its own DoS — size `nf_conntrack_max`, alert on table-full drops, `notrack` stateless high-volume traffic.
- **Anti-spoofing** — `rp_filter` strict (RFC 3704).
- **Don't be an amplifier** — BCP 38 / RFC 2827: no open UDP reflectors (recursive DNS, NTP monlist, memcached, SSDP, chargen) on the public edge.

R8 reframed so edge scrubbing is named generically (Anycast/provider tiers, not just Cloudflare), cross-referencing `sota-cloud-infrastructure` rules/03 §10 for the cloud L3/4 tiers. Two audit-checklist items (with `sysctl` greps) + SKILL.md index/scope/trigger updates.

Every factual claim primary-sourced: [nftables synproxy wiki](https://wiki.nftables.org/wiki-nftables/index.php/Synproxy), kernel.org ip-sysctl, RFC 2827/3704. File 191/500 lines, description 1019/1024, all 6 invariants pass.
