### PR TITLE
feat(evals): grow golden sets + first with-vs-without efficacy baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Eval golden sets grown + first efficacy baseline** (roadmap Next). Cases
+  expanded to 20 routing + 13 audit (`evals/cases/`); a with-vs-without run
+  (both arms the same base model — with-library reads the repo skill files,
+  without-library is forbidden from `skills/`) is recorded in
+  `evals/results/2026-07-10/BASELINE.md` with the raw per-arm predictions.
+  Result: a measurable **+0.08 routing recall lift** (0.92→1.00) — the
+  without-library arm missed a must-load skill on 4/20 cases, all explained by
+  the router's cross-cutting rules (tests-accompany-everything,
+  AI-security→code-security, sandboxing-for-containers). Honest finding: the
+  audit cases are saturated (both arms 13/13), so harder multi-vuln cases are
+  the top next-iteration action.
+
 ## [1.13.0] - 2026-07-10
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,9 +21,12 @@ The audit's verdict was "content is trustworthy; the gap is that nothing
 
 ## Next — grow what the prototypes started
 
-4. **Grow the eval golden sets** (contract, migration-safety, prompt-injection
-   cases) and run a real **with-vs-without baseline** measurement; record the
-   number as the first efficacy data point.
+4. **Eval golden sets + first baseline** — *done 2026-07-10* (33 cases; first
+   with-vs-without run in [`evals/results/2026-07-10/BASELINE.md`](../evals/results/2026-07-10/BASELINE.md):
+   **+0.08 routing recall lift** from the cross-cutting rules; audit cases
+   saturated). **Live follow-through:** add **harder audit cases** (multi-vuln,
+   subtler authz/business-logic — the audit arm needs them to discriminate) and
+   re-run averaged over several samples for a stable trend.
 5. **First 6-month accuracy sweep** comes due ~Jan 2027 (freshness window) —
    run it per the `docs/MAINTENANCE.md` runbook and bump `LAST-VERIFIED`.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -60,9 +60,20 @@ for the schema). Add cases freely; keep `expect` to unambiguous must-haves.
   treat the score as a *regression signal*, not an absolute grade. The point is
   the delta over time, not the third decimal place.
 
+## Recorded runs
+
+`results/<date>/` holds the raw per-arm predictions + a `BASELINE.md` writeup
+for each run, so scores are re-scorable and comparable over time. First run:
+[`results/2026-07-10/BASELINE.md`](results/2026-07-10/BASELINE.md) — a
+measurable **+0.08 routing recall lift** with the library (the cross-cutting
+routing rules), and an honest finding that the audit cases are too easy to
+discriminate yet (both arms 13/13).
+
 ## Extending
 
 Add a new case kind by giving each case an `id` and an `expect` list — `score.py`
-is generic over the expected/predicted set comparison. Good next sets: contract
-tests the API skill should demand, migration-safety cases for the DB skill,
-prompt-injection cases for the LLM/agent skills.
+is generic over the expected/predicted set comparison. Highest-value next set
+(from the baseline): **harder audit cases** — multi-vuln snippets and subtler
+authz/business-logic cases where a bare model misses what a skill-guided audit
+catches. Also: contract tests the API skill should demand, migration-safety
+cases for the DB skill.

--- a/evals/cases/audit.jsonl
+++ b/evals/cases/audit.jsonl
@@ -7,3 +7,10 @@
 {"id": "a04", "kind": "audit", "language": "go", "snippet": "tls.Config{InsecureSkipVerify: true}", "expect": ["tls-verification-disabled"]}
 {"id": "a05", "kind": "audit", "language": "python", "snippet": "obj = pickle.loads(request.body)", "expect": ["unsafe-deserialization"]}
 {"id": "a06", "kind": "audit", "language": "python", "snippet": "if user_supplied_token == secret_token:  # string ==", "expect": ["non-constant-time-comparison"]}
+{"id": "a07", "kind": "audit", "language": "python", "snippet": "order = Order.query.get(request.args['order_id']); return order.to_json()", "expect": ["idor"]}
+{"id": "a08", "kind": "audit", "language": "python", "snippet": "user.update(**request.get_json())  # apply all posted fields", "expect": ["mass-assignment"]}
+{"id": "a09", "kind": "audit", "language": "python", "snippet": "resp = requests.get(request.json['callback_url'])", "expect": ["ssrf"]}
+{"id": "a10", "kind": "audit", "language": "python", "snippet": "re.match(r'^(\\w+\\s?)*$', user_input)", "expect": ["redos"]}
+{"id": "a11", "kind": "audit", "language": "python", "snippet": "open(os.path.join(UPLOAD_DIR, request.args['filename']))", "expect": ["path-traversal"]}
+{"id": "a12", "kind": "audit", "language": "python", "snippet": "doc = lxml.etree.fromstring(user_supplied_xml)", "expect": ["xxe"]}
+{"id": "a13", "kind": "audit", "language": "javascript", "snippet": "const cfg = _.merge({}, JSON.parse(req.body))", "expect": ["prototype-pollution"]}

