### PR TITLE
docs(changelog): split the archive to fix the 500-line cap pinch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,8 @@ pre-commit hook scans each commit locally.
   design that counters it
 - [SECURITY.md](SECURITY.md) — reporting bad guidance or a leaked secret
 - [CHANGELOG.md](CHANGELOG.md) — release history (top entry = current version;
-  also mirrored in `VERSION`); releases **1.9.0 and earlier** are archived in
-  [docs/CHANGELOG-archive.md](docs/CHANGELOG-archive.md), which is itself now at
-  the 500-line cap — the next archive move needs a second archive file or a trim
+  also mirrored in `VERSION`); older releases are archived to keep every file
+  under the 500-line cap — **1.9.0–1.5.0** in
+  [docs/CHANGELOG-archive.md](docs/CHANGELOG-archive.md) and **1.4.0 and earlier**
+  in [docs/CHANGELOG-archive-2.md](docs/CHANGELOG-archive-2.md) (split 2026-07-14);
+  when an archive nears 500, start the next numbered part rather than growing it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,8 +481,9 @@ Roadmap items 2, 3, 5, and 6 executed (see `docs/ROADMAP.md` annotations):
 
 ---
 
-Releases **1.9.0 and earlier** are archived in
-[docs/CHANGELOG-archive.md](docs/CHANGELOG-archive.md).
+Releases **1.9.0 and earlier** are archived: 1.9.0–1.5.0 in
+[docs/CHANGELOG-archive.md](docs/CHANGELOG-archive.md), 1.4.0 and earlier in
+[docs/CHANGELOG-archive-2.md](docs/CHANGELOG-archive-2.md).
 
 [1.15.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.15.0
 [1.14.1]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.14.1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ lands through a PR — `main` is protected for everyone, including admins (see
 |---|---|
 | `VERSION` | the new semver, single line |
 | `.claude-plugin/plugin.json` | `"version"`; also the skill/domain counts in `"description"` if they changed |
-| `CHANGELOG.md` | new `## [X.Y.Z] - YYYY-MM-DD` section at the top **and** a `[X.Y.Z]: …/releases/tag/vX.Y.Z` link ref at the bottom (top entry = current version — no `[Unreleased]` left behind); when the file nears the 500-line cap, move the oldest release sections **and their link refs** to `docs/CHANGELOG-archive.md` |
+| `CHANGELOG.md` | new `## [X.Y.Z] - YYYY-MM-DD` section at the top **and** a `[X.Y.Z]: …/releases/tag/vX.Y.Z` link ref at the bottom (top entry = current version — no `[Unreleased]` left behind); when the file nears the 500-line cap, move the oldest release sections **and their link refs** into the newest `docs/CHANGELOG-archive*.md` — and when an archive itself nears 500, start the next numbered part (`docs/CHANGELOG-archive-3.md`, …) rather than growing it. Each archive file's headings and `[X.Y.Z]:` refs must stay in the same file |
 
 ## 2. Count-bearing surfaces (when the skill count changes)
 

--- a/docs/CHANGELOG-archive-2.md
+++ b/docs/CHANGELOG-archive-2.md
@@ -1,0 +1,118 @@
+# Changelog archive (part 2)
+
+The oldest SOTA-skills releases — **1.4.0 down to the 1.0.0 first public
+release** — moved here to keep both the root [CHANGELOG.md](../CHANGELOG.md) and
+[CHANGELOG-archive.md](CHANGELOG-archive.md) under the repository's 500-line cap.
+Same format ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/) /
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html)).
+
+## [1.4.0] - 2026-06-27
+
+### Added
+
+- **Plugin first-run notice** (`hooks/hooks.json` + `scripts/plugin-notice.sh`)
+  — a one-time `SessionStart` notice for plugin installs that points users at the
+  opt-in extras a sandboxed plugin can't auto-configure (always-on routing, status
+  line, pre-commit gates, AGENTS.md). Shows once (marker-guarded); clone users get
+  the same from `install.sh`.
+- **README "Optional extras (for plugin users)"** — documents how plugin users
+  turn on the routing hook, status line, and generators (which ship with the
+  plugin) to match the clone experience.
+
+## [1.3.0] - 2026-06-27
+
+### Added
+
+- **`scripts/statusline.sh`** — a Claude Code status line showing which skills
+  you've actually used this session (read from the transcript's `Skill`
+  invocations), plus model / context % / dir / branch; falls back to the count
+  of installed skills before any are used. Requires `jq`.
+
+### Changed
+
+- **`scripts/install.sh` now offers always-on routing setup** (global CLAUDE.md
+  directive + `UserPromptSubmit` hook) after linking — interactive and
+  dotfiles-aware: detects existing/symlinked `~/.claude/CLAUDE.md` and
+  `settings.json`, asks before changing anything (recommended pre-filled), backs
+  up, writes through symlinks so dotfiles stay authoritative, and is idempotent
+  via managed markers. Flags: `--routing`, `--no-routing`, `--yes`.
+
+## [1.2.0] - 2026-06-27
+
+### Added
+
+- **`sota-docs-workflow` rules/05 — spec-driven development**: the
+  intent→plan→tasks→implement→verify loop, separating what from how, testable
+  acceptance criteria, `[NEEDS CLARIFICATION]` markers, specs-in-repo and
+  spec-drift control, steering vs per-feature specs, and when SDD is overhead.
+- **`sota-testing` rules/08 — BDD / specification by example**: declarative
+  Given-When-Then, the three-amigos value, the outside-in double loop with TDD,
+  scenario-explosion and UI-script anti-patterns, and tracing scenarios to spec
+  acceptance criteria.
+- **`scripts/gen-agents-md.sh`** — generate an `AGENTS.md` entry point so
+  non-Claude agents (Codex, Cursor, Copilot, Gemini CLI, Windsurf, Zed, …) route
+  through the skills. Thin pointer built from each skill's frontmatter; reads
+  rules on demand, no duplication; idempotent managed block.
+- **`scripts/init-gates.sh --docs-gate`** — opt-in pre-commit hook (helper at
+  `.sota/docs-gate.sh`) that blocks a commit changing code without updating any
+  docs (README/CHANGELOG/`docs/`/`*.md`). Heuristic and bypassable
+  (`SKIP=sota-docs-gate`).
+
+### Changed
+
+- The always-on directive (generated `AGENTS.md` and the README `CLAUDE.md`
+  example) now leads with two standing rules that apply to **every answer**:
+  *validate every claim against a primary source before asserting*, and *keep
+  docs current in the same change*.
+
+## [1.1.0] - 2026-06-26
+
+### Added
+
+- **Claude Code plugin + marketplace** (`.claude-plugin/`): install with
+  `/plugin marketplace add martinholovsky/SOTA-skills` then
+  `/plugin install sota-skills@sota-skills`, and update with `/plugin update`.
+- **`scripts/install.sh`** — installer that doubles as the updater: re-run after
+  `git pull` to link newly-added skills and prune removed ones (idempotent);
+  `--update`, `--project DIR`, `--copy`. Also links the local profile.
+- **`scripts/init-gates.sh`** — detects a repo's languages and generates a
+  SOTA-aligned `.pre-commit-config.yaml`: ruff/mypy/pytest/pip-audit,
+  gofumpt/golangci-lint/govulncheck, clippy/cargo-audit, eslint/tsc/audit,
+  shellcheck/shfmt, plus gitleaks. Fast checks on commit, heavy on push;
+  idempotent via a managed marker block.
+- **README**: "Always-on routing", "Enforcing the gates", and "Updating"
+  sections documenting how to keep the skills applied and current.
+
+## [1.0.0] - 2026-06-17
+
+First public release.
+
+### Added
+
+- **30 skills** spanning architecture; security (code security, threat
+  modeling, secrets management, sandboxing); API design; async/concurrency;
+  performance; databases; observability; testing; LLM engineering; frontend
+  design; cloud infrastructure; Kubernetes; identity & access; network security;
+  detection engineering; data engineering; privacy/compliance; mobile; CLI UX;
+  shell scripting; docs/workflow; and the Rust, Go, Python, and
+  JavaScript/TypeScript language skills.
+- **`sota` master router** with task-to-skill routing and operating principles,
+  including a mandatory claim-validation principle.
+- **BUILD and AUDIT modes** for every skill. Findings carry severity + effort +
+  standard mapping + fix; every rules file ends with an executable audit
+  checklist; every file stays under 500 lines for incremental loading.
+- **Audit methodology**: scoping/rules of engagement, a verified static-analysis
+  tool matrix, an evidence standard, and a report template.
+- **Per-user `profiles/`** mechanism with `example.md.template`; real profiles
+  are git-ignored so the library stays generic.
+- **Repository invariants** enforced in pre-commit and CI: ≤500-line files,
+  audit-checklist presence in every rules file, and an internal-reference
+  denylist, plus gitleaks secret scanning.
+- **Governance**: contributor guide, security policy, and code of conduct;
+  `main` protected with required status checks.
+
+[1.4.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.4.0
+[1.3.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.3.0
+[1.2.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.2.0
+[1.1.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.1.0
+[1.0.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.0.0

--- a/docs/CHANGELOG-archive.md
+++ b/docs/CHANGELOG-archive.md
@@ -4,7 +4,9 @@ Older SOTA-skills releases, moved out of [CHANGELOG.md](../CHANGELOG.md) to
 keep that file under the repository's 500-line cap. Same format
 ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/) /
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)); current releases
-live in the root CHANGELOG.
+live in the root CHANGELOG. This file holds **1.9.0 down to 1.5.0**; still older
+releases (**1.4.0 and earlier**) are in
+[CHANGELOG-archive-2.md](CHANGELOG-archive-2.md).
 
 ## [1.9.0] - 2026-07-03
 
@@ -383,118 +385,9 @@ goes from 30 to 34 skills.
   PHP) signature detection at ingest (`rules/09`), and Redis `EVAL`/Qdrant-filter
   injection guidance (`sota-databases/rules/06`).
 
-## [1.4.0] - 2026-06-27
-
-### Added
-
-- **Plugin first-run notice** (`hooks/hooks.json` + `scripts/plugin-notice.sh`)
-  — a one-time `SessionStart` notice for plugin installs that points users at the
-  opt-in extras a sandboxed plugin can't auto-configure (always-on routing, status
-  line, pre-commit gates, AGENTS.md). Shows once (marker-guarded); clone users get
-  the same from `install.sh`.
-- **README "Optional extras (for plugin users)"** — documents how plugin users
-  turn on the routing hook, status line, and generators (which ship with the
-  plugin) to match the clone experience.
-
-## [1.3.0] - 2026-06-27
-
-### Added
-
-- **`scripts/statusline.sh`** — a Claude Code status line showing which skills
-  you've actually used this session (read from the transcript's `Skill`
-  invocations), plus model / context % / dir / branch; falls back to the count
-  of installed skills before any are used. Requires `jq`.
-
-### Changed
-
-- **`scripts/install.sh` now offers always-on routing setup** (global CLAUDE.md
-  directive + `UserPromptSubmit` hook) after linking — interactive and
-  dotfiles-aware: detects existing/symlinked `~/.claude/CLAUDE.md` and
-  `settings.json`, asks before changing anything (recommended pre-filled), backs
-  up, writes through symlinks so dotfiles stay authoritative, and is idempotent
-  via managed markers. Flags: `--routing`, `--no-routing`, `--yes`.
-
-## [1.2.0] - 2026-06-27
-
-### Added
-
-- **`sota-docs-workflow` rules/05 — spec-driven development**: the
-  intent→plan→tasks→implement→verify loop, separating what from how, testable
-  acceptance criteria, `[NEEDS CLARIFICATION]` markers, specs-in-repo and
-  spec-drift control, steering vs per-feature specs, and when SDD is overhead.
-- **`sota-testing` rules/08 — BDD / specification by example**: declarative
-  Given-When-Then, the three-amigos value, the outside-in double loop with TDD,
-  scenario-explosion and UI-script anti-patterns, and tracing scenarios to spec
-  acceptance criteria.
-- **`scripts/gen-agents-md.sh`** — generate an `AGENTS.md` entry point so
-  non-Claude agents (Codex, Cursor, Copilot, Gemini CLI, Windsurf, Zed, …) route
-  through the skills. Thin pointer built from each skill's frontmatter; reads
-  rules on demand, no duplication; idempotent managed block.
-- **`scripts/init-gates.sh --docs-gate`** — opt-in pre-commit hook (helper at
-  `.sota/docs-gate.sh`) that blocks a commit changing code without updating any
-  docs (README/CHANGELOG/`docs/`/`*.md`). Heuristic and bypassable
-  (`SKIP=sota-docs-gate`).
-
-### Changed
-
-- The always-on directive (generated `AGENTS.md` and the README `CLAUDE.md`
-  example) now leads with two standing rules that apply to **every answer**:
-  *validate every claim against a primary source before asserting*, and *keep
-  docs current in the same change*.
-
-## [1.1.0] - 2026-06-26
-
-### Added
-
-- **Claude Code plugin + marketplace** (`.claude-plugin/`): install with
-  `/plugin marketplace add martinholovsky/SOTA-skills` then
-  `/plugin install sota-skills@sota-skills`, and update with `/plugin update`.
-- **`scripts/install.sh`** — installer that doubles as the updater: re-run after
-  `git pull` to link newly-added skills and prune removed ones (idempotent);
-  `--update`, `--project DIR`, `--copy`. Also links the local profile.
-- **`scripts/init-gates.sh`** — detects a repo's languages and generates a
-  SOTA-aligned `.pre-commit-config.yaml`: ruff/mypy/pytest/pip-audit,
-  gofumpt/golangci-lint/govulncheck, clippy/cargo-audit, eslint/tsc/audit,
-  shellcheck/shfmt, plus gitleaks. Fast checks on commit, heavy on push;
-  idempotent via a managed marker block.
-- **README**: "Always-on routing", "Enforcing the gates", and "Updating"
-  sections documenting how to keep the skills applied and current.
-
-## [1.0.0] - 2026-06-17
-
-First public release.
-
-### Added
-
-- **30 skills** spanning architecture; security (code security, threat
-  modeling, secrets management, sandboxing); API design; async/concurrency;
-  performance; databases; observability; testing; LLM engineering; frontend
-  design; cloud infrastructure; Kubernetes; identity & access; network security;
-  detection engineering; data engineering; privacy/compliance; mobile; CLI UX;
-  shell scripting; docs/workflow; and the Rust, Go, Python, and
-  JavaScript/TypeScript language skills.
-- **`sota` master router** with task-to-skill routing and operating principles,
-  including a mandatory claim-validation principle.
-- **BUILD and AUDIT modes** for every skill. Findings carry severity + effort +
-  standard mapping + fix; every rules file ends with an executable audit
-  checklist; every file stays under 500 lines for incremental loading.
-- **Audit methodology**: scoping/rules of engagement, a verified static-analysis
-  tool matrix, an evidence standard, and a report template.
-- **Per-user `profiles/`** mechanism with `example.md.template`; real profiles
-  are git-ignored so the library stays generic.
-- **Repository invariants** enforced in pre-commit and CI: ≤500-line files,
-  audit-checklist presence in every rules file, and an internal-reference
-  denylist, plus gitleaks secret scanning.
-- **Governance**: contributor guide, security policy, and code of conduct;
-  `main` protected with required status checks.
-
+[1.9.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.9.0
+[1.8.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.8.0
 [1.7.1]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.7.1
 [1.7.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.7.0
 [1.6.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.6.0
 [1.5.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.5.0
-[1.4.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.4.0
-[1.3.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.3.0
-[1.2.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.2.0
-[1.1.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.1.0
-[1.0.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.0.0
-[1.8.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.8.0


### PR DESCRIPTION
`docs/CHANGELOG-archive.md` had reached **exactly 500 lines** — the next release
cut (or archive move) would have blown the invariant. Split at the 1.5.0/1.4.0
boundary:

- `docs/CHANGELOG-archive.md` → **1.9.0–1.5.0** (393 lines, healthy runway)
- `docs/CHANGELOG-archive-2.md` → **1.4.0–1.0.0** (new, 118 lines)

**Verified byte-identical:** the 428 release-body lines are unchanged across the
split (integrity-checked against `HEAD`, no content lost). Also fixed a
pre-existing broken heading link — the archived `[1.9.0]` section had no matching
`[1.9.0]:` ref; refs are regenerated per file so every heading now resolves and
each file's headings + refs live together.

**Pointers updated in the same change:** AGENTS.md and the root CHANGELOG
boundary note reference both archive files; RELEASING.md now says to start the
next numbered archive part (`-3`, …) when one nears 500 rather than growing it.

## Validation
- `./scripts/check-invariants.sh` — all 7 pass (root 495, archive 393, archive-2 118)
- pre-commit (gitleaks + invariants) — pass
