### PR TITLE
docs(roadmap): re-cut around the 2026-07-10 audit + fix STALE bookkeeping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,5 +99,5 @@ pre-commit hook scans each commit locally.
   eval harness (keeping fast-moving claims true and measuring efficacy)
 - [SECURITY.md](SECURITY.md) — reporting bad guidance or a leaked secret
 - [CHANGELOG.md](CHANGELOG.md) — release history (top entry = current version;
-  also mirrored in `VERSION`); releases 1.6.0 and earlier are archived in
+  also mirrored in `VERSION`); releases 1.7.1 and earlier are archived in
   [docs/CHANGELOG-archive.md](docs/CHANGELOG-archive.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Roadmap re-cut around the 2026-07-10 audit** (`docs/ROADMAP.md`): the
+  2026-07-01 cycle (fully executed) demoted to history; a fresh Now/Next/Later
+  reflects the audit — Now (prove/protect accuracy) closed this cycle, Next
+  (grow evals + first 6-month sweep), Later (distribution over coverage,
+  STRAT-MED-1). Fixed two STALE bookkeeping items the audit flagged: the
+  2026-07-08 sweep is a "34-skill" pass (not "full-library" — it covered 34 of
+  40 skills), and the low-severity-triage tally no longer implies 58+32=75
+  (the ~75 candidate findings split across files into more line-items).
 - **Invariant-gate hardening** (2026-07-10 audit): check 2 now tracks code-fence
   state so a `## Audit checklist` inside a fence no longer satisfies the
   "ends-with" rule (the 2026-07-01 fix was incomplete; verified identical
@@ -156,18 +164,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Low-severity sweep triage (2026-07-09)** — the 75 never-verified
-  low-severity suggestions from the 2026-07-08 sweep were re-verified
-  hypothesis-by-hypothesis against primary sources by one agent per skill:
-  **58 applied** (each cites the verifying source; e.g. GraphQL @oneOf per
-  the September 2025 spec edition, Mercurius WS depth-bypass CVE-2026-30241
-  checklist item, NATS 2.12–2.15 feature gates + the 2.15 ack-subject ACL
-  migration warning, PEP 734 subinterpreters + Python 3.14 asyncio
-  introspection, Go 1.25 testing/synctest, C++26 DIS status), **32 skipped**
-  with recorded reasons (refuted, already covered by the verified-fix pass,
-  or not worth the lines). No version pins added; all invariants green.
-- **Freshness sweep 2026-07-08** — full-library research pass (one web-research
-  agent per skill, 34 skills; every high/medium finding independently
+- **Low-severity sweep triage (2026-07-09)** — the never-verified
+  low-severity suggestions from the 2026-07-08 sweep (~75 candidate findings)
+  were re-verified hypothesis-by-hypothesis against primary sources by one
+  agent per skill: **58 applied** (each cites the verifying source; e.g.
+  GraphQL @oneOf per the September 2025 spec edition, Mercurius WS depth-bypass
+  CVE-2026-30241 checklist item, NATS 2.12–2.15 feature gates + the 2.15
+  ack-subject ACL migration warning, PEP 734 subinterpreters + Python 3.14
+  asyncio introspection, Go 1.25 testing/synctest, C++26 DIS status),
+  **32 skipped** with recorded reasons (refuted, already covered by the
+  verified-fix pass, or not worth the lines). The applied+skipped tallies
+  exceed 75 because some findings split across multiple files. No version pins
+  added; all invariants green.
+- **Freshness sweep 2026-07-08** — 34-skill research pass (one web-research
+  agent per skill; every high/medium finding independently
   adversarially verified against primary sources) fixed **7 high + 58 medium**
   confirmed gaps across 31 skills. Highlights: SurrealDB 3.1.5 security batch
   (databases/08); Argo CD repo-server unpatched gRPC RCE → require
@@ -347,144 +357,9 @@ first-screen impact.
   commands → two example prompts → standards → skills table; directory tree
   and modes detail moved down beside "How it works".
 
-## [1.7.1] - 2026-07-01
-
-Fixes every confirmed finding of the 2026-07-01 adversarial audit
-(`docs/AUDIT-2026-07-01.md`) except the accepted-risk history disclosure
-(finding S1 — names remain in pre-July-2026 git history by decision).
-
-### Fixed
-
-- **`sota-security-compliance` frontmatter was invalid strict YAML** (HIGH):
-  the inline description contained `Trigger keywords: …`, which strict loaders
-  reject — the skill could be silently skipped. Now a `>-` block scalar
-  (994 chars); invariant 4 additionally rejects unquoted inline descriptions
-  containing `: ` so the class can't recur.
-- **`init-gates.sh` could silently skip whole language gates** (HIGH): the
-  `has()` file-list probe piped `printf` into `grep -q`, which under
-  `pipefail` can die by SIGPIPE on large repos and read as "language not
-  detected". Now a herestring; reproduced before/after with a 200k-file list.
-- **`init-gates.sh` silent no-ops**: a `repos: []`-style config produced
-  "wrote .pre-commit-config.yaml" with no gates inserted (now dies with
-  instructions); altered/re-indented `sota-gates` markers made every re-run a
-  silent unchanged rewrite (now detected exact-line and refused); running in a
-  non-git dir crashed on `pre-commit install` after writing the config (now a
-  warning); Bun ≥ 1.2 text lockfile `bun.lock` now selects `bun audit`.
-- **`install.sh` `--copy` → default-install switch corrupted the target**:
-  `ln -sfn` can't replace a real directory, so the stale snapshot stayed (with
-  a self-named symlink nested inside) while the script reported success. Now
-  detected and replaced after a prompt. Altered routing markers in
-  `~/.claude/CLAUDE.md` are refused instead of looping "out of date" forever.
-- **`gen-agents-md.sh`**: orphaned/altered managed-block markers now refuse to
-  touch the file (previously a lone BEGIN marker set up content loss on the
-  next run); marker splice is exact-line so a *quoted* marker can't misfire;
-  skill count uses `find -L` (symlinked layouts reported "0 skills indexed").
-- **`check-invariants.sh` hardening**: check 1 counts a missing final newline
-  and skips deleted-but-tracked files instead of aborting; check 2 requires
-  the audit checklist to be the file's LAST `## ` heading ("ends with", as
-  documented); check 3 is case-insensitive, also scans file/directory names,
-  and surfaces scan errors instead of failing open.
-- **sota-jvm mislabeled JDK 25 scoped values as preview**: JEP 506 is final in
-  Java 25 (structured concurrency remains preview, JEP 505). SKILL.md body and
-  rules/03 corrected against openjdk.org.
-- **sota-golang baseline raised to Go 1.25+**: 1.24 left security support with
-  1.26's release (go.dev/doc/devel/release); feature notes unchanged.
-- **Count/format drift**: README hero counts restored to the skills-markdown
-  basis (255 files, ~52k lines — "279 files" counted every tracked file);
-  README/CONTRIBUTING rules-file line-range claims now match reality (~80–350);
-  the v1.5.0 pre-fix description lengths corrected to invariant 4's own
-  measurements; plugin/marketplace descriptions say 34 domains + router
-  (35 skills); router cross-cutting rules renumbered sequentially (were
-  1-9, 13-16, 10-12); audit-methodology short finding format regains the
-  `effort` field and 11 skill finding templates gained an `Effort:` line;
-  five bare `rules/08` references in sota-llm-engineering now name
-  sota-code-security; a garbled cross-reference in sota-code-security
-  rules/09 reworded.
-- **Secret-scanning guidance reconciled** (was duplicated with drift):
-  sota-devsecops rules/05 §5.2 owns pipeline gate layering,
-  sota-secrets-management rules/04 owns tool config + leak response — now
-  cross-referenced both ways, and gitleaks commands use the current
-  `gitleaks git` CLI (the official pre-commit hook's own invocation).
-- Stale docs: `CLAUDE.md` pointed at the changelog with "(current: v1.0.0)"
-  seven releases later — the pointer is now version-less; gitleaks scan scope
-  documented accurately in `CLAUDE.md`, `CONTRIBUTING.md`, and `README.md`.
-
-### Changed
-
-- **CI secret scan now covers the full git history**: the gitleaks job checks
-  out with `fetch-depth: 0` and runs `gitleaks git` (every commit) instead of
-  `gitleaks detect --no-git` (working tree only). Validated locally first:
-  44 commits scanned, no leaks.
-- **CI hardening**: `actions/checkout` re-pinned to v7.0.0 (SHA-pinned;
-  was v4.2.2, three majors old), `persist-credentials: false` on every
-  checkout, and a new `shellcheck` job gates `scripts/*.sh`. The
-  sota-devsecops SHA-pinning example no longer hard-codes an aging SHA.
-- **Internal-name denylist externalized**: the private patterns moved out of
-  the tracked script into a git-ignored `.denylist.local` (pre-commit) and the
-  `SOTA_DENYLIST` repository secret (CI). The tracked script keeps only the
-  generic reader-assumption phrases; fork PRs run those and the maintainer's
-  CI runs the full list. Pre-2026-07 history still contains the old inline
-  list — reviewed and accepted (audit finding S1).
-- **`scripts/install.sh` checks contributor pre-commit hygiene**: when run from
-  a git checkout it detects a missing pre-commit hook and offers to install it
-  (or prints an install tip when the `pre-commit` tool itself is absent).
-  Non-fatal for end users; CI enforces the same checks regardless.
-
-### Added
-
-- `docs/AUDIT-2026-07-01.md` — full adversarial audit report (decision ledger,
-  findings, reproduction status), and `docs/ROADMAP.md` — audit-derived
-  priorities.
-
-## [1.7.0] - 2026-07-01
-
-Adds a security & compliance engineering skill — the cybersecurity-regulation
-counterpart to `sota-privacy-compliance` (which stays data/privacy-centric). It
-covers the control frameworks and product-security regulations that drive
-architecture, code, and CI gates rather than the organizational policy binder,
-with an explicit engineering-vs-organizational scope boundary. The library goes
-from 34 to 35 skills.
-
-### Added
-
-- **`sota-security-compliance` — security & compliance engineering skill** (35th
-  skill): SKILL.md + 5 rules — `01-control-frameworks-as-code` (NIST CSF 2.0 as
-  the organizing spine; control → mechanism → evidence crosswalk; policy-as-code
-  gates; baselines/tailoring/OSCAL), `02-nist-800-53-171-cmmc-fedramp` (SP
-  800-53 Rev 5 families & baselines, SP 800-171 Rev 3 CUI boundary +
-  FIPS-validated crypto, CMMC 2.0 levels & phase-in, FedRAMP + FedRAMP 20x),
-  `03-ssdf-secure-sdlc` (SP 800-218 PO/PS/PW/RV practices as CI gates, federal
-  secure-software self-attestation, SP 800-218A for AI/model development),
-  `04-eu-cyber-resilience-act` (Regulation (EU) 2024/2847 — SBOM, coordinated
-  vulnerability disclosure, signed update channel, secure-by-default, the 24h/72h
-  ENISA reporting clocks, phased timeline), `05-iec-62443-ot-ics` (OT/ICS zones &
-  conduits, Security Levels SL-T/C/A, the 7 Foundational Requirements, 62443-4-1
-  vs SSDF, 62443 as a CRA conformity route). Cross-links to
-  `sota-privacy-compliance`, `sota-devsecops`, `sota-identity-access`,
-  `sota-network-security`, and `sota-detection-engineering` rather than
-  duplicating them. Statuses verified July 2026 against NIST CSRC, EUR-Lex, the
-  Federal Register, and ISA/IEC (CSF 2.0 Feb 2024; 800-53 Rev 5; 800-171 Rev 3
-  May 2024; SSDF v1.1 / 800-218A; CMMC 32 CFR eff. Dec 2024 + 48 CFR eff. Nov
-  2025; CRA reporting from 11 Sep 2026, main obligations from 11 Dec 2027).
-
-### Changed
-
-- Router (`sota/SKILL.md`) catalog table, rules index, and description updated to
-  include `sota-security-compliance`.
-- README skill count (34 → 35), file/line counts (279 files, ~53k lines), and
-  skills table updated.
-- `scripts/install.sh` always-on routing is now **update-aware**: re-running (or
-  `--update`) refreshes the managed `~/.claude/CLAUDE.md` directive and the
-  `settings.json` reminder hook in place when their wording changes upstream —
-  prompting first, backing up, editing only the content between the managed
-  markers, writing through a symlink so dotfiles keep their link, and leaving a
-  hook with custom wording untouched. Previously the block was write-once
-  (detected by marker presence and skipped), so wording changes never propagated.
-  README "Always-on routing" and "Updating" sections document the new behavior.
-
 ---
 
-Releases **1.6.0 and earlier** are archived in
+Releases **1.7.1 and earlier** are archived in
 [docs/CHANGELOG-archive.md](docs/CHANGELOG-archive.md).
 
 [1.12.1]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.12.1
@@ -493,5 +368,3 @@ Releases **1.6.0 and earlier** are archived in
 [1.10.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.10.0
 [1.9.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.9.0
 [1.8.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.8.0
-[1.7.1]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.7.1
-[1.7.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.7.0

--- a/docs/CHANGELOG-archive.md
+++ b/docs/CHANGELOG-archive.md
@@ -6,6 +6,141 @@ keep that file under the repository's 500-line cap. Same format
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)); current releases
 live in the root CHANGELOG.
 
+## [1.7.1] - 2026-07-01
+
+Fixes every confirmed finding of the 2026-07-01 adversarial audit
+(`docs/AUDIT-2026-07-01.md`) except the accepted-risk history disclosure
+(finding S1 — names remain in pre-July-2026 git history by decision).
+
+### Fixed
+
+- **`sota-security-compliance` frontmatter was invalid strict YAML** (HIGH):
+  the inline description contained `Trigger keywords: …`, which strict loaders
+  reject — the skill could be silently skipped. Now a `>-` block scalar
+  (994 chars); invariant 4 additionally rejects unquoted inline descriptions
+  containing `: ` so the class can't recur.
+- **`init-gates.sh` could silently skip whole language gates** (HIGH): the
+  `has()` file-list probe piped `printf` into `grep -q`, which under
+  `pipefail` can die by SIGPIPE on large repos and read as "language not
+  detected". Now a herestring; reproduced before/after with a 200k-file list.
+- **`init-gates.sh` silent no-ops**: a `repos: []`-style config produced
+  "wrote .pre-commit-config.yaml" with no gates inserted (now dies with
+  instructions); altered/re-indented `sota-gates` markers made every re-run a
+  silent unchanged rewrite (now detected exact-line and refused); running in a
+  non-git dir crashed on `pre-commit install` after writing the config (now a
+  warning); Bun ≥ 1.2 text lockfile `bun.lock` now selects `bun audit`.
+- **`install.sh` `--copy` → default-install switch corrupted the target**:
+  `ln -sfn` can't replace a real directory, so the stale snapshot stayed (with
+  a self-named symlink nested inside) while the script reported success. Now
+  detected and replaced after a prompt. Altered routing markers in
+  `~/.claude/CLAUDE.md` are refused instead of looping "out of date" forever.
+- **`gen-agents-md.sh`**: orphaned/altered managed-block markers now refuse to
+  touch the file (previously a lone BEGIN marker set up content loss on the
+  next run); marker splice is exact-line so a *quoted* marker can't misfire;
+  skill count uses `find -L` (symlinked layouts reported "0 skills indexed").
+- **`check-invariants.sh` hardening**: check 1 counts a missing final newline
+  and skips deleted-but-tracked files instead of aborting; check 2 requires
+  the audit checklist to be the file's LAST `## ` heading ("ends with", as
+  documented); check 3 is case-insensitive, also scans file/directory names,
+  and surfaces scan errors instead of failing open.
+- **sota-jvm mislabeled JDK 25 scoped values as preview**: JEP 506 is final in
+  Java 25 (structured concurrency remains preview, JEP 505). SKILL.md body and
+  rules/03 corrected against openjdk.org.
+- **sota-golang baseline raised to Go 1.25+**: 1.24 left security support with
+  1.26's release (go.dev/doc/devel/release); feature notes unchanged.
+- **Count/format drift**: README hero counts restored to the skills-markdown
+  basis (255 files, ~52k lines — "279 files" counted every tracked file);
+  README/CONTRIBUTING rules-file line-range claims now match reality (~80–350);
+  the v1.5.0 pre-fix description lengths corrected to invariant 4's own
+  measurements; plugin/marketplace descriptions say 34 domains + router
+  (35 skills); router cross-cutting rules renumbered sequentially (were
+  1-9, 13-16, 10-12); audit-methodology short finding format regains the
+  `effort` field and 11 skill finding templates gained an `Effort:` line;
+  five bare `rules/08` references in sota-llm-engineering now name
+  sota-code-security; a garbled cross-reference in sota-code-security
+  rules/09 reworded.
+- **Secret-scanning guidance reconciled** (was duplicated with drift):
+  sota-devsecops rules/05 §5.2 owns pipeline gate layering,
+  sota-secrets-management rules/04 owns tool config + leak response — now
+  cross-referenced both ways, and gitleaks commands use the current
+  `gitleaks git` CLI (the official pre-commit hook's own invocation).
+- Stale docs: `CLAUDE.md` pointed at the changelog with "(current: v1.0.0)"
+  seven releases later — the pointer is now version-less; gitleaks scan scope
+  documented accurately in `CLAUDE.md`, `CONTRIBUTING.md`, and `README.md`.
+
+### Changed
+
+- **CI secret scan now covers the full git history**: the gitleaks job checks
+  out with `fetch-depth: 0` and runs `gitleaks git` (every commit) instead of
+  `gitleaks detect --no-git` (working tree only). Validated locally first:
+  44 commits scanned, no leaks.
+- **CI hardening**: `actions/checkout` re-pinned to v7.0.0 (SHA-pinned;
+  was v4.2.2, three majors old), `persist-credentials: false` on every
+  checkout, and a new `shellcheck` job gates `scripts/*.sh`. The
+  sota-devsecops SHA-pinning example no longer hard-codes an aging SHA.
+- **Internal-name denylist externalized**: the private patterns moved out of
+  the tracked script into a git-ignored `.denylist.local` (pre-commit) and the
+  `SOTA_DENYLIST` repository secret (CI). The tracked script keeps only the
+  generic reader-assumption phrases; fork PRs run those and the maintainer's
+  CI runs the full list. Pre-2026-07 history still contains the old inline
+  list — reviewed and accepted (audit finding S1).
+- **`scripts/install.sh` checks contributor pre-commit hygiene**: when run from
+  a git checkout it detects a missing pre-commit hook and offers to install it
+  (or prints an install tip when the `pre-commit` tool itself is absent).
+  Non-fatal for end users; CI enforces the same checks regardless.
+
+### Added
+
+- `docs/AUDIT-2026-07-01.md` — full adversarial audit report (decision ledger,
+  findings, reproduction status), and `docs/ROADMAP.md` — audit-derived
+  priorities.
+
+## [1.7.0] - 2026-07-01
+
+Adds a security & compliance engineering skill — the cybersecurity-regulation
+counterpart to `sota-privacy-compliance` (which stays data/privacy-centric). It
+covers the control frameworks and product-security regulations that drive
+architecture, code, and CI gates rather than the organizational policy binder,
+with an explicit engineering-vs-organizational scope boundary. The library goes
+from 34 to 35 skills.
+
+### Added
+
+- **`sota-security-compliance` — security & compliance engineering skill** (35th
+  skill): SKILL.md + 5 rules — `01-control-frameworks-as-code` (NIST CSF 2.0 as
+  the organizing spine; control → mechanism → evidence crosswalk; policy-as-code
+  gates; baselines/tailoring/OSCAL), `02-nist-800-53-171-cmmc-fedramp` (SP
+  800-53 Rev 5 families & baselines, SP 800-171 Rev 3 CUI boundary +
+  FIPS-validated crypto, CMMC 2.0 levels & phase-in, FedRAMP + FedRAMP 20x),
+  `03-ssdf-secure-sdlc` (SP 800-218 PO/PS/PW/RV practices as CI gates, federal
+  secure-software self-attestation, SP 800-218A for AI/model development),
+  `04-eu-cyber-resilience-act` (Regulation (EU) 2024/2847 — SBOM, coordinated
+  vulnerability disclosure, signed update channel, secure-by-default, the 24h/72h
+  ENISA reporting clocks, phased timeline), `05-iec-62443-ot-ics` (OT/ICS zones &
+  conduits, Security Levels SL-T/C/A, the 7 Foundational Requirements, 62443-4-1
+  vs SSDF, 62443 as a CRA conformity route). Cross-links to
+  `sota-privacy-compliance`, `sota-devsecops`, `sota-identity-access`,
+  `sota-network-security`, and `sota-detection-engineering` rather than
+  duplicating them. Statuses verified July 2026 against NIST CSRC, EUR-Lex, the
+  Federal Register, and ISA/IEC (CSF 2.0 Feb 2024; 800-53 Rev 5; 800-171 Rev 3
+  May 2024; SSDF v1.1 / 800-218A; CMMC 32 CFR eff. Dec 2024 + 48 CFR eff. Nov
+  2025; CRA reporting from 11 Sep 2026, main obligations from 11 Dec 2027).
+
+### Changed
+
+- Router (`sota/SKILL.md`) catalog table, rules index, and description updated to
+  include `sota-security-compliance`.
+- README skill count (34 → 35), file/line counts (279 files, ~53k lines), and
+  skills table updated.
+- `scripts/install.sh` always-on routing is now **update-aware**: re-running (or
+  `--update`) refreshes the managed `~/.claude/CLAUDE.md` directive and the
+  `settings.json` reminder hook in place when their wording changes upstream —
+  prompting first, backing up, editing only the content between the managed
+  markers, writing through a symlink so dotfiles keep their link, and leaving a
+  hook with custom wording untouched. Previously the block was write-once
+  (detected by marker presence and skipped), so wording changes never propagated.
+  README "Always-on routing" and "Updating" sections document the new behavior.
+
 ## [1.6.0] - 2026-06-29
 
 Adds four language/domain skills found missing in a coverage gap-analysis,
@@ -303,6 +438,8 @@ First public release.
 - **Governance**: contributor guide, security policy, and code of conduct;
   `main` protected with required status checks.
 
+[1.7.1]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.7.1
+[1.7.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.7.0
 [1.6.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.6.0
 [1.5.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.5.0
 [1.4.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.4.0

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,9 +1,45 @@
 # Roadmap
 
-Priorities set by the 2026-07-01 audit ([AUDIT-2026-07-01.md](AUDIT-2026-07-01.md)).
-Ordered; revisit after each release.
+Priorities set by the **2026-07-10 audit**
+([AUDIT-2026-07-10.md](AUDIT-2026-07-10.md)). Ordered; revisit after each
+release. The 2026-07-01 cycle is fully executed and kept below as history.
 
-## Now — correctness of what's shipped
+## Now — prove and protect accuracy *(done this cycle)*
+
+The audit's verdict was "content is trustworthy; the gap is that nothing
+*proves or protects* accuracy." Closed 2026-07-10 (PRs #63–#66):
+
+1. **Content-accuracy runbook + shorter window** — `docs/MAINTENANCE.md`
+   documents the reproducible per-skill re-verification sweep (was only in
+   maintainer memory); `check-freshness.sh` window cut 12→6 months. *(#66)*
+2. **Audit defect cleanup** — content corrections (OWASP/RFC/ingress/Iceberg/
+   version-pins) + router-map refresh *(#63)*; **invariant 7** (router
+   completeness) + check-2 fence / check-5 semver / CI fail-open hardening
+   *(#64)*; installer decline-abort + profile-clobber *(#65)*.
+3. **Eval-harness prototype** — `evals/` (golden-set cases + `score.py`,
+   verified end-to-end) makes the efficacy claim measurable. *(#66)*
+
+## Next — grow what the prototypes started
+
+4. **Grow the eval golden sets** (contract, migration-safety, prompt-injection
+   cases) and run a real **with-vs-without baseline** measurement; record the
+   number as the first efficacy data point.
+5. **First 6-month accuracy sweep** comes due ~Jan 2027 (freshness window) —
+   run it per the `docs/MAINTENANCE.md` runbook and bump `LAST-VERIFIED`.
+
+## Later — distribution over coverage
+
+6. **Pause net-new skills; invest in distribution.** Coverage is an exhausted
+   lever at current adoption (audit: 4 stars / 1 issue after 41 skills). Put
+   the effort into visibility (marketplace, a published before/after audit
+   demo) and the badge→verifiable-audit idea (link the "Built with" badge to a
+   committed audit report + commit SHA). *(audit STRAT-MED-1)*
+
+---
+
+## Completed — 2026-07-01 audit cycle *(history)*
+
+### Now — correctness of what's shipped
 
 1. **Fix the audit's HIGH and MEDIUM findings.** The two HIGHs
    (sota-security-compliance frontmatter invalid under strict YAML;
@@ -17,7 +53,7 @@ Ordered; revisit after each release.
    CI job in #37; version-lockstep (check 5) and count-surface (check 6)
    invariants on 2026-07-04.)*
 
-## Next — keep the core promise true
+### Next — keep the core promise true
 
 3. **Freshness ledger.** Per-rules-file `last-verified: YYYY-MM` metadata plus
    a scheduled CI job reporting files past their re-verify window. The README
@@ -47,7 +83,7 @@ Ordered; revisit after each release.
    primary source and redirects security-sensitive reports to the private
    advisory flow — plus a contact-link config; Discussions enabled.)*
 
-## Later — coverage decisions (decide, don't drift)
+### Later — coverage decisions (decide, don't drift)
 
 6. **Close or declare the language/domain gaps.** PHP and Ruby have no skill
    (incidental mentions only); Swift exists only at sota-mobile's


### PR DESCRIPTION
Final piece of the audit execution.

**Roadmap re-cut (approved patch):** the 2026-07-01 cycle (all items verified shipped) demoted to a 'Completed — history' section; a fresh Now/Next/Later — **Now** (prove/protect accuracy) closed this cycle via PRs #63–#66, **Next** (grow eval golden sets + first 6-month sweep ~Jan 2027), **Later** (distribution over coverage, STRAT-MED-1).

**Two STALE bookkeeping fixes** (D-STALE-1/2): 2026-07-08 sweep is now a **'34-skill'** pass (34 of 40, not 'full-library'); low-severity-triage entry no longer implies 58+32=75.

**CHANGELOG housekeeping:** archived releases 1.7.0/1.7.1 to `docs/CHANGELOG-archive.md` (the [Unreleased] audit-execution entries pushed the root over the 500-line cap; pre-commit correctly blocked it). AGENTS.md archive pointer updated to '1.7.1 and earlier'.

All 7 invariants pass.