--- a/evals/cases/router.jsonl
+++ b/evals/cases/router.jsonl
@@ -14,3 +14,11 @@
 {"id": "r10", "kind": "routing", "prompt": "Run sensitive workloads on rented cloud VMs with hardware attestation.", "expect": ["sota-confidential-computing"]}
 {"id": "r11", "kind": "routing", "prompt": "Rewrite the error messages and empty states on our settings screen.", "expect": ["sota-ux-writing"]}
 {"id": "r12", "kind": "routing", "prompt": "Checkout is slow in production — figure out why.", "expect": ["sota-performance"]}
+{"id": "r13", "kind": "routing", "prompt": "Write consumer-driven contract tests between our two services.", "expect": ["sota-testing"]}
+{"id": "r14", "kind": "routing", "prompt": "Is this database migration safe to run with zero downtime?", "expect": ["sota-databases"]}
+{"id": "r15", "kind": "routing", "prompt": "Our LLM agent runs tools on user input — check it for prompt injection and sandbox escapes.", "expect": ["sota-code-security", "sota-sandboxing"]}
+{"id": "r16", "kind": "routing", "prompt": "Build an offline-first sync feature for our iOS app.", "expect": ["sota-mobile"]}
+{"id": "r17", "kind": "routing", "prompt": "We're adding a user data-export feature — what are our GDPR obligations?", "expect": ["sota-privacy-compliance"]}
+{"id": "r18", "kind": "routing", "prompt": "Add OpenTelemetry tracing and SLOs across our services.", "expect": ["sota-observability"]}
+{"id": "r19", "kind": "routing", "prompt": "Threat-model our new payment flow before we build it.", "expect": ["sota-threat-modeling"]}
+{"id": "r20", "kind": "routing", "prompt": "Write Terraform for our AWS landing zone with IAM guardrails.", "expect": ["sota-cloud-infrastructure", "sota-devsecops"]}

