### PR TITLE
docs(readme): surface measured lifts + script install after plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ Evaluation-harness additions (no skill-content change; not in CI — see
   with the before/after data and honest boundary. Draft for the maintainer to
   publish (roadmap item 7, distribution).
 
+### Changed
+
+- **README surfaces the measured lift up front** — the dense one-liner is now a
+  scannable per-dimension list (completeness +0.39, freshness +0.53, routing
+  +0.10, with the multi-sample endpoints and the "near-zero variance" note), and
+  the clone/script install method now follows the plugin method directly (the
+  plugin-extras note moved below both).
+
 ## [1.15.0] - 2026-07-13
 
 The measured-efficacy release: completeness proven as the library's thesis, the

--- a/README.md
+++ b/README.md
@@ -61,9 +61,12 @@ regulation writes down: cancellation & backpressure, retries with jitter,
 circuit breakers, outbox/saga, zero-downtime migrations, measure-first
 performance, API evolvability, per-language idioms, SLOs, test-suite health.
 
-**Measured, not asserted.** Vs. an *unguided model* (same model, no library), the library lifts bare
-"build X" prompts from ~60% to ~99% best-practice coverage across 7 tasks (**+0.39**), is large on 2026
-facts (**+0.50**), and helps routing (**+0.10**) — clean, blind-judged. [Why it works & results →](docs/WHY-IT-WORKS.md)
+**Measured, not asserted** — library vs. an *unguided model* (same model, no
+library); clean, blind-judged, stable across samples ([results & method →](docs/WHY-IT-WORKS.md)):
+
+- **Completeness +0.39** — from a bare "build X" prompt, best-practice coverage goes ~60% → ~100% (7 tasks): the model stops silently dropping tests, rate limiting, structured logging, and TLS. Web search can't recover this.
+- **Freshness +0.53** — current-2026 facts (RFCs, CVEs, EOLs) 0.44 → 0.97, where an unguided model is *confidently wrong*.
+- **Routing +0.10** — the right skills load for the task (0.90 → 1.00), even ones a keyword read misses; with the library, results barely move run-to-run.
 
 ## Skills
 
@@ -125,11 +128,6 @@ Deliberately **not covered**: Scala/Elixir, standalone C (inside `sota-c-cpp`), 
 /plugin install sota-skills@sota-skills
 ```
 
-The plugin installs the skills; a few extras (routing reminder, status line,
-pre-commit gates, AGENTS.md) aren't auto-enabled — see
-[Optional extras for plugin users](#optional-extras-for-plugin-users). On first
-run the plugin shows a one-time notice pointing there.
-
 **Or clone + link** (best if you want a local checkout to read, hack on, or pin).
 Skills are discovered from `.claude/skills/` (per project) or `~/.claude/skills/`
 (personal, all projects). Clone the repo, then run the installer — it symlinks
@@ -142,12 +140,13 @@ git clone https://github.com/martinholovsky/SOTA-skills && cd SOTA-skills
 ./scripts/install.sh --copy          # copy instead of symlink (pin a snapshot)
 ```
 
-Prefer no script? The personal install is just:
+Prefer no script? `./scripts/install.sh` only symlinks `skills/*/` into
+`~/.claude/skills/` — do that by hand if you'd rather.
 
-```sh
-mkdir -p ~/.claude/skills
-for d in skills/*/; do ln -sfn "$(pwd)/$d" ~/.claude/skills/"$(basename "$d")"; done
-```
+The plugin (or `--copy`) installs the skills; a few extras (routing reminder,
+status line, pre-commit gates, AGENTS.md) aren't auto-enabled — see
+[Optional extras for plugin users](#optional-extras-for-plugin-users). On first
+run the plugin shows a one-time notice pointing there.
 
 ### Updating
 


### PR DESCRIPTION
Two asks: (1) the benefits/lifts weren't clear from the docs — make the key ones
prominent in the README; (2) move the script install step right after the plugin
install method.

## Benefits/lifts, now scannable in the README
Replaced the dense one-line claim with a per-dimension list carrying the
**validated multi-sample numbers** (from the merged `MULTI-SAMPLE.md`):

- **Completeness +0.39** — ~60% → ~100% best-practice coverage (7 tasks); stops silently dropping tests, rate limiting, logging, TLS; web search can't recover it.
- **Freshness +0.53** — 2026 facts 0.44 → 0.97, unguided model *confidently wrong*.
- **Routing +0.10** — right skills load (0.90 → 1.00); with-library, results barely move run-to-run.

Each ties back to `docs/WHY-IT-WORKS.md`. Numbers cross-checked against
`completeness-3sample.json` / `freshness-32-3x.json` / `routing-3sample.json`.

## Install reorder
The Installation section now goes **plugin → clone/script (`install.sh`) →
one-line manual pointer → plugin-extras note**, so the script method follows the
plugin method directly (the extras note used to sit between them). The redundant
hand-rolled symlink loop collapses to a one-line pointer.

## Line-cap discipline
README was at the 500-line hard cap; these edits are net **−1** (now 499) —
benefit list offset by collapsing the manual snippet and removing a duplicate
sentence. CHANGELOG `[Unreleased]` notes the change (now 493).

## Validation
- `./scripts/check-invariants.sh` — all 7 pass (README 499, CHANGELOG 493)
- pre-commit (gitleaks + invariants) — pass
