### PR TITLE
feat(evals,docs): content-accuracy runbook + efficacy eval harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,9 @@ Separately, `scripts/check-freshness.sh` (run monthly by
 `.github/workflows/freshness.yml`) tracks the root `LAST-VERIFIED` stamp —
 the date of the last full-library re-verification sweep against primary
 sources. Update it only after such a sweep; the run goes red when the stamp
-exceeds the 12-month window. Per-file line-1 markers are retired.
+exceeds the **6-month** window. Per-file line-1 markers are retired. The
+sweep runbook and the efficacy eval harness live in
+[docs/MAINTENANCE.md](docs/MAINTENANCE.md) and [evals/](evals/).
 
 Secrets are scanned by **gitleaks** (`.gitleaks.toml`, which disables only the
 noisy entropy-based `generic-api-key` rule so the security skills' intentional
@@ -93,6 +95,8 @@ pre-commit hook scans each commit locally.
 - [RELEASING.md](RELEASING.md) — how to cut a release, including every
   version- and count-bearing surface (README, router, manifests, social
   preview)
+- [docs/MAINTENANCE.md](docs/MAINTENANCE.md) — accuracy sweep runbook +
+  eval harness (keeping fast-moving claims true and measuring efficacy)
 - [SECURITY.md](SECURITY.md) — reporting bad guidance or a leaked secret
 - [CHANGELOG.md](CHANGELOG.md) — release history (top entry = current version;
   also mirrored in `VERSION`); releases 1.6.0 and earlier are archived in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Content-accuracy runbook + eval harness** (2026-07-10 audit STRAT-HIGH-1/2,
+  the two top strategic gaps). `docs/MAINTENANCE.md` documents the reproducible
+  per-skill re-verification sweep (extract rot-prone claims → verify vs primary
+  sources → fix under the no-pins/EOL policies → adversarial re-verify → bump
+  `LAST-VERIFIED`) that previously lived only in maintainer memory, and states
+  honestly which dimensions are CI-automated vs human/agent discipline. The
+  freshness re-verify window is cut **12 → 6 months** (content drifts far
+  faster; 6mo stays clearable). New `evals/` prototype: a runnable
+  efficacy-regression harness — golden-set cases (`cases/router.jsonl`,
+  `cases/audit.jsonl`) + `score.py` (recall/precision vs an agent's
+  predictions, exit 1 on any miss). Deliberately not in CI (an LLM eval is
+  non-deterministic); it gives a repeatable with-vs-without baseline. Harness
+  verified end-to-end this session (perfect predictions → exit 0, misses →
+  exit 1); AGENTS.md/CONTRIBUTING.md link the runbook.
 - **Invariant 7 — router completeness** (`check-invariants.sh`): every domain
   skill must appear in the router's routing table AND library map; every map
   entry must name a real skill. Automates the drift class the 2026-07-10 audit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,9 @@ AGENTS.md                     # guidance for AI assistants working on the repo
   primary sources, findings adversarially verified, fixes applied). Update it
   only after such a sweep — not on ordinary edits. A monthly CI job
   (`scripts/check-freshness.sh`) goes red when the stamp exceeds the