--- a/evals/results/2026-07-10/BASELINE.md
+++ b/evals/results/2026-07-10/BASELINE.md
@@ -1,0 +1,77 @@
+# Eval baseline — 2026-07-10
+
+First efficacy measurement (roadmap Next item). Golden sets: 20 routing cases
+(`cases/router.jsonl`) + 13 audit cases (`cases/audit.jsonl`). Scored with
+`evals/score.py`. Raw predictions for each arm are in this directory
+(`pred_*.json`) so the run is re-scorable.
+
+## Method
+
+Four arms, run as parallel subagents on the same underlying model:
+
+- **routing / with-library** — read `skills/sota/SKILL.md` (the router: routing
+  table + cross-cutting rules) and apply it.
+- **routing / without-library** — forbidden from reading `skills/`; given only
+  the 40 skill *names* + own judgment.
+- **audit / with-library** — read `skills/sota-code-security/rules/*` (+ the
+  matching language skill) and apply the checks.
+- **audit / without-library** — forbidden from reading `skills/`; own knowledge.
+
+Both arms of a pair got identical inputs (prompts / snippets), with the
+`expect` answers stripped. The delta between arms is the library's **marginal
+contribution on top of the same base model** — not a claim about the model.
+
+## Results
+
+| Arm | Cases | Mean recall | Mean precision |
+|---|---|---|---|
+| routing — with library | 20 | **1.00** | 0.84 |
+| routing — without library | 20 | **0.92** | 0.93 |
+| audit — with library | 13 | 1.00 | 1.00 |
+| audit — without library | 13 | 1.00 | 1.00 |
+
+**Routing recall lift: +0.08 (0.92 → 1.00).** The without-library arm missed a
+must-load skill on 4 of 20 cases; with the router it missed none:
+
+- **r01** (file-upload API) — without missed `sota-testing` (router rule 7,
+  "tests accompany everything").
+- **r02** (review Dockerfiles/K8s) — without missed `sota-sandboxing`
+  (pod/container isolation).
+- **r03** (multi-tenant billing) — without missed `sota-api-design`.
+- **r07** (LLM agent runs tools on user input) — without routed only to
+  `sota-llm-engineering` and missed `sota-code-security` (router rule 5 puts
+  prompt-injection/tool-call security there).
+
+These are exactly the **cross-cutting routing rules** the router encodes and a
+bare model doesn't reliably apply — the library's clearest measured value.
+
+The recall gain comes with a **precision cost** (0.93 → 0.84): the with-library
+arm loads more skills, some beyond the minimal must-load set (e.g. r02 also
+loaded network-security + devsecops + shell-scripting — plausibly relevant, but
+not in the golden set). For routing this is expected and mostly benign (loading
+an extra relevant skill isn't a bug); recall is the load-bearing metric.
+
+## Honest limitations
+
+- **Audit eval is saturated** — both arms scored 13/13, including the cases I
+  designed to be *harder* (IDOR, mass-assignment, ReDoS, XXE,
+  prototype-pollution). On unambiguous single-vuln snippets the base model
+  already catches everything, so the eval can't discriminate here. **Next
+  iteration:** multi-vuln snippets, subtler business-logic/authz cases, and
+  cases keyed to library-specific knowledge (specific CVEs, the
+  "hidden-field-is-adversarial" doctrine, timing/side-channel nuance).
+- **Single run, non-deterministic** — one sample per arm; treat as a
+  directional signal, not a stable metric. Re-run and average for a real trend.
+- **`expect` sets are judgment calls** — the routing must-load sets are minimal
+  by design; precision numbers are informational, not a grade.
+- **Same-model control** — "without-library" is the base model instructed not
+  to read `skills/`; it measures marginal library value, and relies on the arm
+  honoring the instruction.
+
+## Takeaway
+
+The library delivers a **measurable, mechanism-explained routing lift** (+0.08
+recall, driven by the cross-cutting rules). The audit dimension needs harder
+cases before it can measure anything — that is itself the top action for the
+next eval iteration. This is the first data point; the value is the delta over
+time as the golden sets grow and the runs are averaged.

--- a/evals/results/2026-07-10/pred_audit-with.json
+++ b/evals/results/2026-07-10/pred_audit-with.json
@@ -1,0 +1,41 @@
+{
+    "a01": [
+        "sql-injection"
+    ],
+    "a02": [
+        "command-injection"
+    ],
+    "a03": [
+        "weak-password-hashing"
+    ],
+    "a04": [
+        "tls-verification-disabled"
+    ],
+    "a05": [
+        "unsafe-deserialization"
+    ],
+    "a06": [
+        "non-constant-time-comparison"
+    ],
+    "a07": [
+        "idor"
+    ],
+    "a08": [
+        "mass-assignment"
+    ],
+    "a09": [
+        "ssrf"
+    ],
+    "a10": [
+        "redos"
+    ],
+    "a11": [
+        "path-traversal"
+    ],
+    "a12": [
+        "xxe"
+    ],
+    "a13": [
+        "prototype-pollution"
+    ]
+}

--- a/evals/results/2026-07-10/pred_audit-without.json
+++ b/evals/results/2026-07-10/pred_audit-without.json
@@ -1,0 +1,41 @@
+{
+    "a01": [
+        "sql-injection"
+    ],
+    "a02": [
+        "command-injection"
+    ],
+    "a03": [
+        "weak-password-hashing"
+    ],
+    "a04": [
+        "tls-verification-disabled"
+    ],
+    "a05": [
+        "unsafe-deserialization"
+    ],
+    "a06": [
+        "non-constant-time-comparison"
+    ],
+    "a07": [
+        "idor"
+    ],
+    "a08": [
+        "mass-assignment"
+    ],
+    "a09": [
+        "ssrf"
+    ],
+    "a10": [
+        "redos"
+    ],
+    "a11": [
+        "path-traversal"
+    ],
+    "a12": [
+        "xxe"
+    ],
+    "a13": [
+        "prototype-pollution"
+    ]
+}

--- a/evals/results/2026-07-10/pred_routing-with.json
+++ b/evals/results/2026-07-10/pred_routing-with.json
@@ -1,0 +1,82 @@
+{
+    "r01": [
+        "sota-api-design",
+        "sota-code-security",
+        "sota-testing"
+    ],
+    "r02": [
+        "sota-kubernetes",
+        "sota-devsecops",
+        "sota-sandboxing",
+        "sota-network-security",
+        "sota-shell-scripting"
+    ],
+    "r03": [
+        "sota-architecture",
+        "sota-databases",
+        "sota-api-design"
+    ],
+    "r04": [
+        "sota-network-security"
+    ],
+    "r05": [
+        "sota-shell-scripting"
+    ],
+    "r06": [
+        "sota-devsecops",
+        "sota-secrets-management"
+    ],
+    "r07": [
+        "sota-llm-engineering",
+        "sota-code-security",
+        "sota-databases",
+        "sota-sandboxing"
+    ],
+    "r08": [
+        "sota-golang",
+        "sota-code-security",
+        "sota-api-design"
+    ],
+    "r09": [
+        "sota-frontend-design",
+        "sota-web-frameworks"
+    ],
+    "r10": [
+        "sota-confidential-computing"
+    ],
+    "r11": [
+        "sota-ux-writing"
+    ],
+    "r12": [
+        "sota-performance",
+        "sota-databases",
+        "sota-observability"
+    ],
+    "r13": [
+        "sota-testing",
+        "sota-api-design"
+    ],
+    "r14": [
+        "sota-databases"
+    ],
+    "r15": [
+        "sota-code-security",
+        "sota-sandboxing"
+    ],
+    "r16": [
+        "sota-mobile"
+    ],
+    "r17": [
+        "sota-privacy-compliance"
+    ],
+    "r18": [
+        "sota-observability"
+    ],
+    "r19": [
+        "sota-threat-modeling"
+    ],
+    "r20": [
+        "sota-cloud-infrastructure",
+        "sota-devsecops"
+    ]
+}

--- a/evals/results/2026-07-10/pred_routing-without.json
+++ b/evals/results/2026-07-10/pred_routing-without.json
@@ -1,0 +1,71 @@
+{
+    "r01": [
+        "sota-api-design",
+        "sota-code-security"
+    ],
+    "r02": [
+        "sota-kubernetes",
+        "sota-devsecops"
+    ],
+    "r03": [
+        "sota-architecture",
+        "sota-databases"
+    ],
+    "r04": [
+        "sota-network-security"
+    ],
+    "r05": [
+        "sota-shell-scripting"
+    ],
+    "r06": [
+        "sota-devsecops"
+    ],
+    "r07": [
+        "sota-llm-engineering"
+    ],
+    "r08": [
+        "sota-golang",
+        "sota-code-security"
+    ],
+    "r09": [
+        "sota-frontend-design",
+        "sota-web-frameworks"
+    ],
+    "r10": [
+        "sota-confidential-computing"
+    ],
+    "r11": [
+        "sota-ux-writing",
+        "sota-frontend-design"
+    ],
+    "r12": [
+        "sota-performance",
+        "sota-observability"
+    ],
+    "r13": [
+        "sota-testing"
+    ],
+    "r14": [
+        "sota-databases"
+    ],
+    "r15": [
+        "sota-code-security",
+        "sota-sandboxing"
+    ],
+    "r16": [
+        "sota-mobile"
+    ],
+    "r17": [
+        "sota-privacy-compliance"
+    ],
+    "r18": [
+        "sota-observability"
+    ],
+    "r19": [
+        "sota-threat-modeling"
+    ],
+    "r20": [
+        "sota-cloud-infrastructure",
+        "sota-devsecops"
+    ]
+}


### PR DESCRIPTION
Executes the roadmap's Next item: grow the eval golden sets and run the first efficacy measurement.

**Golden sets:** 12→20 routing cases, 6→13 audit cases (added harder ones: IDOR, mass-assignment, SSRF, ReDoS, path-traversal, XXE, prototype-pollution). All routing `expect` skills validated to resolve to real dirs.

**Baseline (4 arms, same base model):** with-library reads the actual repo skill files; without-library is forbidden from `skills/`; both get identical answer-stripped inputs. Scored with `evals/score.py`; raw predictions committed under `evals/results/2026-07-10/` for reproducibility.

| Arm | recall |
|---|---|
| routing — with | **1.00** |
| routing — without | **0.92** |
| audit — with | 1.00 |
| audit — without | 1.00 |

**+0.08 routing recall lift** — the without-library arm missed a must-load skill on 4/20 cases (r01 sota-testing, r02 sota-sandboxing, r03 sota-api-design, r07 sota-code-security), each exactly a cross-cutting router rule the bare model doesn't apply. That's the library's clearest measured value.

**Honest limitation reported:** the audit cases are saturated (both arms 13/13, even the 'harder' ones) — the base model already catches unambiguous single-vuln snippets, so the audit eval can't discriminate yet. Harder multi-vuln / authz cases are the documented top next-iteration action. See [BASELINE.md](evals/results/2026-07-10/BASELINE.md) for full method + caveats.

All invariants pass.