### PR TITLE
test(evals): competitor benchmark — SOTA leads the most popular libraries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ pre-commit hook scans each commit locally.
 - [SECURITY.md](SECURITY.md) — reporting bad guidance or a leaked secret
 - [CHANGELOG.md](CHANGELOG.md) — release history (top entry = current version;
   also mirrored in `VERSION`); older releases are archived to keep every file
-  under the 500-line cap — **1.9.0–1.5.0** in
+  under the 500-line cap — **1.10.0–1.5.0** in
   [docs/CHANGELOG-archive.md](docs/CHANGELOG-archive.md) and **1.4.0 and earlier**
   in [docs/CHANGELOG-archive-2.md](docs/CHANGELOG-archive-2.md) (split 2026-07-14);
   when an archive nears 500, start the next numbered part rather than growing it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,19 @@ Evaluation-harness additions (no skill-content change; not in CI — see
   with the before/after data and honest boundary. Draft for the maintainer to
   publish (roadmap item 7, distribution).
 
+### Added
+
+- **Competitor benchmark** (`evals/run-competitors.py`,
+  `evals/cases/competitors.json`, `results/2026-07-13/COMPETITOR-BENCHMARK.md`) —
+  SOTA vs. the most popular competing guidance libraries on the 7 completeness
+  tasks, content-only and blind-judged. **SOTA 0.99 vs ECC (~230k★) 0.87,
+  awesome-cursorrules (~40k★) 0.83, alirezarezvani/claude-skills (~23k★) 0.81**;
+  unguided 0.58. SOTA wins or ties every one of the 21 head-to-head cases and
+  loses none; competitors are legitimate (all beat unguided by +0.23–0.28) but
+  drop the cross-cutting non-negotiables (rate limiting, transport, tests) SOTA
+  embeds. Clears the roadmap honesty gate for a scoped, reproducible "vs library
+  X" claim; `docs/WHY-IT-WORKS.md` now carries it.
+
 ### Changed
 
 - **README surfaces the measured lift up front** — the dense one-liner is now a
@@ -433,55 +446,9 @@ one residual root-caused, and the BUILD workflow rewritten around it.
   count surfaces updated to 40 skills / 289 files / ~57k lines (README
   badge/hero/alt/table, plugin.json, marketplace.json, social-preview pill + PNG).
 
-## [1.10.0] - 2026-07-04
-
-Coverage complete + auditable promises: two new language skills (39 total),
-Swift-language and AD/Kerberos depth, and every remaining roadmap item
-executed — invariant lint gate, freshness ledger, structured feedback intake.
-
-The four coverage builds approved under roadmap item 6 (39 skills total):
-
-- **`sota-php`** — PHP 8.3+ floor / 8.5 current (verified php.net), strict
-  idioms, OWASP-grade security (PDO, escaping, uploads/LFI, unserialize/Phar,
-  sessions), Composer supply chain (`composer audit`), PHPStan/Psalm,
-  OPcache/FPM/JIT. SKILL.md + 6 rules files.
-- **`sota-ruby`** — Ruby 4.0 current / 3.4 maintained (verified
-  ruby-lang.org), idioms & typing (RBS/Sorbet), security (SQLi, ERB escaping,
-  Marshal/`YAML.load` semantics since Psych 4, ReDoS + `Regexp.timeout`),
-  Bundler supply chain (bundler-audit, lockfile checksums since Bundler 2.6),
-  GVL/Ractors/YJIT (ZJIT flagged experimental). SKILL.md + 5 rules files.
-- **Swift as a language** — `sota-mobile` rules/07: Swift 6.3 strict
-  concurrency (verified swift.org), actors/Sendable, structured concurrency,
-  ARC/retain cycles, unsafe interop, SPM registry security, Swift Testing.
-- **Active Directory/Kerberos/ADCS** — `sota-identity-access` rules/07
-  (Enterprise Access Model, delegation, Kerberoasting/gMSA/dMSA, ESC classes,
-  KB5014754 enforcement, Windows LAPS) + `sota-detection-engineering`
-  rules/07 (event-ID telemetry baseline, Sigma-style detections with ATT&CK
-  IDs, AD deception), cross-linked. README "Coverage & non-goals" now lists
-  only true non-goals; router/manifests/counts updated to 39 skills.
-
-Roadmap items 2, 3, 5, and 6 executed (see `docs/ROADMAP.md` annotations):
-
-- **Invariants 5 & 6** in `check-invariants.sh`: version lockstep (`VERSION`
-  == `plugin.json` == CHANGELOG top; newest tag never ahead) and count-surface
-  drift (README badge/hero/alt, router body, plugin/marketplace descriptions,
-  social-preview pill vs a recount of the tree). CI invariants job now checks
-  out full history so the tag comparison runs.
-- **Freshness ledger**: rules files carry a line-1
-  `<!-- last-verified: YYYY-MM -->` marker (18 files stamped from their
-  existing in-text dates — never retroactively); `scripts/check-freshness.sh`
-  + a monthly `freshness.yml` workflow report stale markers and the unstamped
-  backlog.
-- **Feedback intake**: bad-guidance and skill-request issue forms (primary
-  source required; security-sensitive reports routed to private advisories)
-  and GitHub Discussions enabled.
-- **README "Coverage & non-goals"**: PHP, Ruby, Swift-as-a-language, and
-  Active Directory/Kerberos depth declared out of scope for now and queued as
-  approved follow-up builds.
-
 ---
 
-Releases **1.9.0 and earlier** are archived: 1.9.0–1.5.0 in
+Releases **1.10.0 and earlier** are archived: 1.10.0–1.5.0 in
 [docs/CHANGELOG-archive.md](docs/CHANGELOG-archive.md), 1.4.0 and earlier in
 [docs/CHANGELOG-archive-2.md](docs/CHANGELOG-archive-2.md).
 
@@ -492,4 +459,3 @@ Releases **1.9.0 and earlier** are archived: 1.9.0–1.5.0 in
 [1.12.1]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.12.1
 [1.12.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.12.0
 [1.11.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.11.0
-[1.10.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.10.0

--- a/docs/CHANGELOG-archive.md
+++ b/docs/CHANGELOG-archive.md
@@ -4,9 +4,55 @@ Older SOTA-skills releases, moved out of [CHANGELOG.md](../CHANGELOG.md) to
 keep that file under the repository's 500-line cap. Same format
 ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/) /
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html)); current releases
-live in the root CHANGELOG. This file holds **1.9.0 down to 1.5.0**; still older
+live in the root CHANGELOG. This file holds **1.10.0 down to 1.5.0**; still older
 releases (**1.4.0 and earlier**) are in
 [CHANGELOG-archive-2.md](CHANGELOG-archive-2.md).
+
+## [1.10.0] - 2026-07-04
+
+Coverage complete + auditable promises: two new language skills (39 total),
+Swift-language and AD/Kerberos depth, and every remaining roadmap item
+executed — invariant lint gate, freshness ledger, structured feedback intake.
+
+The four coverage builds approved under roadmap item 6 (39 skills total):
+
+- **`sota-php`** — PHP 8.3+ floor / 8.5 current (verified php.net), strict
+  idioms, OWASP-grade security (PDO, escaping, uploads/LFI, unserialize/Phar,
+  sessions), Composer supply chain (`composer audit`), PHPStan/Psalm,
+  OPcache/FPM/JIT. SKILL.md + 6 rules files.
+- **`sota-ruby`** — Ruby 4.0 current / 3.4 maintained (verified
+  ruby-lang.org), idioms & typing (RBS/Sorbet), security (SQLi, ERB escaping,
+  Marshal/`YAML.load` semantics since Psych 4, ReDoS + `Regexp.timeout`),
+  Bundler supply chain (bundler-audit, lockfile checksums since Bundler 2.6),
+  GVL/Ractors/YJIT (ZJIT flagged experimental). SKILL.md + 5 rules files.
+- **Swift as a language** — `sota-mobile` rules/07: Swift 6.3 strict
+  concurrency (verified swift.org), actors/Sendable, structured concurrency,
+  ARC/retain cycles, unsafe interop, SPM registry security, Swift Testing.
+- **Active Directory/Kerberos/ADCS** — `sota-identity-access` rules/07
+  (Enterprise Access Model, delegation, Kerberoasting/gMSA/dMSA, ESC classes,
+  KB5014754 enforcement, Windows LAPS) + `sota-detection-engineering`
+  rules/07 (event-ID telemetry baseline, Sigma-style detections with ATT&CK
+  IDs, AD deception), cross-linked. README "Coverage & non-goals" now lists
+  only true non-goals; router/manifests/counts updated to 39 skills.
+
+Roadmap items 2, 3, 5, and 6 executed (see `docs/ROADMAP.md` annotations):
+
+- **Invariants 5 & 6** in `check-invariants.sh`: version lockstep (`VERSION`
+  == `plugin.json` == CHANGELOG top; newest tag never ahead) and count-surface
+  drift (README badge/hero/alt, router body, plugin/marketplace descriptions,
+  social-preview pill vs a recount of the tree). CI invariants job now checks
+  out full history so the tag comparison runs.
+- **Freshness ledger**: rules files carry a line-1
+  `<!-- last-verified: YYYY-MM -->` marker (18 files stamped from their
+  existing in-text dates — never retroactively); `scripts/check-freshness.sh`
+  + a monthly `freshness.yml` workflow report stale markers and the unstamped
+  backlog.
+- **Feedback intake**: bad-guidance and skill-request issue forms (primary
+  source required; security-sensitive reports routed to private advisories)
+  and GitHub Discussions enabled.
+- **README "Coverage & non-goals"**: PHP, Ruby, Swift-as-a-language, and
+  Active Directory/Kerberos depth declared out of scope for now and queued as
+  approved follow-up builds.
 
 ## [1.9.0] - 2026-07-03
 
@@ -385,6 +431,7 @@ goes from 30 to 34 skills.
   PHP) signature detection at ingest (`rules/09`), and Redis `EVAL`/Qdrant-filter
   injection guidance (`sota-databases/rules/06`).
 
