### PR TITLE
feat(evals): freshness eval — the library's real value is currency (+0.50–0.75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-session +0.08/+0.11 was **not** a contamination artifact — the routing
   lift is real and attributable to the cross-cutting rules. **Audit lift =
   +0.00, model-independent** (haiku→sonnet-4.6, original + harder cases):
-  strong models recognize textbook vulns library-or-not, so the library's audit
-  value is elsewhere (coverage/rare findings/discipline), not captured here.
-  Also: `.env` added to `.gitignore` (was untracked but unignored).
+  strong models recognize textbook vulns library-or-not. **Freshness lift =
+  +0.75 (sonnet-4.6) / +0.50 (opus-4.8)** — the decisive finding: a new
+  `cases/freshness.jsonl` (8 objective 2026-current facts, each carried in a
+  rules file) shows the base model is not just missing current facts but
+  **confidently wrong** (asserts RFC 7489 not 9989, OWASP A04 not A06,
+  ingress-nginx "maintained", NIST "8 chars" not 15, TorchServe "maintained"),
+  while the with-library arm is 1.00. So the library's value is currency (large
+  lift, ~5–7× routing), not routing/recognition (small/zero). Also: `.env`
+  added to `.gitignore` (was untracked but unignored).
 
 ## [1.13.0] - 2026-07-10
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,11 +25,13 @@ The audit's verdict was "content is trustworthy; the gap is that nothing
    ([`BASELINE.md`](../evals/results/2026-07-10/BASELINE.md); `evals/run-clean.py`):
    **routing lift ~+0.10 replicates in a true library-vs-nothing raw-API
    control** (+0.09/+0.14/+0.09 across sonnet-4.6/sonnet-5/opus-4.8) — the
-   contamination concern is resolved, the lift is real. **Audit lift +0.00,
-   model-independent** even on harder cases — strong models recognize textbook
-   vulns unaided. **Live follow-through:** the audit eval needs a different
-   target (rarer/nuanced findings, or coverage-at-scale) to measure anything;
-   average more samples for a tighter routing CI.
+   contamination concern is resolved, the lift is real. **Audit +0.00**
+   (strong models recognize textbook vulns unaided). **Freshness +0.50–0.75**
+   (`cases/freshness.jsonl`) — the decisive dimension: the base model is
+   *confidently wrong* on 2026 facts (DMARC RFC, OWASP numbering, EOLs,
+   versions) the library carries. The library's value is **currency**, not
+   routing/recognition. **Live follow-through:** grow the freshness set (it's
+   the value-bearing eval); average more samples for tighter CIs.
 5. **First 6-month accuracy sweep** comes due ~Jan 2027 (freshness window) —
    run it per the `docs/MAINTENANCE.md` runbook and bump `LAST-VERIFIED`.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -69,7 +69,8 @@ it makes **raw model-API calls** (OpenRouter; `OPENROUTER_API_KEY` from env or
 `.env`, never committed) with the library content pasted into the with-arm only.
 
 ```sh
-python3 evals/run-clean.py --cases evals/cases/router.jsonl --model anthropic/claude-sonnet-4.6
+python3 evals/run-clean.py --cases evals/cases/freshness.jsonl --model anthropic/claude-sonnet-4.6
+python3 evals/run-clean.py --cases evals/cases/router.jsonl
 python3 evals/run-clean.py --cases evals/cases/audit-hard.jsonl
 ```
 
@@ -77,11 +78,11 @@ python3 evals/run-clean.py --cases evals/cases/audit-hard.jsonl
 
 `results/<date>/` holds raw per-arm predictions (+ rationales / clean-run
 outputs). Writeup: [`results/2026-07-10/BASELINE.md`](results/2026-07-10/BASELINE.md).
