### PR TITLE
feat(evals): clean raw-API control resolves the contamination concern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ profiles/*
 .DS_Store
 *.swp
 *~
+
+# Local secrets (OPENROUTER_API_KEY etc.) — never commit
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Eval golden sets grown + efficacy baseline (2 runs) + control-validity
-  analysis** (roadmap Next). Cases expanded to 20 routing + 13 audit
-  (`evals/cases/`). Two with-vs-without runs recorded in
-  `evals/results/2026-07-10/BASELINE.md` (raw predictions + a logged re-run
-  with per-case rationales in `results/2026-07-11/`). **Routing recall lift
-  +0.08 then +0.11 (~+0.10, replicated)**, driven entirely by the router's
-  cross-cutting rules (the without-arm's logged rationales show naive
-  keyword-matching that misses exactly the rule-driven cases: r01 testing, r02
-  sandboxing, r07 code-security, r20 devsecops). **Control-validity honesty:** a
-  probe confirmed the "without-library" arm is *not* a clean library-free
-  control — the global `CLAUDE.md` routing directive and the injected skill
-  registry are ambient in every subagent (the profile's mapping tables are NOT,
-  refuting one suspected leak). The lift is therefore a **lower bound** vs a
-  routing-aware control, but it is mechanism-attributable to the router rules
-  (which live only in `skills/sota/SKILL.md`, unread by the control). Audit
-  cases saturated (both arms 13/13) — harder multi-vuln cases + an isolated
-  clean-control run are the next actions.
+- **Eval golden sets + efficacy baseline + clean isolated control** (roadmap
+  Next, done). Cases expanded to 20 routing + 13 audit + 7 harder audit
+  (`evals/cases/`). New `evals/run-clean.py` — a **raw model-API** harness
+  (OpenRouter, key from `.env`, never committed) that removes the in-session
+  contamination entirely (no HOME/`CLAUDE.md`/skill-registry) for a true
+  library-vs-nothing control. Findings (all in
+  `evals/results/2026-07-10/BASELINE.md`, raw in `results/2026-07-11/`):
+  **routing recall lift replicates ~+0.10 in the clean control** — +0.09
+  (sonnet-4.6), +0.14 (sonnet-5), +0.09 (opus-4.8), with-library 1.00 each;
+  even opus-4.8 misses the same rule-driven skills without the router (r01
+  testing, r02 sandboxing, r07 code-security, r09 web-frameworks). So the
+  in-session +0.08/+0.11 was **not** a contamination artifact — the routing
+  lift is real and attributable to the cross-cutting rules. **Audit lift =
+  +0.00, model-independent** (haiku→sonnet-4.6, original + harder cases):
+  strong models recognize textbook vulns library-or-not, so the library's audit
+  value is elsewhere (coverage/rare findings/discipline), not captured here.
+  Also: `.env` added to `.gitignore` (was untracked but unignored).
 
 ## [1.13.0] - 2026-07-10
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,15 +21,15 @@ The audit's verdict was "content is trustworthy; the gap is that nothing
 
 ## Next — grow what the prototypes started
 
-4. **Eval golden sets + baseline (2 runs)** — *done 2026-07-10/11* (33 cases;
-   [`evals/results/2026-07-10/BASELINE.md`](../evals/results/2026-07-10/BASELINE.md)):
-   replicated **~+0.10 routing recall lift** from the router's cross-cutting
-   rules (mechanism-confirmed by logged per-case rationales), with a
-   control-validity analysis (the number is a lower bound vs a routing-aware
-   control). **Live follow-through:** (a) add **harder audit cases** (the audit
-   arm saturates at 13/13); (b) run a **truly isolated control** (no sota
-   `CLAUDE.md`/registry) for a clean library-vs-nothing number; (c) average
-   several samples per arm.
+4. **Eval baseline + clean isolated control** — *done 2026-07-10/11*
+   ([`BASELINE.md`](../evals/results/2026-07-10/BASELINE.md); `evals/run-clean.py`):
+   **routing lift ~+0.10 replicates in a true library-vs-nothing raw-API
+   control** (+0.09/+0.14/+0.09 across sonnet-4.6/sonnet-5/opus-4.8) — the
+   contamination concern is resolved, the lift is real. **Audit lift +0.00,
+   model-independent** even on harder cases — strong models recognize textbook
+   vulns unaided. **Live follow-through:** the audit eval needs a different
+   target (rarer/nuanced findings, or coverage-at-scale) to measure anything;
+   average more samples for a tighter routing CI.
 5. **First 6-month accuracy sweep** comes due ~Jan 2027 (freshness window) —
    run it per the `docs/MAINTENANCE.md` runbook and bump `LAST-VERIFIED`.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -60,17 +60,28 @@ for the schema). Add cases freely; keep `expect` to unambiguous must-haves.
   treat the score as a *regression signal*, not an absolute grade. The point is
   the delta over time, not the third decimal place.
 
+## Clean isolated run (no session contamination)
+
+`score.py` scores an agent you drive by hand *inside* a Claude Code session —
+where the sota `CLAUDE.md` directive + skill registry are ambient, so the
+"without-library" arm isn't truly library-free. **`run-clean.py`** removes that:
+it makes **raw model-API calls** (OpenRouter; `OPENROUTER_API_KEY` from env or
+`.env`, never committed) with the library content pasted into the with-arm only.
+
+```sh
+python3 evals/run-clean.py --cases evals/cases/router.jsonl --model anthropic/claude-sonnet-4.6
+python3 evals/run-clean.py --cases evals/cases/audit-hard.jsonl
+```
+
 ## Recorded runs
 
-`results/<date>/` holds the raw per-arm predictions (+ rationales for the
-logged run) so scores are re-scorable and comparable over time. Writeup:
-[`results/2026-07-10/BASELINE.md`](results/2026-07-10/BASELINE.md) — two runs, a
-replicated **~+0.10 routing recall lift** attributable to the router's
-cross-cutting rules, a **control-validity analysis** (the "without-library" arm
-is a routing-aware control, not truly library-free — so the number is a lower
-bound), and the finding that the audit cases are too easy to discriminate yet
-(both arms 13/13). A clean library-vs-nothing run needs an isolated environment
-(no sota `CLAUDE.md`, no registered skills).
+`results/<date>/` holds raw per-arm predictions (+ rationales / clean-run
+outputs). Writeup: [`results/2026-07-10/BASELINE.md`](results/2026-07-10/BASELINE.md).
+Headline: a **replicated ~+0.10 routing recall lift** from the router's
+cross-cutting rules — confirmed both in-session (+0.08/+0.11) and in the clean
+control (+0.09/+0.14/+0.09 on sonnet-4.6/sonnet-5/opus-4.8); even opus-4.8
+misses the same rule-driven skills without the router. **Audit lift = +0.00,
+model-independent** — strong models recognize textbook vulns library-or-not.
 
 ## Extending
 

--- a/evals/cases/audit-hard.jsonl
+++ b/evals/cases/audit-hard.jsonl
@@ -1,0 +1,10 @@
+# Harder audit golden set — multi-vuln + subtler cases meant to DISCRIMINATE
+# (the base audit.jsonl saturates at 13/13). `expect` = every category that
+# must be flagged; a partial catch (misses one of a multi-vuln) scores <1.
+{"id": "ah01", "kind": "audit", "language": "python", "snippet": "name=request.args['name']; rows=db.execute(\"SELECT * FROM u WHERE name='\"+name+\"'\"); return \"<h1>Hello \"+name+\"</h1>\"", "expect": ["sql-injection", "xss"]}
+{"id": "ah02", "kind": "audit", "language": "python", "snippet": "u = User(**request.get_json()); u.save()  # posted JSON may set is_admin=true", "expect": ["mass-assignment"]}
+{"id": "ah03", "kind": "audit", "language": "python", "snippet": "charge_card(request.json['amount_cents'])  # amount comes from the client", "expect": ["business-logic-flaw"]}
+{"id": "ah04", "kind": "audit", "language": "python", "snippet": "reset_token = str(random.random())[2:10]", "expect": ["insecure-random"]}
+{"id": "ah05", "kind": "audit", "language": "python", "snippet": "log.info('login attempt user=' + request.args['user'])", "expect": ["log-injection"]}
+{"id": "ah06", "kind": "audit", "language": "python", "snippet": "return redirect(request.args.get('next'))", "expect": ["open-redirect"]}
+{"id": "ah07", "kind": "audit", "language": "python", "snippet": "return '<div class=bio>' + stored_user_bio + '</div>'  # bio is stored user input", "expect": ["xss"]}

--- a/evals/results/2026-07-10/BASELINE.md
+++ b/evals/results/2026-07-10/BASELINE.md
@@ -5,10 +5,12 @@ whether the "without-library" arm is a valid control (it is only partially —
 read §Control validity). Golden sets: 20 routing cases (`cases/router.jsonl`)
 + 13 audit cases (`cases/audit.jsonl`). Scored with `evals/score.py`.
 
-- **Run 1** (2026-07-10): raw predictions in this directory (`pred_*.json`).
-- **Run 2** (2026-07-11): logged re-run — per-case rationales + a context
-  self-report per arm + a hardened control. Raw in
-  [`../2026-07-11/logged-run.json`](../2026-07-11/logged-run.json).
+- **Run 1** (2026-07-10): in-session, raw predictions here (`pred_*.json`).
+- **Run 2** (2026-07-11): in-session logged re-run — per-case rationales +
+  context self-reports + hardened control (`../2026-07-11/logged-run.json`).
+- **Run 3** (2026-07-11): **clean raw-API control** via `evals/run-clean.py` —
+  no session contamination; cross-model. This is the decisive one — see §Clean
+  isolated run.
 
 ## Method
 
@@ -84,6 +86,39 @@ budget; the router errs toward over-loading. Recall is the load-bearing metric
 for "did the security-relevant skill get applied", but the precision cost is a
 genuine tradeoff, not noise.
 
+## Clean isolated run — 2026-07-11 (resolves the control-validity concern)
+
+`evals/run-clean.py` makes **raw model-API calls** (OpenRouter): no HOME, no
+`CLAUDE.md`, no skill registry, nothing sota — the with-library arm gets the
+skill content *pasted into the prompt*, the without-library arm gets only the
+task (+ the skill names / vocab needed to score). This is the true
+library-vs-nothing control the §Control-validity section said was missing. Raw
+outputs in [`../2026-07-11/`](../2026-07-11/).
+
+**Routing lift replicates across every model tier** (with-library = 1.00 each):
+
+| Model | without-library recall | lift |
+|---|---|---|
+| `claude-sonnet-4.6` | 0.91 | **+0.09** |
+| `claude-sonnet-5` | 0.86 | **+0.14** |
+| `claude-opus-4.8` | 0.91 | **+0.09** |
+
+Even **opus-4.8** (strongest) misses the *same* rule-driven skills without the
+router: **r01** `sota-testing`, **r02** `sota-sandboxing`, **r07**
+`sota-code-security`, **r09** `sota-web-frameworks` — every model, every run.
+So the in-session +0.08/+0.11 was **not** a contamination artifact: the routing
+lift is real (~+0.10, clean) and attributable to the router's cross-cutting
+rules, which no model applies reliably on its own.
+
+**Audit lift is +0.00 — model-independent.** Both arms score 1.00 on `haiku-4.5`
+*and* `sonnet-4.6`, on the original *and* the harder cases (multi-vuln, subtle
+business-logic). A current model catches textbook vulns from base knowledge,
+library or not. **Honest conclusion:** the library's audit value is *not* in
+recognizing common vulns — it's in systematic coverage at scale, rarer/nuanced
+findings, and checklist discipline, none of which this eval captures. Building
+"harder" cases didn't help; the eval needs a fundamentally different audit
+target (or the audit lift genuinely is ~0 for strong models).
+
 ## Honest limitations
 
 - **Audit eval is saturated** — both arms 13/13 across both runs, including the
@@ -91,10 +126,11 @@ genuine tradeoff, not noise.
   unambiguous single-vuln snippets the base model already catches everything.
   **Top next action:** multi-vuln snippets and subtler authz/business-logic
   cases where a systematic skill-guided audit beats recognition.
-- **Not a truly library-free control** — the directive + skill registry are
-  ambient and can't be stripped from within a configured session. A clean
-  library-vs-nothing run needs an **isolated environment** (fresh API call, no
-  sota `CLAUDE.md`, no registered skills). The number here is a lower bound.
+- **In-session control is contaminated (RESOLVED for routing)** — the runs 1/2
+  numbers are lower bounds because the directive + registry are ambient in a
+  configured session. The 2026-07-11 clean API run (§ above) removes that
+  contamination entirely and confirms the routing lift holds (~+0.10 across
+  three model tiers). Reproduce with `python3 evals/run-clean.py --cases …`.
 - **One sample per arm per run** — two runs agree in direction (~+0.10) but
   this is a directional signal, not a stable metric. Average more samples.
 - **`expect` sets are minimal must-load judgment calls** — precision numbers
@@ -102,10 +138,15 @@ genuine tradeoff, not noise.
 
 ## Takeaway
 
-A **replicated, mechanism-confirmed routing recall lift (~+0.10)** attributable
-to the router's cross-cutting rules — even against a control that already knows
-the skills exist and was told to route. The audit dimension can't measure
-anything until it gets harder cases. The number is a lower bound vs a
-routing-aware control; a truly clean library-vs-nothing measurement needs an
-isolated run outside this session's config. First real efficacy data point —
-value is the delta as golden sets grow and runs are averaged.
+A **replicated, clean, mechanism-confirmed routing recall lift (~+0.10)** — it
+holds in-session (+0.08/+0.11) *and* in a fully isolated raw-API control
+(+0.09/+0.14/+0.09 on sonnet-4.6/sonnet-5/opus-4.8), driven by the router's
+cross-cutting rules that no model applies reliably alone. That settles the
+contamination question: the lift is real, not a config artifact.
+
+The **audit dimension shows no measurable lift (+0.00), model-independent** even
+on harder cases — a genuine, honest finding: strong models don't need the
+library to recognize textbook vulnerabilities. The library's audit value lives
+elsewhere (coverage at scale, rarer findings, discipline) and needs a different
+eval to measure — or it may simply be ~0 for capable models on this task shape.
+Both are honest data points; the routing number is the one that stands up.

--- a/evals/results/2026-07-11/clean-audit-hard-haiku.json
+++ b/evals/results/2026-07-11/clean-audit-hard-haiku.json
@@ -1,0 +1,58 @@
+{
+ "without-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "ah01": [
+    "sql-injection",
+    "xss"
+   ],
+   "ah02": [
+    "mass-assignment"
+   ],
+   "ah03": [
+    "business-logic-flaw"
+   ],
+   "ah04": [
+    "insecure-random"
+   ],
+   "ah05": [
+    "log-injection"
+   ],
+   "ah06": [
+    "open-redirect"
+   ],
+   "ah07": [
+    "xss"
+   ]
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "ah01": [
+    "sql-injection",
+    "xss"
+   ],
+   "ah02": [
+    "mass-assignment"
+   ],
+   "ah03": [
+    "business-logic-flaw"
+   ],
+   "ah04": [
+    "insecure-random"
+   ],
+   "ah05": [
+    "log-injection"
+   ],
+   "ah06": [
+    "open-redirect"
+   ],
+   "ah07": [
+    "xss"
+   ]
+  }
+ }
+}

--- a/evals/results/2026-07-11/clean-audit-hard.json
+++ b/evals/results/2026-07-11/clean-audit-hard.json
@@ -1,0 +1,58 @@
+{
+ "without-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "ah01": [
+    "sql-injection",
+    "xss"
+   ],
+   "ah02": [
+    "mass-assignment"
+   ],
+   "ah03": [
+    "business-logic-flaw"
+   ],
+   "ah04": [
+    "insecure-random"
+   ],
+   "ah05": [
+    "log-injection"
+   ],
+   "ah06": [
+    "open-redirect"
+   ],
+   "ah07": [
+    "xss"
+   ]
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "ah01": [
+    "sql-injection",
+    "xss"
+   ],
+   "ah02": [
+    "mass-assignment"
+   ],
+   "ah03": [
+    "business-logic-flaw"
+   ],
+   "ah04": [
+    "insecure-random"
+   ],
+   "ah05": [
+    "log-injection"
+   ],
+   "ah06": [
+    "open-redirect"
+   ],
+   "ah07": [
+    "xss"
+   ]
+  }
+ }
+}

--- a/evals/results/2026-07-11/clean-audit.json
+++ b/evals/results/2026-07-11/clean-audit.json
@@ -1,0 +1,92 @@
+{
+ "without-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "a01": [
+    "sql-injection"
+   ],
+   "a02": [
+    "command-injection"
+   ],
+   "a03": [
+    "weak-password-hashing"
+   ],
+   "a04": [
+    "tls-verification-disabled"
+   ],
+   "a05": [
+    "unsafe-deserialization"
+   ],
+   "a06": [
+    "non-constant-time-comparison"
+   ],
+   "a07": [
+    "idor"
+   ],
+   "a08": [
+    "mass-assignment"
+   ],
+   "a09": [
+    "ssrf"
+   ],
+   "a10": [
+    "redos"
+   ],
+   "a11": [
+    "path-traversal"
+   ],
+   "a12": [
+    "xxe"
+   ],
+   "a13": [
+    "prototype-pollution"
+   ]
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "a01": [
+    "sql-injection"
+   ],
+   "a02": [
+    "command-injection"
+   ],
+   "a03": [
+    "weak-password-hashing"
+   ],
+   "a04": [
+    "tls-verification-disabled"
+   ],
+   "a05": [
+    "unsafe-deserialization"
+   ],
+   "a06": [
+    "non-constant-time-comparison"
+   ],
+   "a07": [
+    "idor"
+   ],
+   "a08": [
+    "mass-assignment"
+   ],
+   "a09": [
+    "ssrf"
+   ],
+   "a10": [
+    "redos"
+   ],
+   "a11": [
+    "path-traversal"
+   ],
+   "a12": [
+    "xxe"
+   ],
+   "a13": [
+    "prototype-pollution"
+   ]
+  }
+ }
+}

--- a/evals/results/2026-07-11/clean-routing-anthropic-claude-opus-4-8.json
+++ b/evals/results/2026-07-11/clean-routing-anthropic-claude-opus-4-8.json
@@ -1,0 +1,215 @@
+{
+ "without-library": {
+  "recall": 0.9083333333333332,
+  "misses": {
+   "r01": [
+    "sota-testing"
+   ],
+   "r02": [
+    "sota-sandboxing"
+   ],
+   "r07": [
+    "sota-code-security"
+   ],
+   "r09": [
+    "sota-web-frameworks"
+   ]
+  },
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-code-security",
+    "sota-web-frameworks"
+   ],
+   "r02": [
+    "sota-kubernetes",
+    "sota-cloud-infrastructure",
+    "sota-code-security",
+    "sota-devsecops"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-identity-access"
+   ],
+   "r04": [
+    "sota-network-security"
+   ],
+   "r05": [
+    "sota-shell-scripting",
+    "sota-cli-ux"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-secrets-management",
+    "sota-code-security"
+   ],
+   "r07": [
+    "sota-llm-engineering"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-code-security"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-javascript-typescript"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure"
+   ],
+   "r11": [
+    "sota-ux-writing",
+    "sota-copywriting",
+    "sota-frontend-design"
+   ],
+   "r12": [
+    "sota-performance",
+    "sota-observability"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases",
+    "sota-data-engineering"
+   ],
+   "r15": [
+    "sota-llm-engineering",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-threat-modeling"
+   ],
+   "r16": [
+    "sota-mobile",
+    "sota-async-concurrency"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-security-compliance"
+   ],
+   "r18": [
+    "sota-observability"
+   ],
+   "r19": [
+    "sota-threat-modeling"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-identity-access",
+    "sota-devsecops"
+   ]
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-testing"
+   ],
+   "r02": [
+    "sota-devsecops",
+    "sota-kubernetes",
+    "sota-sandboxing",
+    "sota-network-security",
+    "sota-shell-scripting"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-identity-access",
+    "sota-threat-modeling",
+    "sota-privacy-compliance",
+    "sota-testing"
+   ],
+   "r04": [
+    "sota-network-security"
+   ],
+   "r05": [
+    "sota-shell-scripting"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-secrets-management",
+    "sota-shell-scripting"
+   ],
+   "r07": [
+    "sota-llm-engineering",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-databases",
+    "sota-testing"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-api-design",
+    "sota-code-security",
+    "sota-async-concurrency",
+    "sota-shell-scripting",
+    "sota-testing"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-web-frameworks",
+    "sota-javascript-typescript",
+    "sota-ux-writing"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure",
+    "sota-secrets-management"
+   ],
+   "r11": [
+    "sota-ux-writing",
+    "sota-frontend-design"
+   ],
+   "r12": [
+    "sota-databases",
+    "sota-performance",
+    "sota-observability"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases"
+   ],
+   "r15": [
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-llm-engineering"
+   ],
+   "r16": [
+    "sota-mobile",
+    "sota-testing"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-code-security"
+   ],
+   "r18": [
+    "sota-observability",
+    "sota-architecture"
+   ],
+   "r19": [
+    "sota-threat-modeling",
+    "sota-code-security"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-devsecops",
+    "sota-network-security",
+    "sota-secrets-management"
+   ]
+  }
+ }
+}

--- a/evals/results/2026-07-11/clean-routing-anthropic-claude-sonnet-5.json
+++ b/evals/results/2026-07-11/clean-routing-anthropic-claude-sonnet-5.json
@@ -1,0 +1,197 @@
+{
+ "without-library": {
+  "recall": 0.8583333333333332,
+  "misses": {
+   "r01": [
+    "sota-testing"
+   ],
+   "r02": [
+    "sota-sandboxing"
+   ],
+   "r07": [
+    "sota-code-security"
+   ],
+   "r09": [
+    "sota-web-frameworks"
+   ],
+   "r15": [
+    "sota-code-security"
+   ],
+   "r20": [
+    "sota-devsecops"
+   ]
+  },
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-code-security"
+   ],
+   "r02": [
+    "sota-kubernetes",
+    "sota-code-security",
+    "sota-devsecops"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases"
+   ],
+   "r04": [
+    "sota-network-security"
+   ],
+   "r05": [
+    "sota-shell-scripting"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-secrets-management",
+    "sota-code-security"
+   ],
+   "r07": [
+    "sota-llm-engineering"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-code-security"
+   ],
+   "r09": [
+    "sota-frontend-design"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure"
+   ],
+   "r11": [
+    "sota-ux-writing"
+   ],
+   "r12": [
+    "sota-performance",
+    "sota-observability"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases"
+   ],
+   "r15": [
+    "sota-llm-engineering",
+    "sota-sandboxing",
+    "sota-threat-modeling"
+   ],
+   "r16": [
+    "sota-mobile"
+   ],
+   "r17": [
+    "sota-privacy-compliance"
+   ],
+   "r18": [
+    "sota-observability"
+   ],
+   "r19": [
+    "sota-threat-modeling"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-identity-access"
+   ]
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-testing"
+   ],
+   "r02": [
+    "sota-kubernetes",
+    "sota-sandboxing",
+    "sota-network-security",
+    "sota-devsecops",
+    "sota-shell-scripting"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-code-security",
+    "sota-testing"
+   ],
+   "r04": [
+    "sota-network-security"
+   ],
+   "r05": [
+    "sota-shell-scripting",
+    "sota-testing"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-secrets-management"
+   ],
+   "r07": [
+    "sota-llm-engineering",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-databases",
+    "sota-testing"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-api-design",
+    "sota-code-security",
+    "sota-testing"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-web-frameworks",
+    "sota-javascript-typescript"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure"
+   ],
+   "r11": [
+    "sota-ux-writing"
+   ],
+   "r12": [
+    "sota-databases",
+    "sota-performance",
+    "sota-observability"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases"
+   ],
+   "r15": [
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-llm-engineering"
+   ],
+   "r16": [
+    "sota-mobile"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-api-design"
+   ],
+   "r18": [
+    "sota-observability"
+   ],
+   "r19": [
+    "sota-threat-modeling"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-devsecops"
+   ]
+  }
+ }
+}

--- a/evals/results/2026-07-11/clean-routing-sonnet46.json
+++ b/evals/results/2026-07-11/clean-routing-sonnet46.json
@@ -1,0 +1,234 @@
+{
+ "without-library": {
+  "recall": 0.9083333333333332,
+  "misses": {
+   "r01": [
+    "sota-testing"
+   ],
+   "r02": [
+    "sota-sandboxing"
+   ],
+   "r07": [
+    "sota-code-security"
+   ],
+   "r09": [
+    "sota-web-frameworks"
+   ]
+  },
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-web-frameworks",
+    "sota-code-security"
+   ],
+   "r02": [
+    "sota-kubernetes",
+    "sota-devsecops",
+    "sota-code-security"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-identity-access"
+   ],
+   "r04": [
+    "sota-network-security",
+    "sota-security-compliance"
+   ],
+   "r05": [
+    "sota-shell-scripting",
+    "sota-cli-ux"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-identity-access",
+    "sota-secrets-management",
+    "sota-code-security"
+   ],
+   "r07": [
+    "sota-llm-engineering",
+    "sota-data-engineering",
+    "sota-api-design"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-code-security",
+    "sota-web-frameworks"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-javascript-typescript",
+    "sota-ux-writing"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure",
+    "sota-security-compliance"
+   ],
+   "r11": [
+    "sota-ux-writing",
+    "sota-copywriting"
+   ],
+   "r12": [
+    "sota-performance",
+    "sota-observability",
+    "sota-databases"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases",
+    "sota-testing"
+   ],
+   "r15": [
+    "sota-llm-engineering",
+    "sota-sandboxing",
+    "sota-code-security",
+    "sota-threat-modeling"
+   ],
+   "r16": [
+    "sota-mobile",
+    "sota-async-concurrency",
+    "sota-databases"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-security-compliance"
+   ],
+   "r18": [
+    "sota-observability",
+    "sota-cloud-infrastructure"
+   ],
+   "r19": [
+    "sota-threat-modeling",
+    "sota-security-compliance",
+    "sota-code-security"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-identity-access",
+    "sota-devsecops"
+   ]
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-testing"
+   ],
+   "r02": [
+    "sota-kubernetes",
+    "sota-sandboxing",
+    "sota-devsecops",
+    "sota-network-security",
+    "sota-shell-scripting"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-code-security",
+    "sota-identity-access",
+    "sota-threat-modeling",
+    "sota-testing"
+   ],
+   "r04": [
+    "sota-network-security"
+   ],
+   "r05": [
+    "sota-shell-scripting",
+    "sota-code-security"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-secrets-management",
+    "sota-identity-access"
+   ],
+   "r07": [
+    "sota-llm-engineering",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-databases",
+    "sota-testing"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-code-security",
+    "sota-api-design",
+    "sota-secrets-management",
+    "sota-threat-modeling"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-web-frameworks",
+    "sota-javascript-typescript",
+    "sota-ux-writing"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure",
+    "sota-secrets-management",
+    "sota-identity-access"
+   ],
+   "r11": [
+    "sota-ux-writing",
+    "sota-frontend-design"
+   ],
+   "r12": [
+    "sota-performance",
+    "sota-databases",
+    "sota-observability",
+    "sota-async-concurrency"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases"
+   ],
+   "r15": [
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-llm-engineering",
+    "sota-threat-modeling"
+   ],
+   "r16": [
+    "sota-mobile",
+    "sota-async-concurrency",
+    "sota-testing"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-databases",
+    "sota-code-security"
+   ],
+   "r18": [
+    "sota-observability",
+    "sota-architecture"
+   ],
+   "r19": [
+    "sota-threat-modeling",
+    "sota-code-security",
+    "sota-identity-access",
+    "sota-secrets-management",
+    "sota-api-design"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-identity-access",
+    "sota-devsecops",
+    "sota-network-security",
+    "sota-shell-scripting"
+   ]
+  }
+ }
+}

--- a/evals/run-clean.py
+++ b/evals/run-clean.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Clean, isolated with-vs-without efficacy run via a direct model API.
+
+Unlike the in-session eval (where the sota CLAUDE.md directive and the skill
+registry are ambient in every subagent — see results/2026-07-10/BASELINE.md
+§Control validity), this makes RAW API calls: no HOME, no CLAUDE.md, no skill
+registry — just model + prompt. So the "without-library" arm is a true
+library-vs-nothing control.
+
+- without-library arm: the task only (+ the category vocabulary / the 40 skill
+  names, which are needed to score, but NOT the router rules or skill guidance).
+- with-library arm: the same task PLUS the actual repo skill content
+  (skills/sota/SKILL.md for routing; skills/sota-code-security/rules/*.md for
+  audit) pasted into the prompt.
+
+Auth: OPENROUTER_API_KEY (read from env or ./.env). Never printed or committed.
+
+Usage:
+  python3 evals/run-clean.py --cases evals/cases/audit-hard.jsonl
+  python3 evals/run-clean.py --cases evals/cases/router.jsonl --model anthropic/claude-sonnet-4.6
+Exit 0 always (it reports; scoring is the output, not a gate).
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.request
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+VOCAB = [
+    "sql-injection", "command-injection", "weak-password-hashing", "tls-verification-disabled",
+    "unsafe-deserialization", "non-constant-time-comparison", "idor", "mass-assignment", "ssrf",
+    "redos", "path-traversal", "xxe", "prototype-pollution", "xss", "csrf", "open-redirect",
+    "insecure-random", "missing-authentication", "log-injection", "hardcoded-secret",
+    "business-logic-flaw",
+]
+
+
+def load_env_key():
+    k = os.environ.get("OPENROUTER_API_KEY")
+    if k:
+        return k
+    envp = os.path.join(ROOT, ".env")
+    if os.path.exists(envp):
+        for line in open(envp, encoding="utf-8"):
+            line = line.strip()
+            if line.startswith("OPENROUTER_API_KEY="):
+                return line.split("=", 1)[1].strip().strip("'\"")
+    sys.exit("OPENROUTER_API_KEY not found in env or ./.env")
+
+
+def load_cases(path):
+    out = []
+    for line in open(path, encoding="utf-8"):
+        line = line.strip()
+        if line and not line.startswith("#"):
+            out.append(json.loads(line))
+    return out
+
+
+def read(*parts):
+    return open(os.path.join(ROOT, *parts), encoding="utf-8").read()
+
+
+def audit_library_context():
+    import glob
+    files = sorted(glob.glob(os.path.join(ROOT, "skills/sota-code-security/rules/*.md")))
+    return "\n\n".join(open(f, encoding="utf-8").read() for f in files)
+
+
+def build_prompt(cases, kind, with_lib):
+    stripped = [{k: v for k, v in c.items() if k != "expect"} for c in cases]
+    tasks = json.dumps(stripped, indent=1)
+    if kind == "audit":
+        vocab = ", ".join(VOCAB)
+        head = (f"You are a security code reviewer. For each snippet, list the vulnerability "
+                f"category slugs that apply, using ONLY this vocabulary: {vocab}.")
+        lib = (f"\n\nApply the following security guidance:\n\n{audit_library_context()}\n\n"
+               if with_lib else "\n\nUse only your own security knowledge.\n\n")
+    else:
+        names = ", ".join(sorted(os.path.basename(d) for d in _skill_dirs()))
+        head = ("You are routing an engineering task to skills. For each prompt, list the "
+                f"sota-* skill names that should load. Available skills: {names}.")
+        lib = (f"\n\nApply this router (its routing table AND cross-cutting rules):\n\n"
+               f"{read('skills/sota/SKILL.md')}\n\n" if with_lib
+               else "\n\nUse only the skill names above and your own judgment.\n\n")
+    return (f"{head}{lib}Cases:\n{tasks}\n\n"
+            'Output ONLY a JSON object mapping each case id to a list of slugs/skill-names, '
+            'e.g. {"x1": ["sql-injection"]}. No prose, no code fence.')
+
+
+def _skill_dirs():
+    import glob
+    return [d for d in glob.glob(os.path.join(ROOT, "skills/sota-*")) if os.path.isdir(d)]
+
+
+def call(model, key, prompt):
+    body = json.dumps({"model": model, "messages": [{"role": "user", "content": prompt}],
+                       "temperature": 0}).encode()
+    req = urllib.request.Request("https://openrouter.ai/api/v1/chat/completions", data=body,
+                                 headers={"Authorization": f"Bearer {key}",
+                                          "Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=180) as r:
+        txt = json.load(r)["choices"][0]["message"]["content"]
+    s, e = txt.find("{"), txt.rfind("}")
+    if s < 0 or e < 0:
+        sys.exit(f"model did not return JSON:\n{txt[:400]}")
+    return json.loads(txt[s:e + 1])
+
+
+def score(cases, preds):
+    tot, misses = 0.0, {}
+    for c in cases:
+        exp = set(c["expect"])
+        got = set(preds.get(c["id"], []))
+        r = len(exp & got) / len(exp)
+        tot += r
+        if r < 1.0:
+            misses[c["id"]] = sorted(exp - got)
+    return tot / len(cases), misses
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cases", required=True)
+    ap.add_argument("--model", default="anthropic/claude-sonnet-4.6")
+    ap.add_argument("--out", default=None)
+    a = ap.parse_args()
+    key = load_env_key()
+    cases = load_cases(a.cases)
+    kind = cases[0].get("kind", "audit")
+    print(f"model={a.model}  kind={kind}  cases={len(cases)}  (clean API run, no sota config)\n")
+    result = {}
+    for with_lib in (False, True):
+        arm = "with-library" if with_lib else "without-library"
+        preds = call(a.model, key, build_prompt(cases, kind, with_lib))
+        rec, misses = score(cases, preds)
+        result[arm] = {"recall": rec, "misses": misses, "predictions": preds}
+        print(f"{arm:16s} recall={rec:.2f}"
+              + (f"  misses: {misses}" if misses else "  (no misses)"))
+    lift = result["with-library"]["recall"] - result["without-library"]["recall"]
+    print(f"\nLIFT (with − without) = {lift:+.2f}")
+    if a.out:
+        json.dump(result, open(a.out, "w"), indent=1)
+        print(f"saved {a.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Answers the question you raised: **is the routing lift real, or is the auto-routing config feeding the control the answers?**

**New ** makes **raw OpenRouter API calls** — no HOME, no `CLAUDE.md`, no skill registry, nothing sota. The with-library arm gets the skill content pasted in; the without-library arm gets only the task. This is the true library-vs-nothing control that couldn't exist inside a configured Claude Code session. (`OPENROUTER_API_KEY` from `.env`, never committed; gitleaks clean; `.env` now gitignored.)

**Routing lift replicates in the clean control — across every model tier** (with-library = 1.00 each):

| model | without-library | lift |
|---|---|---|
| sonnet-4.6 | 0.91 | **+0.09** |
| sonnet-5 | 0.86 | **+0.14** |
| opus-4.8 | 0.91 | **+0.09** |

Even **opus-4.8** misses the same rule-driven skills without the router (r01 testing, r02 sandboxing, r07 code-security, r09 web-frameworks). So the in-session +0.08/+0.11 was **not** contamination — the routing lift is real (~+0.10) and attributable to the router's cross-cutting rules, which no model applies reliably alone.

**Audit lift = +0.00, model-independent** (haiku→sonnet-4.6, original *and* 7 harder multi-vuln/business-logic cases): strong models recognize textbook vulns library-or-not. Honest conclusion recorded — the library's audit value is elsewhere (coverage-at-scale / rarer findings / discipline), not measured by this eval.

Raw outputs in `results/2026-07-11/`; full writeup in `results/2026-07-10/BASELINE.md` (§Clean isolated run). All invariants pass.