+[1.10.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.10.0
 [1.9.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.9.0
 [1.8.0]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.8.0
 [1.7.1]: https://github.com/martinholovsky/SOTA-skills/releases/tag/v1.7.1

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,12 +134,23 @@ The audit's verdict was "content is trustworthy; the gap is that nothing
 
 ## Unexplored ideas
 
-- **Comparative benchmark vs. a named competing skill library.** Every eval to
-  date is library-vs-*nothing* (an unguided model), so the public claim is
-  honestly limited to that; we make **no** "better than library X" claim. To
-  earn one, run `run-completeness.py`/`run-clean.py` with a competitor's content
-  pasted as a **third arm** (same fixed rubric, same blind opus judge, same token
-  budget) and report the delta — **publishing it even if SOTA ties or loses.**
+- **Comparative benchmark vs. named competing libraries.** ~~Unexplored~~
+  **DONE 2026-07-14** ([`evals/results/2026-07-13/COMPETITOR-BENCHMARK.md`](../evals/results/2026-07-13/COMPETITOR-BENCHMARK.md),
+  `evals/run-competitors.py`, `evals/cases/competitors.json`). SOTA vs. the fair
+  peers, content-only, blind-judged, 7 build tasks: **SOTA 0.99 > ECC ~230k★ 0.87
+  > awesome-cursorrules ~40k★ 0.83 > alirezarezvani/claude-skills ~23k★ 0.81**
+  (unguided 0.58). SOTA wins/ties every one of 21 cases, loses none; competitors
+  are legitimate (all +0.23–0.28 over unguided) but drop the cross-cutting
+  non-negotiables SOTA embeds. The honesty gate is **cleared** — `WHY-IT-WORKS.md`
+  now carries a scoped "vs library X" claim. **Follow-ups still open:** multi-sample
+  the arms; broaden beyond the one task family (frontend/data/mobile); optionally
+  add an *as-deployed* comparison (each library with its own method, not
+  content-only). Original plan/targets kept below for reference.
+- **(reference) Original competitor-benchmark plan.** Every eval to
+  date is library-vs-*nothing* (an unguided model), so the public claim was
+  honestly limited to that; to earn a "vs X" claim, run a competitor's content
+  as a **third arm** (same fixed rubric, blind judge, token budget) and report the
+  delta — **publishing it even if SOTA ties or loses.**
   **Targets validated 2026-07-14 via the GitHub API** (stars + created-date +
   license + repo structure). **Pick on purpose-overlap, not raw stars** — many
   high-star repos are a *different kind* of thing, and the biggest ones are all

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -4,10 +4,10 @@ Most prompt/skill collections *assert* they make an assistant better. This one
 **measures it**, publishes the harness, and reports the numbers by dimension —
 including the dimensions where the lift is small or zero.
 
-**What the comparison is (and isn't).** Every number here is the library
+**What the comparison is.** The headline numbers below are the library
 **vs. an *unguided model*** — the same model, same task, with the library loaded
-vs. with nothing. It is **not** a comparison against other skill libraries; we
-have not benchmarked one, so we make no claim of superiority over them. The
+vs. with nothing. Separately, a **fair head-to-head against the most popular
+competing libraries** now exists too (see [below](#vs-competing-libraries)). The
 control is clean: raw model-API calls (OpenRouter, no Claude Code config or skill
 registry), and a **different** model grades each artifact **blind** to which arm
 produced it. Reproduce it yourself with [`evals/`](../evals/); full methodology,
@@ -66,6 +66,31 @@ across-case sd (6/7 cases perfectly steady); routing at **0.90 → 1.00 (+0.10)*
 with-arm ±0.00; freshness at **0.44 → 0.97 (+0.53)**, with-arm ±0.00. The
 library's contribution isn't a lucky sample — it removes the unguided model's
 case-by-case unreliability ([multi-sample writeup](../evals/results/2026-07-13/MULTI-SAMPLE.md)).
+
+## Vs. competing libraries
+
+The comparisons above are vs. *nothing*. We also ran SOTA head-to-head against the
+most popular competing guidance libraries on the same 7 build tasks — same rubric,
+same blind judge, **content-only** (SOTA's self-audit forcing function turned off,
+so its win is the guidance, not the method):
+
+| Library | Stars | Completeness |
+|---|---|---|
+| **SOTA** | — | **0.99** |
+| ECC | ~230k | 0.87 |
+| awesome-cursorrules | ~40k | 0.83 |
+| alirezarezvani/claude-skills | ~23k | 0.81 |
+| unguided model | — | 0.58 |
+
+**SOTA wins or ties every one of the 21 head-to-head cases and loses none** — yet
+the competitors are no strawmen (all three beat an unguided model by +0.23–0.28).
+Where they fall short is the same place unguided models do: the **cross-cutting
+production non-negotiables** — rate limiting, transport/TLS, tests, structured
+logging — dropped endpoint after endpoint (even the ~230k-star ECC omits rate
+limiting on 3 of 7 tasks). That is exactly what SOTA's operating principle 5 + the
+matched rules exist to close. Scope is honest: one task family (Python/FastAPI
+backend), single-sample, content-only; full method, per-arm misses, and
+limitations in the [competitor benchmark](../evals/results/2026-07-13/COMPETITOR-BENCHMARK.md).
 
 ## What you get by design (beyond the numbers)
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -90,7 +90,17 @@ python3 evals/run-clean.py --cases evals/cases/freshness.jsonl --model anthropic
 python3 evals/run-clean.py --cases evals/cases/router.jsonl
 python3 evals/run-clean.py --cases evals/cases/audit-hard.jsonl
 python3 evals/run-repo-audit.py          # cross-file audit (own fixture repo + harness)
+python3 evals/run-competitors.py --competitors-dir DIR   # SOTA vs competing libraries
 ```
+
+**Competitor benchmark** (`run-competitors.py`, `cases/competitors.json`): SOTA
+vs. the most popular competing guidance libraries on the 7 completeness tasks —
+content-only, blind-judged. Result (2026-07-14): **SOTA 0.99 vs ECC ~230k★ 0.87,
+awesome-cursorrules ~40k★ 0.83, alirezarezvani/claude-skills ~23k★ 0.81** (unguided
+0.58) — SOTA wins/ties every case, loses none; competitors drop the same
+cross-cutting concerns (rate limiting, transport, tests). Clone each competitor at
+the pinned SHA into `DIR`
+([`results/2026-07-13/COMPETITOR-BENCHMARK.md`](results/2026-07-13/COMPETITOR-BENCHMARK.md)).
 
 **Live-agent BUILD validation** (`judge-live-build.py`) closes the completeness
 eval's one simulation gap: `run-completeness.py` *pastes* the router's principle

--- a/evals/cases/competitors.json
+++ b/evals/cases/competitors.json
@@ -1,0 +1,45 @@
+{
+  "_note": "Competitor content manifest for run-competitors.py. Content is NOT vendored here (it is third-party); clone each repo at the pinned SHA into a --competitors-dir and the harness concatenates the listed files into that competitor's guidance bundle. Files chosen 2026-07-14 as each repo's best-matching content for building a secure Python/FastAPI backend feature (the completeness tasks), at a token budget comparable to a SOTA per-case arm. Licenses permit reuse (MIT / CC0); attribute in any published result.",
+  "competitors": {
+    "ECC": {
+      "repo": "affaan-m/ECC",
+      "sha": "ed387446052dfbc6b52de149406b70efa65edc59",
+      "license": "MIT",
+      "stars_approx": 230000,
+      "files": [
+        "the-security-guide.md",
+        "agents/fastapi-reviewer.md",
+        "agents/python-reviewer.md",
+        "agents/security-reviewer.md"
+      ]
+    },
+    "claude-skills": {
+      "repo": "alirezarezvani/claude-skills",
+      "sha": "84dc5a4f6ab93df5195805010572d7d0f874dadb",
+      "license": "MIT",
+      "stars_approx": 22600,
+      "files": [
+        "standards/security/security-standards.md",
+        "engineering/security-guidance/skills/security-guidance/SKILL.md",
+        "engineering/strict-api/SKILL.md",
+        "engineering/skills/api-design-reviewer/SKILL.md"
+      ]
+    },
+    "awesome-cursorrules": {
+      "repo": "PatrickJS/awesome-cursorrules",
+      "sha": "b044f956f021b6e8877f16781bcfc466a6a120e9",
+      "license": "CC0-1.0",
+      "stars_approx": 40300,
+      "files": [
+        "rules/fastapi.mdc",
+        "rules/fastapi-production-architecture-cursorrules-prompt-file.mdc",
+        "rules/python.mdc",
+        "rules/python-312-fastapi-best-practices-cursorrules-prom.mdc",
+        "rules/python-cursorrules-prompt-file-best-practices.mdc",
+        "rules/python-fastapi-best-practices-cursorrules-prompt-f.mdc",
+        "rules/python-fastapi-scalable-api-cursorrules-prompt-fil.mdc",
+        "rules/security-devsecops-ssdls-appsec.mdc"
+      ]
+    }
+  }
+}

--- a/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
+++ b/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
@@ -1,0 +1,82 @@
+# Competitor benchmark — SOTA vs. the most popular guidance libraries (2026-07-14)
+
+**Question:** every prior eval is SOTA vs. an *unguided* model. Does SOTA's
+guidance actually produce more complete code than the most popular competing
+skill/rules libraries on the same "build X" tasks? This runs them as extra arms
+on the 7 completeness tasks, same fixed rubric, same blind opus-4.8 judge.
+
+**Answer: yes — SOTA leads all three, and never loses a single case.**
+
+| arm | mean completeness | vs SOTA | vs unguided | per-case vs SOTA |
+|---|---|---|---|---|
+| **SOTA** | **0.99** | — | +0.40 | — |
+| ECC (~230k★) | 0.87 | **−0.12** | +0.28 | 5 win / 2 tie / 0 loss |
+| awesome-cursorrules (~40.3k★) | 0.83 | **−0.16** | +0.24 | 7 win / 0 tie / 0 loss |
+| alirezarezvani/claude-skills (~22.6k★) | 0.81 | **−0.17** | +0.23 | 6 win / 1 tie / 0 loss |
+| unguided | 0.58 | −0.40 | — | — |
+
+SOTA wins or ties **every one of the 21 head-to-head cases; it loses none.** And
+the competitors are **not strawmen** — all three lift completeness +0.23 to +0.28
+over an unguided model, i.e. they are genuinely good guidance. SOTA is simply more
+complete.
+
+## Why SOTA wins — the cross-cutting concerns competitors drop
+
+Most-missed rubric items per arm across the 7 tasks (what each still omits):
+
+- **unguided:** tests (7/7), rate limiting (6), transport/TLS (5), logging (4)
+- **SOTA:** session-invalidation (1 — the lone `c7` finite-constraint-budget slip)
+- **ECC (~230k★):** **rate limiting (3)**, storage-safety, image-bomb, idempotency, metrics, CSRF
+- **claude-skills:** **transport/TLS (4)**, **tests (4)**, rate limiting (2), logging, CSRF
+- **awesome-cursorrules:** **rate limiting (5)**, transport (2), storage, image-bomb, CSRF
+
+The pattern is consistent: competitors cover the *obvious* per-task security
+(auth, input validation, SQLi) well, but systematically drop the **cross-cutting
+production non-negotiables** — rate limiting, transport enforcement, tests,
+structured logging — on endpoint after endpoint. Even the ~230k-star ECC omits
+rate limiting on 3 of 7 tasks. That is exactly the gap SOTA's router *operating
+principle 5* + the matched rules are designed to close.
+
+## Method (fair, conservative, reproducible)
+
+- **Content-only, level playing field.** Every guided arm (SOTA and each
+  competitor) gets the *same neutral* build wrapper ("apply this guidance, then
+  review your code for completeness against it, don't ship incomplete code"). The
+  wrapper names **no** specific concern (naming e.g. rate limiting would leak
+  SOTA's non-negotiables to the competitors), so the only variable is the pasted
+  guidance. **SOTA's self-audit forcing function is *not* used here** — the number
+  is content-only, so SOTA's win is its guidance, not its method. In real
+  deployment SOTA's self-audit widens the gap (it lifts SOTA to 0.99 *with* the
+  gate in `run-completeness.py`; here SOTA reaches 0.987 on content alone).
+- **Each competitor's best-matching content** for "build a secure Python/FastAPI
+  backend feature," at a token budget in the same ballpark as a SOTA arm, pinned
+  by commit SHA in [`evals/cases/competitors.json`](../../cases/competitors.json).
+  Licenses permit reuse (ECC/claude-skills MIT, cursorrules CC0); attributed here.
+- **Blind judge** (opus-4.8), same rubric as `run-completeness.py`. No artifact was
+  truncated (largest 92 KB, well under the 32k-token cap). Raw per-case data:
+  `competitor-benchmark.json`. Reproduce: `python3 evals/run-competitors.py
+  --competitors-dir <clones>`.
+
+## Honest limitations (state them, don't bury them)
+
+- **One task family** — 7 Python/FastAPI backend-security build tasks. A different
+  domain (frontend, data pipelines, mobile) could shift the ordering; this is the
+  domain we measured.
+- **Single sample, temp 0** (deterministic). Not yet multi-sampled per arm.
+- **Content selection is a judgment call** — we picked each competitor's most
+  relevant files; a different reviewer might pick slightly differently. The manifest
+  makes it inspectable and re-runnable.
+- **Bundle-size asymmetry:** SOTA's per-case bundles (65–100 KB, routed to the
+  task) are larger than the competitors' general bundles (28–42 KB). This is a real
+  SOTA property (routing gives it matched depth), not a thumb on the scale — and
+  per SOTA's own [context-rot finding](../../../docs/WHY-COMPLETENESS-RESIDUAL.md),
+  *more* content is not automatically an advantage.
+
+## What this earns
+
+The [honesty gate](../../../docs/ROADMAP.md) said: make a "better than library X"
+claim only if a fair, blind, reproducible comparison supports it. It now does —
+against the single most-starred cross-AI peer (ECC), the most-starred rules
+library (awesome-cursorrules), and the closest same-kind skills library
+(claude-skills). The claim is scoped to **completeness on backend build tasks**,
+content-only, and is reproducible from this repo.

--- a/evals/results/2026-07-13/competitor-benchmark.json
+++ b/evals/results/2026-07-13/competitor-benchmark.json
@@ -1,0 +1,700 @@
+{
+ "arms": [
+  "without",
+  "sota",
+  "ECC",
+  "claude-skills",
+  "awesome-cursorrules"
+ ],
+ "cases": {
+  "c1_ticket_api": {
+   "rubric_n": 12,
+   "arms": {
+    "without": {
+     "recall": 0.6666666666666666,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "errhygiene",
+      "outschema",
+      "sizelimit"
+     ],
+     "missing": [
+      "ratelimit",
+      "logging",
+      "transport",
+      "tests"
+     ],
+     "artifact_len": 15747
+    },
+    "sota": {
+     "recall": 1.0,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "ratelimit",
+      "pagination",
+      "logging",
+      "errhygiene",
+      "transport",
+      "outschema",
+      "sizelimit",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 69238
+    },
+    "ECC": {
+     "recall": 1.0,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "ratelimit",
+      "pagination",
+      "logging",
+      "errhygiene",
+      "transport",
+      "outschema",
+      "sizelimit",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 47454
+    },
+    "claude-skills": {
+     "recall": 0.75,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "errhygiene",
+      "outschema",
+      "sizelimit",
+      "tests"
+     ],
+     "missing": [
+      "ratelimit",
+      "logging",
+      "transport"
+     ],
+     "artifact_len": 52205
+    },
+    "awesome-cursorrules": {
+     "recall": 0.8333333333333334,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "logging",
+      "errhygiene",
+      "outschema",
+      "sizelimit",
+      "tests"
+     ],
+     "missing": [
+      "ratelimit",
+      "transport"
+     ],
+     "artifact_len": 64555
+    }
+   }
+  },
+  "c2_upload": {
+   "rubric_n": 11,
+   "arms": {
+    "without": {
+     "recall": 0.45454545454545453,
+     "present": [
+      "authn_authz",
+      "contenttype",
+      "sizelimit",
+      "pathtraversal",
+      "reencode"
+     ],
+     "missing": [
+      "storage",
+      "imagebomb",
+      "ratelimit",
+      "logging",
+      "errhygiene",
+      "tests"
+     ],
+     "artifact_len": 18512
+    },
+    "sota": {
+     "recall": 1.0,
+     "present": [
+      "authn_authz",
+      "contenttype",
+      "sizelimit",
+      "pathtraversal",
+      "storage",
+      "imagebomb",
+      "reencode",
+      "ratelimit",
+      "logging",
+      "errhygiene",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 44674
+    },
+    "ECC": {
+     "recall": 0.7272727272727273,
+     "present": [
+      "authn_authz",
+      "contenttype",
+      "sizelimit",
+      "pathtraversal",
+      "reencode",
+      "logging",
+      "errhygiene",
+      "tests"
+     ],
+     "missing": [
+      "storage",
+      "imagebomb",
+      "ratelimit"
+     ],
+     "artifact_len": 43291
+    },
+    "claude-skills": {
+     "recall": 0.8181818181818182,
+     "present": [
+      "authn_authz",
+      "contenttype",
+      "sizelimit",
+      "pathtraversal",
+      "imagebomb",
+      "reencode",
+      "ratelimit",
+      "logging",
+      "errhygiene"
+     ],
+     "missing": [
+      "storage",
+      "tests"
+     ],
+     "artifact_len": 34960
+    },
+    "awesome-cursorrules": {
+     "recall": 0.7272727272727273,
+     "present": [
+      "authn_authz",
+      "contenttype",
+      "sizelimit",
+      "pathtraversal",
+      "reencode",
+      "ratelimit",
+      "logging",
+      "tests"
+     ],
+     "missing": [
+      "storage",
+      "imagebomb",
+      "errhygiene"
+     ],
+     "artifact_len": 79248
+    }
+   }
+  },
+  "c3_emailjob": {
+   "rubric_n": 11,
+   "arms": {
+    "without": {
+     "recall": 0.7272727272727273,
+     "present": [
+      "retry",
+      "deadletter",
+      "secrets",
+      "logging",
+      "metrics",
+      "concurrency",
+      "shutdown",
+      "errhandling"
+     ],
+     "missing": [
+      "idempotency",
+      "ratelimit",
+      "tests"
+     ],
+     "artifact_len": 22977
+    },
+    "sota": {
+     "recall": 1.0,
+     "present": [
+      "idempotency",
+      "retry",
+      "deadletter",
+      "ratelimit",
+      "secrets",
+      "logging",
+      "metrics",
+      "concurrency",
+      "shutdown",
+      "errhandling",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 74315
+    },
+    "ECC": {
+     "recall": 0.7272727272727273,
+     "present": [
+      "retry",
+      "deadletter",
+      "secrets",
+      "logging",
+      "concurrency",
+      "shutdown",
+      "errhandling",
+      "tests"
+     ],
+     "missing": [
+      "idempotency",
+      "ratelimit",
+      "metrics"
+     ],
+     "artifact_len": 59875
+    },
+    "claude-skills": {
+     "recall": 1.0,
+     "present": [
+      "idempotency",
+      "retry",
+      "deadletter",
+      "ratelimit",
+      "secrets",
+      "logging",
+      "metrics",
+      "concurrency",
+      "shutdown",
+      "errhandling",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 63023
+    },
+    "awesome-cursorrules": {
+     "recall": 0.9090909090909091,
+     "present": [
+      "idempotency",
+      "retry",
+      "deadletter",
+      "secrets",
+      "logging",
+      "metrics",
+      "concurrency",
+      "shutdown",
+      "errhandling",
+      "tests"
+     ],
+     "missing": [
+      "ratelimit"
+     ],
+     "artifact_len": 66804
+    }
+   }
+  },
+  "c4_login": {
+   "rubric_n": 10,
+   "arms": {
+    "without": {
+     "recall": 0.5,
+     "present": [
+      "pwhash",
+      "enumeration",
+      "consttime",
+      "session",
+      "validation"
+     ],
+     "missing": [
+      "bruteforce",
+      "nopwlog",
+      "transport",
+      "csrf",
+      "tests"
+     ],
+     "artifact_len": 8111
+    },
+    "sota": {
+     "recall": 1.0,
+     "present": [
+      "pwhash",
+      "bruteforce",
+      "enumeration",
+      "consttime",
+      "session",
+      "validation",
+      "nopwlog",
+      "transport",
+      "csrf",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 53366
+    },
+    "ECC": {
+     "recall": 0.9,
+     "present": [
+      "pwhash",
+      "bruteforce",
+      "enumeration",
+      "consttime",
+      "session",
+      "validation",
+      "nopwlog",
+      "transport",
+      "tests"
+     ],
+     "missing": [
+      "csrf"
+     ],
+     "artifact_len": 32814
+    },
+    "claude-skills": {
+     "recall": 0.7,
+     "present": [
+      "pwhash",
+      "bruteforce",
+      "enumeration",
+      "consttime",
+      "session",
+      "validation",
+      "nopwlog"
+     ],
+     "missing": [
+      "transport",
+      "csrf",
+      "tests"
+     ],
+     "artifact_len": 30531
+    },
+    "awesome-cursorrules": {
+     "recall": 0.9,
+     "present": [
+      "pwhash",
+      "bruteforce",
+      "enumeration",
+      "consttime",
+      "session",
+      "validation",
+      "nopwlog",
+      "transport",
+      "tests"
+     ],
+     "missing": [
+      "csrf"
+     ],
+     "artifact_len": 44034
+    }
+   }
+  },
+  "c5_search": {
+   "rubric_n": 10,
+   "arms": {
+    "without": {
+     "recall": 0.6,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "errhygiene"
+     ],
+     "missing": [
+      "ratelimit",
+      "logging",
+      "transport",
+      "tests"
+     ],
+     "artifact_len": 18946
+    },
+    "sota": {
+     "recall": 1.0,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "ratelimit",
+      "logging",
+      "errhygiene",
+      "transport",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 92544
+    },
+    "ECC": {
+     "recall": 0.9,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "logging",
+      "errhygiene",
+      "transport",
+      "tests"
+     ],
+     "missing": [
+      "ratelimit"
+     ],
+     "artifact_len": 48207
+    },
+    "claude-skills": {
+     "recall": 0.9,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "ratelimit",
+      "logging",
+      "errhygiene",
+      "tests"
+     ],
+     "missing": [
+      "transport"
+     ],
+     "artifact_len": 51016
+    },
+    "awesome-cursorrules": {
+     "recall": 0.9,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "logging",
+      "errhygiene",
+      "transport",
+      "tests"
+     ],
+     "missing": [
+      "ratelimit"
+     ],
+     "artifact_len": 63559
+    }
+   }
+  },
+  "c6_webhook": {
+   "rubric_n": 10,
+   "arms": {
+    "without": {
+     "recall": 0.5,
+     "present": [
+      "sigverify",
+      "constanttime",
+      "idempotency",
+      "validation",
+      "errhygiene"
+     ],
+     "missing": [
+      "sizelimit",
+      "ratelimit",
+      "logging",
+      "transport",
+      "tests"
+     ],
+     "artifact_len": 14870
+    },
+    "sota": {
+     "recall": 1.0,
+     "present": [
+      "sigverify",
+      "constanttime",
+      "idempotency",
+      "validation",
+      "sizelimit",
+      "ratelimit",
+      "logging",
+      "errhygiene",
+      "transport",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 66617
+    },
+    "ECC": {
+     "recall": 0.9,
+     "present": [
+      "sigverify",
+      "constanttime",
+      "idempotency",
+      "validation",
+      "ratelimit",
+      "logging",
+      "errhygiene",
+      "transport",
+      "tests"
+     ],
+     "missing": [
+      "sizelimit"
+     ],
+     "artifact_len": 46803
+    },
+    "claude-skills": {
+     "recall": 0.8,
+     "present": [
+      "sigverify",
+      "constanttime",
+      "idempotency",
+      "validation",
+      "sizelimit",
+      "logging",
+      "errhygiene",
+      "transport"
+     ],
+     "missing": [
+      "ratelimit",
+      "tests"
+     ],
+     "artifact_len": 32929
+    },
+    "awesome-cursorrules": {
+     "recall": 0.8,
+     "present": [
+      "sigverify",
+      "constanttime",
+      "idempotency",
+      "validation",
+      "logging",
+      "errhygiene",
+      "transport",
+      "tests"
+     ],
+     "missing": [
+      "sizelimit",
+      "ratelimit"
+     ],
+     "artifact_len": 51267
+    }
+   }
+  },
+  "c7_pwreset": {
+   "rubric_n": 11,
+   "arms": {
+    "without": {
+     "recall": 0.6363636363636364,
+     "present": [
+      "tokenentropy",
+      "tokenhash",
+      "tokenexpiry",
+      "tokensingleuse",
+      "noenum",
+      "notokenlog",
+      "pwhash"
+     ],
+     "missing": [
+      "ratelimit",
+      "transport",
+      "sessioninvalidate",
+      "tests"
+     ],
+     "artifact_len": 25629
+    },
+    "sota": {
+     "recall": 0.9090909090909091,
+     "present": [
+      "tokenentropy",
+      "tokenhash",
+      "tokenexpiry",
+      "tokensingleuse",
+      "noenum",
+      "ratelimit",
+      "notokenlog",
+      "pwhash",
+      "transport",
+      "tests"
+     ],
+     "missing": [
+      "sessioninvalidate"
+     ],
+     "artifact_len": 68679
+    },
+    "ECC": {
+     "recall": 0.9090909090909091,
+     "present": [
+      "tokenentropy",
+      "tokenhash",
+      "tokenexpiry",
+      "tokensingleuse",
+      "noenum",
+      "ratelimit",
+      "notokenlog",
+      "pwhash",
+      "transport",
+      "tests"
+     ],
+     "missing": [
+      "sessioninvalidate"
+     ],
+     "artifact_len": 39558
+    },
+    "claude-skills": {
+     "recall": 0.7272727272727273,
+     "present": [
+      "tokenentropy",
+      "tokenhash",
+      "tokenexpiry",
+      "tokensingleuse",
+      "noenum",
+      "ratelimit",
+      "notokenlog",
+      "pwhash"
+     ],
+     "missing": [
+      "transport",
+      "sessioninvalidate",
+      "tests"
+     ],
+     "artifact_len": 33733
+    },
+    "awesome-cursorrules": {
+     "recall": 0.7272727272727273,
+     "present": [
+      "tokenentropy",
+      "tokenhash",
+      "tokenexpiry",
+      "tokensingleuse",
+      "noenum",
+      "notokenlog",
+      "pwhash",
+      "tests"
+     ],
+     "missing": [
+      "ratelimit",
+      "transport",
+      "sessioninvalidate"
+     ],
+     "artifact_len": 71217
+    }
+   }
+  }
+ },
+ "means": {
+  "without": 0.5835497835497836,
+  "sota": 0.987012987012987,
+  "ECC": 0.8662337662337664,
+  "claude-skills": 0.8136363636363637,
+  "awesome-cursorrules": 0.8281385281385282
+ }
+}

--- a/evals/run-competitors.py
+++ b/evals/run-competitors.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Competitor benchmark: SOTA vs. named competing guidance libraries, same task.
+
+The completeness eval (run-completeness.py) is SOTA vs. an *unguided* model. This
+adds competitor arms so we can say — with hard numbers — whether SOTA's guidance
+produces more complete code than the most popular competing skill/rules libraries
+on the same "build X" tasks. It reuses the SAME cases, rubric, and blind judge.
+
+FAIRNESS — content-only, level playing field (deliberately conservative for SOTA):
+  - Every GUIDED arm (SOTA and each competitor) gets the SAME neutral build wrapper
+    ("apply this guidance, then review your code for completeness against it, don't
+    ship incomplete code"). The wrapper names NO specific concern (naming e.g. rate
+    limiting would leak SOTA's non-negotiables to competitors), so the ONLY variable
+    is the pasted guidance content.
+  - This does NOT give SOTA its self-audit forcing function (which lifts it to ~0.99
+    in its own deployment, run-completeness.py). So SOTA's number here is a
+    CONTENT-ONLY measure — if SOTA still wins, it is the guidance, not the method.
+  - Each competitor's bundle is its best-matching content for "build a secure
+    Python/FastAPI backend feature" (evals/cases/competitors.json), at a token
+    budget comparable to a SOTA per-case arm. Competitor content is NOT vendored;
+    pass --competitors-dir pointing at clones at the pinned SHAs.
+  - Judge is opus-4.8, blind to which arm produced each artifact.
+
+Auth: OPENROUTER_API_KEY (env or ./.env). Never printed/committed.
+Usage: python3 evals/run-competitors.py --competitors-dir DIR [--build-model M]
+       [--judge-model M] [--only ECC,claude-skills] [--out FILE]
+"""
+import argparse
+import json
+import os
+import sys
+import importlib.util
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Reuse the completeness harness (call/judge/load_cases/principle5).
+_spec = importlib.util.spec_from_file_location(
+    "run_completeness", os.path.join(ROOT, "evals/run-completeness.py"))
+_rc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_rc)
+
+MANIFEST = os.path.join(ROOT, "evals/cases/competitors.json")
+
+# Neutral, concern-agnostic build wrapper — identical for every guided arm.
+NEUTRAL_BUILD = (
+    "\n\n---\nBUILD PROCESS (follow it): apply the guidance above while writing the "
+    "code. Before you finish, review your implementation against that guidance and "
+    "general production best practice, and ADD anything it implies you are missing — "
+    "or state explicitly why it is out of scope. Do not present incomplete code."
+    "\n\nTask: ")
+
+
+def read(path):
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+def sota_bundle(case):
+    """SOTA's per-case content: router principle 5 + the case's rules files."""
+    ctx = "\n\n".join(read(os.path.join(ROOT, s)) for s in case["skills"])
+    return f"{_rc.principle5()}\n\n{ctx}"
+
+
+def competitor_bundle(comp, cdir):
+    """Concatenate a competitor's manifest files from the local clone."""
+    base = os.path.join(cdir, os.path.basename(comp["repo"]))
+    parts = []
+    for rel in comp["files"]:
+        p = os.path.join(base, rel)
+        if not os.path.exists(p):
+            sys.exit(f"missing competitor file: {p}\n(clone {comp['repo']} at {comp['sha']} into {cdir})")
+        parts.append(f"===== {rel} =====\n{read(p)}")
+    return "\n\n".join(parts)
+
+
+def guided_prompt(bundle, task):
+    return (f"Apply the following engineering guidance:\n\n{bundle}{NEUTRAL_BUILD}{task}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--competitors-dir", required=True,
+                    help="dir containing clones (ECC/, claude-skills/, awesome-cursorrules/)")
+    ap.add_argument("--build-model", default="anthropic/claude-sonnet-4.6")
+    ap.add_argument("--judge-model", default="anthropic/claude-opus-4.8")
+    ap.add_argument("--only", default=None, help="comma list of competitor keys to run")
+    ap.add_argument("--out", default=None)
+    a = ap.parse_args()
+    k = _rc.key()
+    cases = _rc.load_cases()
+    manifest = json.load(open(MANIFEST, encoding="utf-8"))["competitors"]
+    comps = list(manifest)
+    if a.only:
+        comps = [c for c in comps if c in a.only.split(",")]
+    arms = ["without", "sota"] + comps
+    print(f"build={a.build_model}  judge={a.judge_model}  cases={len(cases)}  "
+          f"arms={arms}  (content-only, blind judge)\n")
+
+    results, totals = {}, {arm: 0.0 for arm in arms}
+    for c in cases:
+        row = {"rubric_n": len(c["rubric"]), "arms": {}}
+        for arm in arms:
+            if arm == "without":
+                prompt = c["task"]
+            elif arm == "sota":
+                prompt = guided_prompt(sota_bundle(c), c["task"])
+            else:
+                prompt = guided_prompt(competitor_bundle(manifest[arm], a.competitors_dir), c["task"])
+            print(f"  {c['id']:16s} {arm:20s} generating…", flush=True)
+            art = _rc.call(a.build_model, prompt, k, max_tokens=32000, temp=0.0)
+            verdict = _rc.judge(art, c["rubric"], a.judge_model, k)
+            present = [r["id"] for r in c["rubric"] if verdict.get(r["id"]) == "present"]
+            recall = len(present) / len(c["rubric"])
+            totals[arm] += recall
+            row["arms"][arm] = {"recall": recall, "present": present,
+                                "missing": [r["id"] for r in c["rubric"] if r["id"] not in present],
+                                "artifact_len": len(art)}
+            print(f"  {c['id']:16s} {arm:20s} recall={recall:.2f}", flush=True)
+        results[c["id"]] = row
+        line = "  ".join(f"{arm}={row['arms'][arm]['recall']:.2f}" for arm in arms)
+        print(f"{c['id']:16s} {line}")
+    n = len(cases)
+    print("\nMEAN completeness by arm:")
+    for arm in arms:
+        m = totals[arm] / n
+        delta = f"  (vs sota {m - totals['sota']/n:+.2f}, vs unguided {m - totals['without']/n:+.2f})" if arm not in ("without", "sota") else ""
+        print(f"  {arm:20s} {m:.3f}{delta}")
+    if a.out:
+        json.dump({"arms": arms, "cases": results,
+                   "means": {arm: totals[arm]/n for arm in arms}}, open(a.out, "w"), indent=1)
+        print(f"saved {a.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Executes the roadmap's competitor benchmark and **clears the honesty gate** for a
scoped "vs library X" claim. SOTA vs. the validated fair peers on the 7
completeness build tasks — **content-only** (SOTA's self-audit forcing function
turned OFF, so its win is the guidance not the method), same fixed rubric, same
blind opus-4.8 judge.

| Library | Stars | Completeness |
|---|---|---|
| **SOTA** | — | **0.99** |
| ECC | ~230k | 0.87 |
| awesome-cursorrules | ~40k | 0.83 |
| alirezarezvani/claude-skills | ~23k | 0.81 |
| unguided | — | 0.58 |

**SOTA wins or ties every one of the 21 head-to-head cases and loses none.** The
competitors are **not strawmen** — all three beat an unguided model by +0.23–0.28.
Where they fall short is the cross-cutting production non-negotiables — rate
limiting, transport/TLS, tests, structured logging — dropped endpoint after
endpoint (even the ~230k-star ECC omits rate limiting on 3 of 7 tasks). Exactly
what SOTA's operating principle 5 + matched rules close.

**Fairness / reproducibility:**
- Neutral shared build wrapper (names no concern → no leakage of SOTA's
  non-negotiables); only the pasted guidance varies.
- Each competitor's best-matching content, pinned by commit SHA in
  `evals/cases/competitors.json` (content NOT vendored; MIT/CC0, attributed).
- No artifact truncated (largest 92 KB < 32k-token cap). Raw data in
  `competitor-benchmark.json`.
- **Honest limits stated:** one task family (Python/FastAPI backend), single-sample,
  content-only, SOTA bundles larger (routed depth). Follow-ups logged.

`docs/WHY-IT-WORKS.md` now carries the claim (the old "we have not benchmarked one"
line is corrected). `[1.10.0]` archived to keep the root CHANGELOG under 500.

## Validation
- All star counts / SHAs / licenses pulled live from the GitHub API
- `./scripts/check-invariants.sh` — all 7 pass; pre-commit (gitleaks + invariants) — pass
