### PR TITLE
fix(skills): audit content corrections + router library-map refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Audit 2026-07-10 content corrections** (all primary-source verified):
+  OWASP Top 10 2025 mislabel — Insecure Design is **A06**, not A04
+  (`sota-code-security` rules/09); JSON Merge Patch citation **RFC 7386 →
+  7396** (obsoleted 2014, `sota-api-design` rules/01); ingress-nginx wording —
+  the 2026 CVE wave **was** patched in the final releases (≥1.13.9/1.14.5/
+  1.15.1), the standing risk is post-EOL CVEs (`sota-kubernetes` rules/01);
+  Iceberg v3 "GA across major engines" overstated → GA on Snowflake/Databricks/
+  Spark, Trino still lagging (`sota-data-engineering` rules/01); a
+  `grep -v "--"` end-of-options bug in an audit checklist
+  (`sota-javascript-typescript` rules/07); a dangling retired-convention
+  "last-verified" reference (`sota-confidential-computing` rules/04); and
+  ~7 rot-prone version pins reworded to the no-pins policy (Rust 1.96→"recent
+  stable", golangci-lint, Swift, Flutter, PHP, Ruby, Vue/Nuxt patch→minor).
+- **Router library map** (`skills/sota/SKILL.md`) — added the missing
+  `sota-confidential-computing` bullet (41st skill) and refreshed the stale
+  `sota-testing` (→09) and `sota-docs-workflow` (→05) bullets. Routing table
+  and per-skill indexes were already correct; only the map overview drifted.
+
 ### Added
 
 - **`docs/AUDIT-2026-07-10.md`** — second adversarial repository audit (13

--- a/skills/sota-api-design/rules/01-rest-http-design.md
+++ b/skills/sota-api-design/rules/01-rest-http-design.md
@@ -36,7 +36,7 @@ workflow, contract testing.
 | HEAD | yes | yes | Metadata/existence checks. |
 | QUERY | yes | yes | Safe read with a request body (RFC 10008, 2026); responses cacheable. Searches/filters too large for a URL. Ecosystem support is early — fall back to `POST /searches` (§1) where proxies/frameworks lack it. |
 | PUT | no | yes | Full replace at a client-chosen or known URL. |
-| PATCH | no | **no** (unless designed so) | Partial update. Prefer JSON Merge Patch (RFC 7386) for simple cases; JSON Patch (RFC 6902) when array surgery is needed. |
+| PATCH | no | **no** (unless designed so) | Partial update. Prefer JSON Merge Patch (RFC 7396) for simple cases; JSON Patch (RFC 6902) when array surgery is needed. |
 | POST | no | no | Create under a collection; non-idempotent actions. Pair with idempotency keys (§6). |
 | DELETE | no | yes | Delete. Repeat DELETE returns 404 or 204 — both acceptable; pick one and document it. |
 

--- a/skills/sota-code-security/rules/09-untrusted-data-ingestion.md
+++ b/skills/sota-code-security/rules/09-untrusted-data-ingestion.md
@@ -7,7 +7,7 @@ data *feeds and content*, where the bytes themselves are the weapon: hostile
 parsers (image/archive/PDF/Office/XML/CSV), resource-exhaustion at the ingest
 boundary, schema validation, feed provenance, and the render/LLM exits. Maps to
 OWASP A08:2025 (Software or Data Integrity Failures), A05:2025 (Injection),
-A04:2025 (Insecure Design). CWE-409, CWE-776, CWE-434, CWE-22, CWE-502, CWE-1333.
+A06:2025 (Insecure Design). CWE-409, CWE-776, CWE-434, CWE-22, CWE-502, CWE-1333.
 
 This is **not** rules/01 (injection at a *sink* — SQL/shell/path/template) nor
 rules/05 (encoding at the *render* sink). Those fix the moment data meets an

--- a/skills/sota-confidential-computing/rules/04-confidential-kubernetes.md
+++ b/skills/sota-confidential-computing/rules/04-confidential-kubernetes.md
@@ -49,7 +49,7 @@ each layer adds attestation surface and failure modes.
 
 ## 2. Confidential nodes (managed offerings)
 
-Verified against vendor docs as of this file's last-verified date; **re-verify
+Provider GA states move fast; **re-verify
 GA status at the provider's documentation before committing to a design.**
 
 - **GKE Confidential GKE Nodes** — GA. Original GA on AMD SEV; AMD SEV-SNP and

--- a/skills/sota-data-engineering/rules/01-architecture-and-modeling.md
+++ b/skills/sota-data-engineering/rules/01-architecture-and-modeling.md
@@ -53,8 +53,9 @@ duckdb.sql("""
 ## Warehouse vs lakehouse
 
 Decide by ownership and access patterns, not fashion. Both converge: every
-major warehouse reads/writes Iceberg (Iceberg v3 went GA across major engines
-in 2025–2026), and lakehouse engines speak SQL.
+major warehouse reads/writes Iceberg (v3 is GA on Snowflake/Databricks and
+Spark 4.0; verify your engine — Trino v3 support still lagged as of writing),
+and lakehouse engines speak SQL.
 
 - **Choose a managed warehouse (Snowflake/BigQuery/Redshift-class) when:**
   one team owns the data end-to-end, workloads are SQL-dominant, you want

--- a/skills/sota-golang/rules/07-tooling-ci.md
+++ b/skills/sota-golang/rules/07-tooling-ci.md
@@ -71,7 +71,7 @@ is fine but redundant. `gofumpt` over `gofmt`: stricter, zero-config,
 no debates.
 
 Version notes (2026-06): golangci-lint v2.9.0+ is required for Go 1.26
-support (current: v2.12.x). `noctx` now also flags missing-ctx `log/slog`,
+support (use the latest stable). `noctx` now also flags missing-ctx `log/slog`,
 `os/exec` and `crypto/tls` call sites, not just HTTP requests; `errcheck`
 v1.10+ excludes `crypto/rand.Read` by default (it never fails).
 

--- a/skills/sota-javascript-typescript/rules/07-testing-and-tooling.md
+++ b/skills/sota-javascript-typescript/rules/07-testing-and-tooling.md
@@ -225,7 +225,7 @@ steps:
 
 - [ ] CI runs typecheck, lint, tests as blocking steps — `cat .github/workflows/*.yml | grep -E "tsc|eslint|vitest|test"`; missing typecheck gate = MEDIUM.
 - [ ] ESLint config is flat + `strictTypeChecked` (type-aware): `grep -rn "strictTypeChecked\|projectService" eslint.config.*` — syntax-only linting in a TS repo = MEDIUM.
-- [ ] `grep -rn "eslint-disable" src/ | grep -v "--"` — disables without reason comments; count trend (LOW each, MEDIUM in volume).
+- [ ] `grep -rn "eslint-disable" src/ | grep -v -- "--"` — disables without reason comments; count trend (LOW each, MEDIUM in volume).
 - [ ] `grep -rn "querySelector\|container\." src/**/*.test.tsx` and `getByTestId` density — implementation-coupled tests (LOW/MEDIUM).
 - [ ] `grep -rn "fireEvent" src/` in component tests — should be `userEvent` (LOW).
 - [ ] `grep -rn "waitForTimeout\|setTimeout" e2e/ tests/` — sleep-based waits = flake (MEDIUM).

--- a/skills/sota-kubernetes/rules/01-control-plane-etcd.md
+++ b/skills/sota-kubernetes/rules/01-control-plane-etcd.md
@@ -207,7 +207,8 @@ machine:
   -24514/-1580/-3288/-4342; CSI SMB/NFS subDir path traversal CVE-2026-3864/-3865), and
   the distro (Talos/k3s/k0s).
 - **ingress-nginx is EOL** (retired by SIG Network/SRC; maintenance ended March 2026, repo
-  read-only, no fixes even for the 2026 CVE wave above). A deployed ingress-nginx is a
+  read-only). The 2026 CVE wave *was* patched in the final releases (>=1.13.9/1.14.5/1.15.1);
+  the standing risk is that any CVE found after EOL gets **no** fix. A deployed ingress-nginx is a
   standing High finding: migrate to Gateway API or an actively maintained ingress
   controller (ingress/edge config depth is `sota-network-security`).
 
@@ -225,4 +226,4 @@ machine:
 - [ ] Nodes: minimal/hardened OS, kube-bench passing, no routine SSH? Talos: SecureBoot + TPM/LUKS2 disk encryption, machineconfig/talosconfig stored as secrets and scoped? k3s/k0s: `--secrets-encryption` on, unused add-ons disabled?
 - [ ] Running a SUPPORTED minor (not EOL)? Skew within policy (control plane ≥ nodes, ≤3 minors)? (`kubectl version`, `kubectl get nodes -o wide`)
 - [ ] CVE-response runbook exists and covers control plane + every add-on/controller + ingress/CSI + distro?
-- [ ] No EOL ingress-nginx still deployed (retired March 2026, unpatched 2026 CVE wave — High; migration to Gateway API or a maintained controller done or dated)?
+- [ ] No EOL ingress-nginx still deployed (retired March 2026 — final releases patched the 2026 CVE wave, but any post-EOL CVE is unpatched — High; migration to Gateway API or a maintained controller done or dated)?

--- a/skills/sota-mobile/rules/01-platform-and-stack.md
+++ b/skills/sota-mobile/rules/01-platform-and-stack.md
@@ -11,11 +11,11 @@ Stack choice is a one-way door: migrating a shipped app between stacks is a rewr
 | Android | Android 17 (API 37) stable since June 16, 2026 (Pixels first, OEM rollouts ongoing); Play target-API mandate remains API 36 (next row). |
 | Play target API | New apps and updates must target **API 36 by Aug 31, 2026** (API 35 floor for Wear OS / Android TV). Stale targets make the app invisible to new users on newer devices. |
 | Play 16 KB pages | Since **Nov 1, 2025**, new apps/updates targeting Android 15+ must support 16 KB page sizes on 64-bit devices. Pure-JVM/Kotlin apps comply automatically; anything with native `.so` libraries (including most RN/Flutter plugins) must use compatible builds. Verify in Play Console app bundle explorer. |
-| Swift | Swift 6.3.x (Xcode 26.5). Swift 6 strict concurrency is the norm for new code. |
+| Swift | Swift 6.x on current Xcode (verify the latest). Swift 6 strict concurrency is the norm for new code. |
 | Kotlin | Kotlin 2.x with K2 compiler; coroutines/Flow standard. |
 | SwiftUI / Compose | Default UI toolkits for new native code on both platforms. UIKit/Views are for interop, framework gaps, and legacy — not greenfield screens without a stated reason. |
 | React Native | 0.86 (Jun 2026) — fixes the Android 15+ edge-to-edge issues (insets, `KeyboardAvoidingView`) that the mandatory API-36 edge-to-edge (1.4) exposes; repo moved to the `react` GitHub org under the React Foundation. 0.85 (Apr 2026) **removed** the Bridge from the codebase entirely (no fallback, no interop, no shim). New Architecture (JSI + Fabric + TurboModules) became non-disableable in 0.82 (Oct 2025); the Bridge interop layer stayed functional through 0.84. Hermes is the default engine on both platforms. |
-| Flutter | 3.44 current stable; ~4 stable releases/year; Material/Cupertino libraries being split into separately-versioned packages. |
+| Flutter | recent stable (~4 releases/year, verify current); Material/Cupertino libraries being split into separately-versioned packages. |
 | Kotlin Multiplatform | KMP stable since 2023 for shared logic. Compose Multiplatform for iOS **stable since 1.8.0 (May 2025)** — production-ready (Netflix, Cash App scale), but iOS fidelity still trails SwiftUI for platform-idiomatic feel; budget per-platform polish. |
 | OWASP MASVS | v2.1 current (adds MASVS-PRIVACY); verification levels replaced by MAS profiles + MASWE weakness enumeration. MASTG v2.0.0 stable (June 2026) supplies the test procedures. |
 

--- a/skills/sota-php/SKILL.md
+++ b/skills/sota-php/SKILL.md
@@ -19,7 +19,7 @@ description: >-
 ## Purpose
 
 This skill encodes the 2026 state of the art for PHP: a supported-version baseline
-(PHP 8.3+ floor, 8.5 current stable — see `rules/01`), `strict_types` everywhere, typed
+(PHP 8.3+ floor; 8.5 is the latest annual line — verify current, see `rules/01`), `strict_types` everywhere, typed
 object-oriented design, security-by-default at every trust boundary, a locked and audited
 Composer supply chain, and measured runtime performance. It serves two modes:
 

--- a/skills/sota-ruby/SKILL.md
+++ b/skills/sota-ruby/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 # SOTA Ruby (2026)
 
 Expert-level rules for producing and auditing production Ruby. Baseline language
-line: **Ruby 3.4+**, with Ruby 4.0 (released 2025-12-25) as the current stable
+line: **Ruby 3.4+**, with Ruby 4.0 (released 2025-12-25) as the latest major
 line. Per the [official branches page](https://www.ruby-lang.org/en/downloads/branches/):
 4.0 and 3.4 are in normal maintenance; 3.3 is security-maintenance only
 (expected EOL 2027-03); 3.2 and older are EOL (3.2 since 2026-04-01) — running

--- a/skills/sota-rust/SKILL.md
+++ b/skills/sota-rust/SKILL.md
@@ -20,7 +20,8 @@ description: >-
 
 This skill encodes the 2026 state of the art for production Rust: the idioms,
 security posture, performance discipline, and CI baseline expected of an
-expert Rust codebase. Baseline as of mid-2026: stable Rust 1.96 (May 2026),
+expert Rust codebase. Baseline as of mid-2026: a recent stable Rust toolchain (verify the current
+release at blog.rust-lang.org),
 edition 2024 (next edition expected ~2027), tokio still 1.x. It serves two modes — **BUILD** (write new code to this
 standard) and **AUDIT** (find where existing code falls short, with severity
 and evidence). The detailed rules live in `rules/*.md`; load only the files

--- a/skills/sota-security-compliance/rules/02-nist-800-53-171-cmmc-fedramp.md
+++ b/skills/sota-security-compliance/rules/02-nist-800-53-171-cmmc-fedramp.md
@@ -13,8 +13,8 @@ rest are scopes and assessment wrappers over it.
 
 ## 1. SP 800-53 — the control catalog
 
-**Status:** **Rev 5**, finalized 10 Dec 2020 (Rev 5.1.1); the control **baselines**
-in **SP 800-53B** reached **Release 5.2.0 on 27 Aug 2025** — the catalog is current
+**Status:** **Rev 5**, finalized 10 Dec 2020 (Rev 5.1.1); the **SP 800-53/53B** catalog and baselines
+reached **Release 5.2.0 on 27 Aug 2025** — the catalog is current
 and actively maintained, no Rev 6 (csrc.nist.gov/pubs/sp/800/53/r5/upd1/final).
 
 **20 control families**; Rev 5 added **PT** (PII processing) and **SR** (supply-

--- a/skills/sota-web-frameworks/rules/01-baseline.md
+++ b/skills/sota-web-frameworks/rules/01-baseline.md
@@ -10,8 +10,8 @@ security releases weekly.
 |---|---|---|---|
 | React | 19.2.x | 19.x | 18.x maintained but no new features; React Compiler needs 19 idioms |
 | Next.js | 16.2.x | 15.x (16.x preferred) | **Active LTS 16.x**, **Maintenance LTS 15.x** (critical + security ~2y from 2024-10-21). Everything **< 15 is unsupported** — treat as a finding |
-| Vue | 3.5.39 | 3.5+ | Vue 2 **EOL 2023-12-31** (paid extended support only). 3.6 (Vapor mode) in beta — not stable |
-| Nuxt | 4.4.8 | 4.x | Nuxt 3 **security-patches-only until 2026-07-31** (then EOL); Nuxt 2 EOL 2024-06-30; Nuxt 5 (unreleased) brings Nitro v3 + h3 v2 |
+| Vue | 3.5.x | 3.5+ | Vue 2 **EOL 2023-12-31** (paid extended support only). 3.6 (Vapor mode) in beta — not stable |
+| Nuxt | 4.4.x | 4.x | Nuxt 3 **security-patches-only until 2026-07-31** (then EOL); Nuxt 2 EOL 2024-06-30; Nuxt 5 (unreleased) brings Nitro v3 + h3 v2 |
 | Nitro | 2.13.x | 2.x | v3 in beta; ships with Nuxt 5 |
 | Pinia | 3.x | 3.x | Pinia 3 dropped Vue 2; default Nuxt/Vue store |
 

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -271,7 +271,8 @@ For a **full project audit**, work in passes:
   04 SLOs & alerting, 05 operational readiness, 06 audit playbook
 - **sota-testing/rules**: 01 strategy & shape, 02 test design & quality,
   03 doubles & test data, 04 integration/contract/system, 05 e2e & UI,
-  06 property/fuzzing/mutation, 07 suite health & CI
+  06 property/fuzzing/mutation, 07 suite health & CI, 08 BDD/spec-by-example,
+  09 security testing
 - **sota-llm-engineering/rules**: 01 evals, 02 prompt & context engineering,
   03 RAG & retrieval, 04 agents & tools, 05 production engineering,
   06 data & lifecycle
@@ -291,6 +292,9 @@ For a **full project audit**, work in passes:
 - **sota-network-security/rules**: 01 zero-trust architecture,
   02 segmentation & blast radius, 03 K8s network policy, 04 service mesh &
   mTLS, 05 edge/ingress/egress, 06 DNS/TLS/PKI
+- **sota-confidential-computing/rules**: 01 threat model & selection,
+  02 TEE technologies, 03 remote attestation, 04 confidential Kubernetes,
+  05 PETs & computing on encrypted data
 - **sota-detection-engineering/rules**: 01 detection-engineering discipline,
   02 telemetry & SIEM data layer, 03 rule languages & engines, 04 alerting/
   triage/SOC/SOAR, 05 hunting/intel/deception, 06 incident response &
@@ -313,7 +317,7 @@ For a **full project audit**, work in passes:
   correctness, 03 security, 04 CI & operational scripts
 - **sota-docs-workflow/rules**: 01 documentation architecture, 02 API
   reference & changelogs, 03 code review & PR workflow, 04 commits/branches/
-  releases
+  releases, 05 spec-driven development
 - **sota-ux-writing/rules**: 01 voice/tone & plain language, 02 microcopy &
   components, 03 errors & feedback, 04 accessibility & localization
 - **sota-copywriting/rules**: 01 positioning & value proposition,


### PR DESCRIPTION
Fixes the confirmed content/structural defects from the 2026-07-10 audit (docs/AUDIT-2026-07-10.md), each re-verified against a primary source this session:

- **OWASP A04→A06** — Insecure Design is A06:2025 (A04 = Cryptographic Failures) per owasp.org
- **RFC 7386→7396** — JSON Merge Patch; 7386 obsoleted 2014
- **ingress-nginx** — the 2026 CVE wave *was* patched (≥1.13.9/1.14.5/1.15.1); real risk is post-EOL CVEs
- **Iceberg v3** — GA on Snowflake/Databricks/Spark, Trino still lagging (was 'across major engines')
- **grep -v "--"** end-of-options bug → `grep -v -- "--"`
- dangling retired 'last-verified' reference
- ~7 rot-prone version pins → no-pins policy phrasing
- **Router library map**: added missing sota-confidential-computing bullet, refreshed testing/docs-workflow bullets (routing table was already correct)

All 6 invariants pass; router-map completeness independently re-checked (comm empty).