-  re-verify window. Do not add per-file `<!-- last-verified -->` line-1
-  markers (retired convention; the script warns about strays).
+  re-verify window (**6 months**). Do not add per-file `<!-- last-verified -->`
+  line-1 markers (retired convention; the script warns about strays). The
+  step-by-step sweep runbook is [docs/MAINTENANCE.md](docs/MAINTENANCE.md).
 
 **Findings format** (AUDIT mode, used throughout):
 

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -1,0 +1,88 @@
+# Maintenance — keeping the library accurate
+
+The library's value is that its fast-moving claims (versions, CVEs, RFCs,
+specs, GA states, tool status, standards) hold up against primary sources.
+CI enforces *structure* (the 7 invariants in `scripts/check-invariants.sh` +
+gitleaks + shellcheck) but **cannot** verify that a claim is *true* — that
+needs web access and judgment. This file is the human/agent process that
+covers the accuracy dimension CI can't, plus how efficacy is measured.
+
+The 2026-07-10 audit ([AUDIT-2026-07-10.md](AUDIT-2026-07-10.md)) flagged the
+absence of this runbook and eval scaffold as the top strategic gaps.
+
+## 1. The freshness stamp
+
+`LAST-VERIFIED` (repo root) holds the date of the last full-library
+re-verification sweep. `scripts/check-freshness.sh` fails once that stamp is
+older than the re-verify window (**6 months**; was 12 — content drifts far
+faster). `.github/workflows/freshness.yml` runs it monthly (report-only, does
+not block PRs). A red freshness report means: **due for a sweep** — run the
+procedure below, then bump `LAST-VERIFIED`.
+
+The window is 6 months, not shorter, on purpose: a too-short window is
+perpetually red and trains everyone to ignore it (the same failure the
+retired per-file-marker backlog had). 6 months catches real drift while
+staying clearable.
+
+## 2. The re-verification sweep (runbook)
+
+Goal: re-verify every skill's rot-prone claims against primary sources and
+fix what has drifted. Do it as a **rolling** pass (a few skills a month) or a
+**batched** sweep before the window expires — either way, update
+`LAST-VERIFIED` only after a full pass.
+
+**Per skill:**
+
+1. **Extract the rot-prone claims** — anything with a shelf life: version
+   numbers and "latest/current" statements, CVE/advisory IDs and fix
+   versions, RFC/ISO/NIST/OWASP/CIS/WCAG numbers and editions, "GA since /
+   removed in / deprecated" statements, tool recommendations and their
+   maintenance status.
+2. **Verify each against a PRIMARY source** you fetch now — vendor release
+   notes, the RFC editor, NIST/OWASP pages, GitHub Security Advisories, the
+   project's own repo/docs. Not memory, not a blog restating it.
+3. **Fix drift under the repo policies** (see
+   [CONTRIBUTING.md](../CONTRIBUTING.md)): no rot-prone version pins ("latest
+   stable, verify at source"; keep only semantic boundaries like "fixed in
+   vX" / "GA since"); replace EOL/unmaintained tools with their maintained
+   successor (project-recommended first, then a maintained CNCF/OSS fork),
+   keeping a one-line EOL note for auditors.
+4. **Adversarially re-verify** — a second pass (ideally a different agent)
+   that re-fetches the source and re-reads the edit, defaulting to "wrong"
+   until the evidence reproduces. This is where hallucinated citations get
+   caught (e.g. the 2026-07 sweeps caught "BIMI = RFC 8910" and a stale
+   DMARC RFC this way).
+
+**At scale**, this is a natural multi-agent job: one research+fix agent per
+skill in parallel, then an independent adversarial verify pass, then land the
+fixes via PR. The 2026-07-08 sweep (65 fixes) and 2026-07-10 audit followed
+exactly this shape, reproducible from the CHANGELOG entries.
+
+**After a full pass:** set `LAST-VERIFIED` to today (`date +%F`), note the
+sweep in the CHANGELOG, and open a PR. Do **not** add per-file markers — that
+convention is retired.
+
+## 3. Measuring efficacy (the eval harness)
+
+Freshness keeps claims *true*; the eval harness (`evals/`) keeps the library
+*effective* — does loading a skill actually change agent output for the
+better? It is a manually-run prototype (an LLM eval can't run deterministically
+in CI): golden-set cases with expected outcomes + a scoring script. See
+[`evals/README.md`](../evals/README.md) for how to run it and read the score.
+Run it before and after a large content change as a regression check, and
+grow the golden sets as coverage warrants.
+
+## 4. What is and isn't automated
+
+| Dimension | Gate | Automated? |
+|---|---|---|
+| Structure (line cap, checklist-last, description cap, counts, router completeness) | `check-invariants.sh` (7 checks) | Yes — pre-commit + CI |
+| Secrets | gitleaks (full history) | Yes — CI |
+| Shell quality | shellcheck | Yes — CI |
+| Claim **accuracy** | this runbook + `LAST-VERIFIED` | No — human/agent, monthly red-flag |
+| **Efficacy** | `evals/` | No — manual prototype |
+
+The bottom two are deliberately not in CI: verifying a claim against a live
+primary source, or scoring an LLM's output, is non-deterministic and needs
+network + judgment. Keeping them honest is a maintainer discipline, and this
+file is the checklist for it.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,68 @@
+# evals/ — efficacy regression harness (prototype)
+
+Freshness (see [../docs/MAINTENANCE.md](../docs/MAINTENANCE.md)) keeps the
+library's claims *true*. This harness asks a different question: does loading a
+skill actually change agent output for the better? It turns "the skills work"
+from an assertion into a number you can re-run.
+
+**This is a prototype and is deliberately not in CI.** An LLM eval is
+non-deterministic and needs an agent + network, so it can't be a blocking gate.
+You run an agent over the cases yourself and score the result here. The value
+is a repeatable baseline: run it before and after a large content change and
+watch the score, and grow the golden sets as coverage warrants (2026-07-10
+audit STRAT-HIGH-2).
+
+## Cases
+
+- `cases/router.jsonl` — routing: a plain prompt → the skills that must load.
+  Tests the router's task→skill mapping.
+- `cases/audit.jsonl` — audit: a deliberately vulnerable snippet → the finding
+  category an audit must flag. Tests that the security skills catch the obvious.
+
+Each line is one case with an `id` and an `expect` list (see `score.py` header
+for the schema). Add cases freely; keep `expect` to unambiguous must-haves.
+
+## How to run
+
+1. **Baseline (no skills):** in a session with the SOTA skills NOT loaded, give
+   the agent each case's `prompt` (routing) or ask it to audit each `snippet`
+   (audit). Record what it did in a predictions JSON:
+
+   ```json
+   { "r01": ["sota-api-design", "sota-code-security"], "a01": ["sql-injection"] }
+   ```
+   (routing → skills it loaded; audit → finding categories it reported.)
+
+2. **With skills:** repeat in a session with the SOTA skills loaded (via the
+   plugin or `~/.claude/skills`). Record a second predictions JSON.
+
+3. **Score both:**
+
+   ```sh
+   python3 evals/score.py evals/cases/router.jsonl predictions-with.json
+   python3 evals/score.py evals/cases/audit.jsonl  predictions-with.json
+   ```
+
+   The script prints per-case recall (did it load/flag every expected item?)
+   and precision (FYI), then the means. It exits non-zero if any case has a
+   miss. Compare the *with-skills* score to the *baseline* — the delta is the
+   library's measured lift.
+
+## Interpreting
+
+- **Recall is the load-bearing metric.** A miss (recall < 1.0) is a real gap:
+  either the skill isn't being routed/applied, or its guidance doesn't cover the
+  case. Investigate — it's exactly the kind of blind spot the harness exists to
+  surface.
+- **Precision is informational** for routing (loading an extra relevant skill
+  isn't wrong); for audit, extras are usually fine too (more true findings).
+- These golden sets are small and the `expect` sets are judgment calls, so
+  treat the score as a *regression signal*, not an absolute grade. The point is
+  the delta over time, not the third decimal place.
+
+## Extending
+
+Add a new case kind by giving each case an `id` and an `expect` list — `score.py`
+is generic over the expected/predicted set comparison. Good next sets: contract
+tests the API skill should demand, migration-safety cases for the DB skill,
+prompt-injection cases for the LLM/agent skills.

--- a/evals/cases/audit.jsonl
+++ b/evals/cases/audit.jsonl
@@ -1,0 +1,9 @@
+# Audit golden set — does an audit (with the relevant skills loaded) flag the
+# planted vulnerability? `expect` = finding categories the agent MUST report.
+# Snippets are deliberately vulnerable, minimal, and unambiguous. `kind` audit.
+{"id": "a01", "kind": "audit", "language": "python", "snippet": "cur.execute(\"SELECT * FROM users WHERE id = \" + request.args['id'])", "expect": ["sql-injection"]}
+{"id": "a02", "kind": "audit", "language": "javascript", "snippet": "child_process.exec('ping ' + req.query.host)", "expect": ["command-injection"]}
+{"id": "a03", "kind": "audit", "language": "python", "snippet": "stored = hashlib.md5(password.encode()).hexdigest()", "expect": ["weak-password-hashing"]}
+{"id": "a04", "kind": "audit", "language": "go", "snippet": "tls.Config{InsecureSkipVerify: true}", "expect": ["tls-verification-disabled"]}
+{"id": "a05", "kind": "audit", "language": "python", "snippet": "obj = pickle.loads(request.body)", "expect": ["unsafe-deserialization"]}
+{"id": "a06", "kind": "audit", "language": "python", "snippet": "if user_supplied_token == secret_token:  # string ==", "expect": ["non-constant-time-comparison"]}

--- a/evals/cases/router.jsonl
+++ b/evals/cases/router.jsonl
@@ -1,0 +1,16 @@
+# Routing golden set — does the sota router load the clearly-relevant skills?
+# `expect` = must-load skills (recall-focused). Derived from the router's own
+# routing table + cross-cutting rules in skills/sota/SKILL.md. Extra loads are
+# not penalized as errors; a MISS of an expected skill is the real signal.
+{"id": "r01", "kind": "routing", "prompt": "Add a REST endpoint that accepts file uploads from users.", "expect": ["sota-api-design", "sota-code-security", "sota-testing"]}
+{"id": "r02", "kind": "routing", "prompt": "Review our Dockerfiles and Kubernetes manifests for security issues.", "expect": ["sota-kubernetes", "sota-sandboxing"]}
+{"id": "r03", "kind": "routing", "prompt": "Design a multi-tenant SaaS billing service.", "expect": ["sota-architecture", "sota-databases", "sota-api-design"]}
+{"id": "r04", "kind": "routing", "prompt": "Set up SPF, DKIM and DMARC so our domain can't be spoofed.", "expect": ["sota-network-security"]}
+{"id": "r05", "kind": "routing", "prompt": "Write a bash script that deploys our app and cleans up on failure.", "expect": ["sota-shell-scripting"]}
+{"id": "r06", "kind": "routing", "prompt": "Harden our GitHub Actions CI pipeline: pinned actions, OIDC, SBOM.", "expect": ["sota-devsecops"]}
+{"id": "r07", "kind": "routing", "prompt": "Add a RAG chatbot over our docs with tool use.", "expect": ["sota-llm-engineering", "sota-code-security"]}
+{"id": "r08", "kind": "routing", "prompt": "Audit this Go HTTP service for vulnerabilities.", "expect": ["sota-golang", "sota-code-security"]}
+{"id": "r09", "kind": "routing", "prompt": "Bring our React settings page up to WCAG 2.2 AA.", "expect": ["sota-frontend-design", "sota-web-frameworks"]}
+{"id": "r10", "kind": "routing", "prompt": "Run sensitive workloads on rented cloud VMs with hardware attestation.", "expect": ["sota-confidential-computing"]}
+{"id": "r11", "kind": "routing", "prompt": "Rewrite the error messages and empty states on our settings screen.", "expect": ["sota-ux-writing"]}
+{"id": "r12", "kind": "routing", "prompt": "Checkout is slow in production — figure out why.", "expect": ["sota-performance"]}

--- a/evals/score.py
+++ b/evals/score.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Score an agent's predictions against a golden-set eval case file.
+
+This is a PROTOTYPE regression harness (2026-07-10 audit STRAT-HIGH-2). It does
+NOT run an agent — an LLM eval can't run deterministically in CI. You run an
+agent (Claude Code, or the API) over the cases yourself, record what it did in a
+predictions JSON, and this script scores it. See evals/README.md.
+
+Case files (JSONL, one object per line):
+  {"id": "r1", "kind": "routing", "prompt": "...", "expect": ["sota-api-design", ...]}
+  {"id": "a1", "kind": "audit", "language": "python", "snippet": "...",
+   "expect": ["sql-injection"]}
+
+Predictions file (JSON): { "<case id>": ["<predicted item>", ...], ... }
+  routing → the skills the agent actually loaded for that prompt.
+  audit   → the finding categories the agent flagged in that snippet.
+
+Metric: per-case recall of the expected set (did the agent load/flag what it
+must?), plus precision as an FYI (extras aren't necessarily wrong for routing).
+Recall is the load-bearing number: a miss is a real gap.
+
+Usage:  python3 evals/score.py evals/cases/router.jsonl predictions.json
+        python3 evals/score.py evals/cases/audit.jsonl  predictions.json
+Exit 0 if every case has recall == 1.0 (no misses), else 1.
+"""
+import json
+import sys
+
+
+def load_cases(path):
+    cases = []
+    with open(path, encoding="utf-8") as fh:
+        for n, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            try:
+                cases.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                sys.exit(f"{path}:{n}: invalid JSON: {e}")
+    return cases
+
+
+def main(argv):
+    if len(argv) != 3:
+        sys.exit(__doc__)
+    cases = load_cases(argv[1])
+    preds = json.load(open(argv[2], encoding="utf-8"))
+
+    total_recall = 0.0
+    total_prec = 0.0
+    any_miss = False
+    print(f"{'case':<6} {'recall':>7} {'prec':>6}  misses")
+    print("-" * 60)
+    for c in cases:
+        cid = c["id"]
+        expect = set(c.get("expect", []))
+        pred = set(preds.get(cid, []))
+        if not expect:
+            continue
+        hit = expect & pred
+        recall = len(hit) / len(expect)
+        prec = (len(hit) / len(pred)) if pred else 0.0
+        total_recall += recall
+        total_prec += prec
+        misses = sorted(expect - pred)
+        if misses:
+            any_miss = True
+        flag = "" if recall == 1.0 else "  <-- MISS"
+        print(f"{cid:<6} {recall:>7.2f} {prec:>6.2f}  {', '.join(misses) or '-'}{flag}")
+
+    n = sum(1 for c in cases if c.get("expect"))
+    if n:
+        print("-" * 60)
+        print(f"mean recall {total_recall / n:.2f}   mean precision {total_prec / n:.2f}"
+              f"   ({n} cases)")
+    return 1 if any_miss else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check-freshness.sh
+++ b/scripts/check-freshness.sh
@@ -6,13 +6,14 @@
 # sources. Since 2026-07 that promise is tracked with a SINGLE library-level
 # stamp: the root `LAST-VERIFIED` file holds the date (YYYY-MM-DD) of the last
 # full-library re-verification sweep (per-skill research against primary
-# sources — see the sweep procedure referenced in CONTRIBUTING.md). Update it
-# only after such a sweep, not on ordinary edits (git history already records
-# those).
+# sources — see the runbook in docs/MAINTENANCE.md). Update it only after such
+# a sweep, not on ordinary edits (git history already records those).
 #
 # This script:
 #   - fails (exit 1) if the stamp is older than the re-verify window
-#     (default 12 months) — a red scheduled run is the re-sweep signal;
+#     (default 6 months — content drifts far faster than the old 12-month
+#     window allowed, per the 2026-07-10 audit; 6mo stays clearable so a red
+#     report stays meaningful rather than perpetually-ignored);
 #   - warns about any stray per-file `<!-- last-verified: ... -->` line-1
 #     markers (the pre-2026-07 convention; they should no longer exist).
 #
@@ -23,7 +24,7 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-WINDOW=12
+WINDOW=6
 while [ $# -gt 0 ]; do
   case "$1" in
     --window-months) shift; WINDOW="${1:?--window-months needs a number}" ;;


### PR DESCRIPTION
Executes the audit's two top strategic gaps (STRAT-HIGH-1/2).

**Content-accuracy gate (STRAT-HIGH-1).** The library had no documented, reproducible way to keep claims accurate — the sweep lived in maintainer memory behind a 12-month window while content drifts in weeks.
- `docs/MAINTENANCE.md`: the step-by-step per-skill re-verification runbook (extract rot-prone claims → verify vs primary sources → fix under no-pins/EOL policies → adversarial re-verify → bump `LAST-VERIFIED`), plus an honest table of what's CI-automated vs human/agent.
- `check-freshness.sh` window **12 → 6 months** (still green now; goes red ~Jan 2027). 6mo chosen to stay *clearable* — a perpetually-red report gets ignored (the freshness script's own design principle).

**Eval harness (STRAT-HIGH-2).** The efficacy claim was untested.
- `evals/`: golden-set cases (`router.jsonl` — prompt→must-load skills; `audit.jsonl` — vulnerable snippet→must-flag category) + `score.py` (recall/precision vs an agent's predictions JSON). **Verified end-to-end this session**: perfect predictions → exit 0; misses → flagged + exit 1; all golden-set skill refs resolve to real dirs.
- Deliberately **not in CI** (an LLM eval is non-deterministic + needs an agent) — it's a repeatable with-vs-without baseline you run manually, documented in `evals/README.md`.

All 7 invariants pass; shellcheck clean; new .md files well under the 500-line cap.