### PR TITLE
fix(scripts): installer decline-abort + profile-clobber + config perms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Installer script defects** (2026-07-10 audit): `install.sh` no longer
+  aborts (`set -e`, exit 1) when the user declines a routing prompt — routing
+  setup is best-effort and now always returns success, so pre-commit setup and
+  the final instructions still run (Q-MED-4, reproduced fixed: exit 0, reaches
+  the end); `install.sh` profile-linking no longer silently clobbers a real
+  file in `~/.claude/profiles` — it backs up + asks first, matching
+  `setup_claude_md`'s contract, and keeps the file untouched non-interactively
+  (Q-MED-5, reproduced: user content preserved); and `init-gates.sh` writes
+  `.pre-commit-config.yaml` as 644 instead of the `mktemp` 600 (Q-LOW).
 - **Audit 2026-07-10 content corrections** (all primary-source verified):
   OWASP Top 10 2025 mislabel — Insecure Design is **A06**, not A04
   (`sota-code-security` rules/09); JSON Merge Patch citation **RFC 7386 →

--- a/scripts/init-gates.sh
+++ b/scripts/init-gates.sh
@@ -387,6 +387,9 @@ assemble() {
   fi
   [ -f "$CONFIG" ] && cp "$CONFIG" "$CONFIG.bak"
   mv "$tmp" "$CONFIG"
+  # mktemp creates 0600; a committed repo config should be world-readable, not
+  # owner-only (2026-07-10 audit Q-LOW). 644 is the conventional perm.
+  chmod 644 "$CONFIG"
 }
 
 # --- run ---------------------------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -155,7 +155,7 @@ setup_claude_md() {
     # shellcheck disable=SC2088  # ~ is display text in the prompt, not a path
     ask_yn "~/.claude/CLAUDE.md is a broken symlink — replace it with a real file holding the directive?" y \
       && { rm -f "$f"; emit_routing_block >"$f"; log "wrote ~/.claude/CLAUDE.md (real file)"; }
-    return
+    return 0
   fi
   if [ -e "$f" ]; then
     if ask_yn "Append the SOTA routing directive to $where?" y; then
@@ -167,6 +167,10 @@ setup_claude_md() {
     ask_yn "Create ~/.claude/CLAUDE.md with the SOTA routing directive?" y \
       && { mkdir -p "$(dirname "$f")"; emit_routing_block >"$f"; log "created ~/.claude/CLAUDE.md"; }
   fi
+  # Declining any prompt above is a valid outcome, not an error — return
+  # success so `set -e` doesn't abort the installer before pre-commit setup
+  # and the final instructions (2026-07-10 audit Q-MED-4).
+  return 0
 }
 
 setup_hook() {
@@ -252,8 +256,12 @@ maybe_setup_routing() {
        fi ;;
   esac
   [ "$go" -eq 1 ] || return 0
-  setup_claude_md
-  setup_hook
+  # Best-effort routing setup: declining a prompt inside either function is a
+  # valid outcome, so never let it abort the installer before pre-commit setup
+  # and the final instructions (2026-07-10 audit Q-MED-4).
+  setup_claude_md || true
+  setup_hook || true
+  return 0
 }
 
 while [ $# -gt 0 ]; do
@@ -329,8 +337,20 @@ if [ "$TARGET" = "$HOME/.claude/skills" ] && [ "$USE_COPY" -eq 0 ]; then
   prof="$(find "$REPO/profiles" -maxdepth 1 -name '*.md' ! -name 'example.md.template' 2>/dev/null | head -n1 || true)"
   if [ -n "$prof" ]; then
     mkdir -p "$HOME/.claude/profiles"
-    ln -sfn "$prof" "$HOME/.claude/profiles/$(basename "$prof")"
-    log "linked profile: ~/.claude/profiles/$(basename "$prof")"
+    dst="$HOME/.claude/profiles/$(basename "$prof")"
+    if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+      # A real file (not our symlink) already lives there — never clobber it
+      # silently; back up + ask, matching setup_claude_md's contract
+      # (2026-07-10 audit Q-MED-5). Non-interactive default is 'n' (keep it).
+      if ask_yn "$dst is a real file — back it up and replace with a link to the repo profile?" n; then
+        backup "$dst"; ln -sfn "$prof" "$dst"; log "linked profile: ~/.claude/profiles/$(basename "$prof")"
+      else
+        log "left existing ~/.claude/profiles/$(basename "$prof") untouched"
+      fi
+    else
+      ln -sfn "$prof" "$dst"
+      log "linked profile: ~/.claude/profiles/$(basename "$prof")"
+    fi
   else
     log "no profile yet — cp profiles/example.md.template profiles/<you>.md, then re-run"
   fi


### PR DESCRIPTION
Fixes the two medium `install.sh` interactive-path defects + one low from the 2026-07-10 audit, each reproduced fixed in a scratch HOME:

- **Q-MED-4 — decline aborts installer:** declining a routing prompt made `set -e` exit 1, skipping pre-commit setup and the final instructions. Routing setup is now best-effort (`setup_claude_md || true; setup_hook || true; return 0`). Reproduced: `printf 'y\nn\n' | … install.sh` → **exit 0, reaches the end**.
- **Q-MED-5 — profile clobber:** `ln -sfn` silently replaced a real file in `~/.claude/profiles`. Now backs up + asks first (default 'n' non-interactively), matching `setup_claude_md`'s contract. Reproduced: pre-existing 'PRECIOUS USER CONTENT' **preserved**.
- **Q-LOW — config perms:** `init-gates.sh` wrote `.pre-commit-config.yaml` as 600 (mktemp perms survived the `mv`); now `chmod 644`.

shellcheck clean; all invariants pass.