### PR TITLE
docs(readme): cite the freshness eval evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   even opus-4.8 misses the same rule-driven skills without the router (r01
   testing, r02 sandboxing, r07 code-security, r09 web-frameworks). So the
   in-session +0.08/+0.11 was **not** a contamination artifact — the routing
-  lift is real and attributable to the cross-cutting rules. **Audit lift =
-  +0.00, model-independent** (haiku→sonnet-4.6, original + harder cases):
+  lift is real and attributable to the cross-cutting rules. README now cites
+  the freshness evidence ("Measured, not asserted") linking `evals/`. **Audit
+  lift = +0.00, model-independent** (haiku→sonnet-4.6, original + harder cases):
   strong models recognize textbook vulns library-or-not. **Freshness lift =
   +0.75 (sonnet-4.6) / +0.50 (opus-4.8)** — the decisive finding: a new
   `cases/freshness.jsonl` (8 objective 2026-current facts, each carried in a

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ regulation writes down: cancellation & backpressure, retries with jitter,
 circuit breakers, outbox/saga, zero-downtime migrations, measure-first
 performance, API evolvability, per-language idioms, SLOs, test-suite health.
 
+**Measured, not asserted.** A current model *without* the library is confidently
+wrong on 2026 facts (wrong DMARC RFC, an EOL'd tool it calls "maintained"); the
+library closes the gap — +0.50–0.75 recall on currency ([evals/](evals/)).
+
 ## Skills
 
 | Skill | Covers |
@@ -247,10 +251,6 @@ skill, *scope* to one rule file, or *stack* an exact combo.
 **Building** — plain prompts; routing picks the skills:
 
 > Design a multi-tenant invoicing service — stack from my profile, or propose one.
-
-> Add a websocket endpoint for live notifications.
-
-> Build the settings page — dark mode, WCAG 2.2 AA.
 
 > Add a RAG search feature over our docs, and write the evals first.
 


### PR DESCRIPTION
Answers 'should we mention the with/without test?' — **yes**, and honestly.

The README hero claims *"fast-moving claims web-verified against primary sources"*; that claim now has data behind it. Adds a compact 3-line **"Measured, not asserted"** note: a current model *without* the library is confidently wrong on 2026 facts (wrong DMARC RFC, an EOL'd tool it calls "maintained") — +0.50–0.75 recall gap on currency — linking [evals/](evals/) for the full, honest by-dimension breakdown (routing modest, audit ~nil, so no cherry-picking).

Reclaimed two redundant Building examples (the websocket one repeats later) to keep README at exactly 500. CHANGELOG updated; MEMORY index refreshed (was stale at v1.12.1). All invariants pass.