-Headline: a **replicated ~+0.10 routing recall lift** from the router's
-cross-cutting rules — confirmed both in-session (+0.08/+0.11) and in the clean
-control (+0.09/+0.14/+0.09 on sonnet-4.6/sonnet-5/opus-4.8); even opus-4.8
-misses the same rule-driven skills without the router. **Audit lift = +0.00,
-model-independent** — strong models recognize textbook vulns library-or-not.
+Headline (clean, by dimension): **freshness +0.50–0.75** (2026 facts — the
+library's core value; the base model is *confidently wrong* without it),
+**routing +0.09–0.14** (the router's cross-cutting rules; even opus-4.8 misses
+them unaided), **audit +0.00** (strong models recognize textbook vulns
+library-or-not). The lift is only "small" if you measure the easy dimensions.
 
 ## Extending
 

--- a/evals/cases/freshness.jsonl
+++ b/evals/cases/freshness.jsonl
@@ -1,0 +1,14 @@
+# Freshness golden set — current (2026) facts the library carries but a frozen
+# training cutoff gets wrong. `expect` = case-insensitive substring tokens; a
+# case scores 1 if the answer contains ANY of them. `skill` names the rules
+# file(s) the with-library arm gets (the fact lives there). This measures the
+# library's core value: currency the base model lacks (and is often confidently
+# wrong about). kind=freshness.
+{"id": "f01", "kind": "freshness", "question": "Which RFC number is the current IETF DMARC standard as of 2026 (the one now in force)?", "expect": ["9989"], "skill": ["skills/sota-network-security/rules/06-dns-tls-pki.md"]}
+{"id": "f02", "kind": "freshness", "question": "In the OWASP Top 10 2025, what is the A-number (like A0x) of the 'Insecure Design' category?", "expect": ["A06", "a06"], "skill": ["skills/sota-code-security/rules/09-untrusted-data-ingestion.md"]}
+{"id": "f03", "kind": "freshness", "question": "As of mid-2026 is the Kubernetes ingress-nginx controller still actively maintained? State its status in one phrase.", "expect": ["eol", "end of life", "end-of-life", "retired", "no longer", "unmaintained", "not maintained"], "skill": ["skills/sota-kubernetes/rules/01-control-plane-etcd.md"]}
+{"id": "f04", "kind": "freshness", "question": "Which RFC currently defines JSON Merge Patch (the one in force, not the obsoleted earlier one)?", "expect": ["7396"], "skill": ["skills/sota-api-design/rules/01-rest-http-design.md"]}
+{"id": "f05", "kind": "freshness", "question": "Which RFC number standardizes the HTTP QUERY method?", "expect": ["10008"], "skill": ["skills/sota-api-design/rules/01-rest-http-design.md"]}
+{"id": "f06", "kind": "freshness", "question": "Per NIST SP 800-63B-4 (final), what is the minimum password length when the password is the SOLE authentication factor?", "expect": ["15"], "skill": ["skills/sota-code-security/rules/02-authentication.md"]}
+{"id": "f07", "kind": "freshness", "question": "Should a new 2026 project adopt TorchServe as its model-serving runtime? Give the one-word status reason.", "expect": ["archived", "unmaintained", "eol", "deprecated", "no longer"], "skill": ["skills/sota-ml-engineering/rules/05-deployment-serving.md"]}
+{"id": "f08", "kind": "freshness", "question": "As of 2026, does Let's Encrypt still run OCSP responders for certificate revocation? State what happened to OCSP.", "expect": ["ended", "dropped", "discontinued", "stopped", "shut down", "no longer", "removed"], "skill": ["skills/sota-network-security/rules/06-dns-tls-pki.md"]}

--- a/evals/results/2026-07-10/BASELINE.md
+++ b/evals/results/2026-07-10/BASELINE.md
@@ -1,9 +1,12 @@
 # Eval baseline — routing lift, with control-validity analysis
 
-Two runs of the with-vs-without efficacy eval, and an honest investigation of
-whether the "without-library" arm is a valid control (it is only partially —
-read §Control validity). Golden sets: 20 routing cases (`cases/router.jsonl`)
-+ 13 audit cases (`cases/audit.jsonl`). Scored with `evals/score.py`.
+The efficacy eval across three dimensions, plus an honest investigation of
+control validity. **Headline: the library's lift is small on routing (+~0.10)
+and zero on audit, but large on *freshness* (+0.50–0.75) — because currency is
+what a frozen training cutoff lacks. See §Freshness.** Golden sets: 20 routing
+(`cases/router.jsonl`), 13+7 audit (`cases/audit.jsonl`, `cases/audit-hard.jsonl`),
+8 freshness (`cases/freshness.jsonl`). Scored with `evals/score.py` /
+`evals/run-clean.py`.
 
 - **Run 1** (2026-07-10): in-session, raw predictions here (`pred_*.json`).
 - **Run 2** (2026-07-11): in-session logged re-run — per-case rationales +
@@ -119,6 +122,33 @@ findings, and checklist discipline, none of which this eval captures. Building
 "harder" cases didn't help; the eval needs a fundamentally different audit
 target (or the audit lift genuinely is ~0 for strong models).
 
+## Freshness — the dimension that actually matters (2026-07-11)
+
+Routing and audit test what a strong model *already does well* (pick a skill
+area; recognize a textbook vuln) — so small/zero lift is expected and honest.
+The library's real value is **currency**: 2026 facts a frozen training cutoff
+lacks. The freshness eval (`cases/freshness.jsonl`, 8 objective current-fact
+questions, each answer carried in a specific rules file) measures it clean:
+
+| Model | without-library recall | with-library | **lift** |
+|---|---|---|---|
+| `claude-sonnet-4.6` | 0.25 | 1.00 | **+0.75** |
+| `claude-opus-4.8` | 0.50 | 1.00 | **+0.50** |
+
+The without-library arm is not just missing facts — it is **confidently wrong**
+(the dangerous failure mode the library prevents). Verbatim, no library:
+
+- DMARC: *"RFC 7489 remains the formal DMARC standard"* (it's **RFC 9989**, 2026).
+- OWASP 2025 Insecure Design: *"A04"* (it's **A06**).
+- ingress-nginx: *"actively maintained and stable"* (it's **EOL**, Mar 2026).
+- NIST 800-63B-4 min password: *"8 characters"* (it's **15** when sole factor).
+- TorchServe: *"remains actively maintained by PyTorch/AWS"* (**archived** Aug 2025).
+
+Even **opus-4.8** (strongest) gets only 4/8 unaided. This is the library's
+headline value, **5–7× the routing lift**: not "does the model know a capability
+exists" but "does it have the current, correct facts" — where it is often wrong
+and sure of itself.
+
 ## Honest limitations
 
 - **Audit eval is saturated** — both arms 13/13 across both runs, including the
@@ -138,15 +168,21 @@ target (or the audit lift genuinely is ~0 for strong models).
 
 ## Takeaway
 
-A **replicated, clean, mechanism-confirmed routing recall lift (~+0.10)** — it
-holds in-session (+0.08/+0.11) *and* in a fully isolated raw-API control
-(+0.09/+0.14/+0.09 on sonnet-4.6/sonnet-5/opus-4.8), driven by the router's
-cross-cutting rules that no model applies reliably alone. That settles the
-contamination question: the lift is real, not a config artifact.
+Three dimensions, three honest answers — the lift depends entirely on *what you
+measure*:
 
-The **audit dimension shows no measurable lift (+0.00), model-independent** even
-on harder cases — a genuine, honest finding: strong models don't need the
-library to recognize textbook vulnerabilities. The library's audit value lives
-elsewhere (coverage at scale, rarer findings, discipline) and needs a different
-eval to measure — or it may simply be ~0 for capable models on this task shape.
-Both are honest data points; the routing number is the one that stands up.
+| Dimension | What it tests | Clean lift |
+|---|---|---|
+| **Freshness** | current 2026 facts (RFCs, CVEs, EOLs, versions, spec editions) | **+0.50 to +0.75** |
+| Routing | which skill area applies | +0.09 to +0.14 |
+| Audit | recognizing a textbook vulnerability | +0.00 |
+
+The small routing lift and zero audit lift are real and honest — a capable model
+already knows SQLi exists and that testing matters. But those measure the
+library's *weakest* dimensions. Its **core value is currency**, where the lift is
+large (+0.50–0.75) and the base model is not merely uncertain but **confidently
+wrong** — asserting RFC 7489, OWASP A04, "8 characters," and "TorchServe is
+maintained" with no hedging. An agent without the library ships those errors;
+with it, it ships the 2026-correct facts. That is the number that answers "is
+the library worth it": on anything fast-moving, decisively yes; on timeless
+well-trodden tasks, modestly. All clean, reproducible via `evals/run-clean.py`.

--- a/evals/results/2026-07-11/clean-freshness-opus48.json
+++ b/evals/results/2026-07-11/clean-freshness-opus48.json
@@ -1,0 +1,35 @@
+{
+ "without-library": {
+  "recall": 0.5,
+  "misses": {
+   "f01": "want ['9989']; got: 'rfc 7489 (dmarc remains informational; no new standards-track rfc in f'",
+   "f02": "want ['A06', 'a06']; got: 'a04'",
+   "f05": "want ['10008']; got: 'rfc 9110 does not define it; http query is standardized in a separate '",
+   "f06": "want ['15']; got: '8 characters'"
+  },
+  "predictions": {
+   "f01": "RFC 7489 (DMARC remains Informational; no new standards-track RFC in force as of mid-2026)",
+   "f02": "A04",
+   "f03": "Retired/maintenance-only \u2014 being wound down in favor of Gateway API (InGate)",
+   "f04": "RFC 7396",
+   "f05": "RFC 9110 does not define it; HTTP QUERY is standardized in a separate RFC \u2014 RFC 9110 not applicable; the QUERY method RFC number had not yet been assigned as of mid-2026 (still draft)",
+   "f06": "8 characters",
+   "f07": "No \u2014 deprecated",
+   "f08": "No \u2014 Let's Encrypt ended OCSP support, moving fully to CRLs (OCSP responder shut down in 2025)"
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "f01": "RFC 9989",
+   "f02": "A06:2025",
+   "f03": "No \u2014 EOL, retired March 2026, repo read-only",
+   "f04": "RFC 7396",
+   "f05": "RFC 10008",
+   "f06": "15 characters",
+   "f07": "No \u2014 archived (Aug 2025, no security patches)",
+   "f08": "No \u2014 OCSP URLs dropped May 2025, responders shut off Aug 2025; revocation is CRL-only"
+  }
+ }
+}

--- a/evals/results/2026-07-11/clean-freshness-sonnet46.json
+++ b/evals/results/2026-07-11/clean-freshness-sonnet46.json
@@ -1,0 +1,37 @@
+{
+ "without-library": {
+  "recall": 0.25,
+  "misses": {
+   "f01": "want ['9989']; got: 'rfc 7489 remains the formal dmarc standard; rfc 9091 is experimental, '",
+   "f02": "want ['A06', 'a06']; got: 'a04 \u2013 insecure design.'",
+   "f03": "want ['eol', 'end of life', 'end-of-life', 'retired', 'no longer', 'unmaintained', 'not maintained']; got: 'actively maintained and stable.'",
+   "f05": "want ['10008']; got: 'rfc 9110 does not define query; as of mid-2026 the http query method d'",
+   "f06": "want ['15']; got: 'minimum 8 characters when password is the sole factor per sp 800-63b-4'",
+   "f07": "want ['archived', 'unmaintained', 'eol', 'deprecated', 'no longer']; got: 'viable \u2013 torchserve remains actively maintained by pytorch/aws.'"
+  },
+  "predictions": {
+   "f01": "RFC 7489 remains the formal DMARC standard; RFC 9091 is experimental, so RFC 7489 is still the operative standard.",
+   "f02": "A04 \u2013 Insecure Design.",
+   "f03": "Actively maintained and stable.",
+   "f04": "RFC 7396 defines JSON Merge Patch and remains in force.",
+   "f05": "RFC 9110 does not define QUERY; as of mid-2026 the HTTP QUERY method draft has not been published as a final RFC.",
+   "f06": "Minimum 8 characters when password is the sole factor per SP 800-63B-4 final.",
+   "f07": "Viable \u2013 TorchServe remains actively maintained by PyTorch/AWS.",
+   "f08": "Let's Encrypt shut down its OCSP responders in 2025, replacing revocation signaling with CRLs only."
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "misses": {},
+  "predictions": {
+   "f01": "RFC 9989",
+   "f02": "A06",
+   "f03": "EOL \u2014 retired by SIG Network/SRC, maintenance ended March 2026, repository read-only.",
+   "f04": "RFC 7396",
+   "f05": "RFC 10008",
+   "f06": "15 characters",
+   "f07": "Archived (repo archived August 2025, no updates or security patches).",
+   "f08": "No \u2014 Let's Encrypt ended OCSP (URLs dropped from certs May 2025, responders shut down August 2025); revocation is CRL-only."
+  }
+ }
+}

--- a/evals/run-clean.py
+++ b/evals/run-clean.py
@@ -69,7 +69,19 @@ def audit_library_context():
 
 
 def build_prompt(cases, kind, with_lib):
-    stripped = [{k: v for k, v in c.items() if k != "expect"} for c in cases]
+    if kind == "freshness":
+        tasks = json.dumps([{"id": c["id"], "question": c["question"]} for c in cases], indent=1)
+        head = "Answer each question with the CURRENT (mid-2026) fact, in ONE short line each."
+        if with_lib:
+            files = sorted({f for c in cases for f in c.get("skill", [])})
+            ctx = "\n\n".join(open(os.path.join(ROOT, f), encoding="utf-8").read() for f in files)
+            lib = f"\n\nUse this current reference material:\n\n{ctx}\n\n"
+        else:
+            lib = "\n\nUse only your own knowledge.\n\n"
+        return (f"{head}{lib}Questions:\n{tasks}\n\n"
+                'Output ONLY a JSON object mapping each id to your one-line answer string, '
+                'e.g. {"f01": "RFC 9989"}. No prose, no code fence.')
+    stripped = [{k: v for k, v in c.items() if k not in ("expect", "skill")} for c in cases]
     tasks = json.dumps(stripped, indent=1)
     if kind == "audit":
         vocab = ", ".join(VOCAB)
@@ -108,15 +120,22 @@ def call(model, key, prompt):
     return json.loads(txt[s:e + 1])
 
 
-def score(cases, preds):
+def score(cases, preds, kind):
     tot, misses = 0.0, {}
     for c in cases:
-        exp = set(c["expect"])
-        got = set(preds.get(c["id"], []))
-        r = len(exp & got) / len(exp)
+        if kind == "freshness":
+            ans = str(preds.get(c["id"], "")).lower()
+            hit = any(tok.lower() in ans for tok in c["expect"])
+            r = 1.0 if hit else 0.0
+            if not hit:
+                misses[c["id"]] = f"want {c['expect']}; got: {ans[:70]!r}"
+        else:
+            exp = set(c["expect"])
+            got = set(preds.get(c["id"], []))
+            r = len(exp & got) / len(exp)
+            if r < 1.0:
+                misses[c["id"]] = sorted(exp - got)
         tot += r
-        if r < 1.0:
-            misses[c["id"]] = sorted(exp - got)
     return tot / len(cases), misses
 
 
@@ -134,7 +153,7 @@ def main():
     for with_lib in (False, True):
         arm = "with-library" if with_lib else "without-library"
         preds = call(a.model, key, build_prompt(cases, kind, with_lib))
-        rec, misses = score(cases, preds)
+        rec, misses = score(cases, preds, kind)
         result[arm] = {"recall": rec, "misses": misses, "predictions": preds}
         print(f"{arm:16s} recall={rec:.2f}"
               + (f"  misses: {misses}" if misses else "  (no misses)"))


### PR DESCRIPTION
Answers your "lift isn't that big" — you were right about what I'd measured, and this shows why.

Routing (+0.10) and audit (+0.00) test what a strong model **already does well** (pick a skill area; spot a textbook vuln). They measured the library's *weakest* dimensions. Its actual core value is **currency** — 2026 facts a frozen training cutoff lacks — and the new freshness eval measures it clean (raw API, no sota config):

| model | without-library | with-library | **lift** |
|---|---|---|---|
| sonnet-4.6 | 0.25 | 1.00 | **+0.75** |
| opus-4.8 | 0.50 | 1.00 | **+0.50** |

The without-library arm isn't just missing facts — it's **confidently wrong** (verbatim): *"RFC 7489 remains the formal DMARC standard"* (→9989), *"A04 – Insecure Design"* (→A06), ingress-nginx *"actively maintained and stable"* (→EOL), *"8 characters"* (→15), TorchServe *"remains actively maintained by PyTorch/AWS"* (→archived). Even **opus-4.8** gets only 4/8 unaided. Every one is a fact the library carries (and several were literal fixes this session).

**New:** `evals/cases/freshness.jsonl` (8 objective current-fact cases, each answer verified in-library + primary-sourced) + freshness support in `run-clean.py`. BASELINE.md reframed around the three dimensions. `.env` gitignored; gitleaks clean; harness has no key value.

**Bottom line:** the lift is ~5–7× larger on the dimension that matters, and the base model ships confident errors without the library. On fast-moving work, decisively worth it; on timeless tasks, modestly so.