### PR TITLE
test(evals): competitor benchmark confidence check + harness multi-sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,10 @@ Evaluation-harness additions (no skill-content change; not in CI — see
   loses none; competitors are legitimate (all beat unguided by +0.23–0.28) but
   drop the cross-cutting non-negotiables (rate limiting, transport, tests) SOTA
   embeds. Clears the roadmap honesty gate for a scoped, reproducible "vs library
-  X" claim; `docs/WHY-IT-WORKS.md` now carries it.
+  X" claim; `docs/WHY-IT-WORKS.md` now carries it. A **3-sample/temp-0.7 confidence
+  check** on the 3 tightest cases confirms the lead holds — SOTA's worst sample is
+  ≥ each competitor's best, and the gaps match the single-sample run. The harness
+  gained `--samples/--temp`, `--ids`, and crash-safe incremental `--out` saving.
 
 ### Changed
 

--- a/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
+++ b/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
@@ -57,12 +57,36 @@ principle 5* + the matched rules are designed to close.
   `competitor-benchmark.json`. Reproduce: `python3 evals/run-competitors.py
   --competitors-dir <clones>`.
 
+## Confidence — the lead survives sampling (multi-sample, 2026-07-14)
+
+The main table is single-sample (temp 0). To check the lead isn't a lucky draw, we
+re-ran **3 samples at temp 0.7** on the **3 tightest cases** — c1, c3, c7, the ones
+where a competitor *tied* SOTA in the single-sample run (`competitor-benchmark-3sample.json`):
+
+| arm | mean (3 tight cases) | vs SOTA |
+|---|---|---|
+| **SOTA** | **0.98** | — |
+| ECC | 0.87 | −0.11 |
+| claude-skills | 0.83 | −0.15 |
+| awesome-cursorrules | 0.82 | −0.16 |
+| unguided | 0.65 | −0.33 |
+
+The gaps (−0.11 to −0.16) are **the same** as the single-sample full-7 run
+(−0.12 to −0.17), and **on every one of these cases SOTA's *worst* sample is ≥ each
+competitor's *best* sample** — competitors occasionally tie SOTA at the ceiling
+(ECC/cursorrules hit 1.00 on c1; ECC ties at 0.91 on c7) but never beat it. SOTA's
+own variance is near-zero (sd 0.00 on c1/c3, 0.04 on c7). The lead is stable.
+*(Multi-sampling the other 4 cases and the full 7 was left for a top-up — those
+were the least contested, so the tight-case check is the informative one.)*
+
 ## Honest limitations (state them, don't bury them)
 
 - **One task family** — 7 Python/FastAPI backend-security build tasks. A different
   domain (frontend, data pipelines, mobile) could shift the ordering; this is the
   domain we measured.
-- **Single sample, temp 0** (deterministic). Not yet multi-sampled per arm.
+- **Mostly single-sample, temp 0** (deterministic). A 3-sample/temp-0.7 confidence
+  check on the 3 tightest cases (above) confirms the lead holds; the other 4 cases
+  and the full 7 are not yet multi-sampled (budget).
 - **Content selection is a judgment call** — we picked each competitor's most
   relevant files; a different reviewer might pick slightly differently. The manifest
   makes it inspectable and re-runnable.

--- a/evals/results/2026-07-13/competitor-benchmark-3sample.json
+++ b/evals/results/2026-07-13/competitor-benchmark-3sample.json
@@ -1,0 +1,442 @@
+{
+ "arms": [
+  "without",
+  "sota",
+  "ECC",
+  "claude-skills",
+  "awesome-cursorrules"
+ ],
+ "samples": 3,
+ "temp": 0.7,
+ "cases": {
+  "c1_ticket_api": {
+   "rubric_n": 12,
+   "arms": {
+    "without": {
+     "recall": 0.6666666666666666,
+     "recalls": [
+      0.6666666666666666,
+      0.6666666666666666,
+      0.6666666666666666
+     ],
+     "min": 0.6666666666666666,
+     "max": 0.6666666666666666,
+     "sd": 0.0,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "errhygiene",
+      "outschema",
+      "sizelimit"
+     ],
+     "missing": [
+      "ratelimit",
+      "logging",
+      "transport",
+      "tests"
+     ],
+     "artifact_len": 15130
+    },
+    "sota": {
+     "recall": 1.0,
+     "recalls": [
+      1.0,
+      1.0,
+      1.0
+     ],
+     "min": 1.0,
+     "max": 1.0,
+     "sd": 0.0,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "ratelimit",
+      "pagination",
+      "logging",
+      "errhygiene",
+      "transport",
+      "outschema",
+      "sizelimit",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 65036
+    },
+    "ECC": {
+     "recall": 0.9722222222222222,
+     "recalls": [
+      0.9166666666666666,
+      1.0,
+      1.0
+     ],
+     "min": 0.9166666666666666,
+     "max": 1.0,
+     "sd": 0.039283710065919325,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "ratelimit",
+      "pagination",
+      "logging",
+      "errhygiene",
+      "transport",
+      "outschema",
+      "sizelimit",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 50172
+    },
+    "claude-skills": {
+     "recall": 0.7777777777777778,
+     "recalls": [
+      0.8333333333333334,
+      0.75,
+      0.75
+     ],
+     "min": 0.75,
+     "max": 0.8333333333333334,
+     "sd": 0.039283710065919325,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "logging",
+      "errhygiene",
+      "outschema",
+      "sizelimit"
+     ],
+     "missing": [
+      "ratelimit",
+      "transport",
+      "tests"
+     ],
+     "artifact_len": 34907
+    },
+    "awesome-cursorrules": {
+     "recall": 0.9166666666666666,
+     "recalls": [
+      0.9166666666666666,
+      1.0,
+      0.8333333333333334
+     ],
+     "min": 0.8333333333333334,
+     "max": 1.0,
+     "sd": 0.06804138174397716,
+     "present": [
+      "authn",
+      "authz",
+      "validation",
+      "sqli",
+      "pagination",
+      "logging",
+      "errhygiene",
+      "outschema",
+      "sizelimit",
+      "tests"
+     ],
+     "missing": [
+      "ratelimit",
+      "transport"
+     ],
+     "artifact_len": 57995
+    }
+   }
+  },
+  "c3_emailjob": {
+   "rubric_n": 11,
+   "arms": {
+    "without": {
+     "recall": 0.6363636363636364,
+     "recalls": [
+      0.7272727272727273,
+      0.6363636363636364,
+      0.5454545454545454
+     ],
+     "min": 0.5454545454545454,
+     "max": 0.7272727272727273,
+     "sd": 0.07422696190252057,
+     "present": [
+      "retry",
+      "deadletter",
+      "secrets",
+      "logging",
+      "shutdown",
+      "errhandling"
+     ],
+     "missing": [
+      "idempotency",
+      "ratelimit",
+      "metrics",
+      "concurrency",
+      "tests"
+     ],
+     "artifact_len": 21365
+    },
+    "sota": {
+     "recall": 1.0,
+     "recalls": [
+      1.0,
+      1.0,
+      1.0
+     ],
+     "min": 1.0,
+     "max": 1.0,
+     "sd": 0.0,
+     "present": [
+      "idempotency",
+      "retry",
+      "deadletter",
+      "ratelimit",
+      "secrets",
+      "logging",
+      "metrics",
+      "concurrency",
+      "shutdown",
+      "errhandling",
+      "tests"
+     ],
+     "missing": [],
+     "artifact_len": 105384
+    },
+    "ECC": {
+     "recall": 0.7272727272727272,
+     "recalls": [
+      0.7272727272727273,
+      0.7272727272727273,
+      0.7272727272727273
+     ],
+     "min": 0.7272727272727273,
+     "max": 0.7272727272727273,
+     "sd": 1.1102230246251565e-16,
+     "present": [
+      "retry",
+      "deadletter",
+      "secrets",
+      "logging",
+      "concurrency",
+      "shutdown",
+      "errhandling",
+      "tests"
+     ],
+     "missing": [
+      "idempotency",
+      "ratelimit",
+      "metrics"
+     ],
+     "artifact_len": 64854
+    },
+    "claude-skills": {
+     "recall": 0.8484848484848485,
+     "recalls": [
+      0.9090909090909091,
+      0.7272727272727273,
+      0.9090909090909091
+     ],
+     "min": 0.7272727272727273,
+     "max": 0.9090909090909091,
+     "sd": 0.08570991287109664,
+     "present": [
+      "idempotency",
+      "retry",
+      "deadletter",
+      "secrets",
+      "logging",
+      "metrics",
+      "concurrency",
+      "shutdown",
+      "errhandling",
+      "tests"
+     ],
+     "missing": [
+      "ratelimit"
+     ],
+     "artifact_len": 70727
+    },
+    "awesome-cursorrules": {
+     "recall": 0.787878787878788,
+     "recalls": [
+      0.9090909090909091,
+      0.7272727272727273,
+      0.7272727272727273
+     ],
+     "min": 0.7272727272727273,
+     "max": 0.9090909090909091,
+     "sd": 0.08570991287109664,
+     "present": [
+      "idempotency",
+      "deadletter",
+      "secrets",
+      "logging",
+      "concurrency",
+      "shutdown",
+      "errhandling",
+      "tests"
+     ],
+     "missing": [
+      "retry",
+      "ratelimit",
+      "metrics"
+     ],
+     "artifact_len": 116106
+    }
+   }
+  },
+  "c7_pwreset": {
+   "rubric_n": 11,
+   "arms": {
+    "without": {
+     "recall": 0.6363636363636364,
+     "recalls": [
+      0.6363636363636364,
+      0.6363636363636364,
+      0.6363636363636364
+     ],
+     "min": 0.6363636363636364,
+     "max": 0.6363636363636364,
+     "sd": 0.0,
+     "present": [
+      "tokenentropy",
+      "tokenhash",
+      "tokenexpiry",
+      "tokensingleuse",
+      "noenum",
+      "notokenlog",
+      "pwhash"
+     ],
+     "missing": [
+      "ratelimit",
+      "transport",
+      "sessioninvalidate",
+      "tests"
+     ],
+     "artifact_len": 18970
+    },
+    "sota": {
+     "recall": 0.9393939393939394,
+     "recalls": [
+      1.0,
+      0.9090909090909091,
+      0.9090909090909091
+     ],
+     "min": 0.9090909090909091,
+     "max": 1.0,
+     "sd": 0.04285495643554835,
+     "present": [
+      "tokenentropy",
+      "tokenhash",
+      "tokenexpiry",
+      "tokensingleuse",
+      "noenum",
+      "ratelimit",
+      "notokenlog",
+      "pwhash",
+      "transport",
+      "tests"
+     ],
+     "missing": [
+      "sessioninvalidate"
+     ],
+     "artifact_len": 62267
+    },
+    "ECC": {
+     "recall": 0.9090909090909091,
+     "recalls": [
+      0.9090909090909091,
+      0.9090909090909091,
+      0.9090909090909091
+     ],
+     "min": 0.9090909090909091,
+     "max": 0.9090909090909091,
+     "sd": 0.0,
+     "present": [
+      "tokenentropy",
+      "tokenhash",
+      "tokenexpiry",
+      "tokensingleuse",
+      "noenum",
+      "ratelimit",
+      "notokenlog",
+      "pwhash",
+      "transport",
+      "tests"
+     ],
+     "missing": [
+      "sessioninvalidate"
+     ],
+     "artifact_len": 41898
+    },
+    "claude-skills": {
+     "recall": 0.8484848484848485,
+     "recalls": [
+      0.8181818181818182,
+      0.9090909090909091,
+      0.8181818181818182
+     ],
+     "min": 0.8181818181818182,
+     "max": 0.9090909090909091,
+     "sd": 0.04285495643554829,
+     "present": [
+      "tokenentropy",
+      "tokenhash",
+      "tokenexpiry",
+      "tokensingleuse",
+      "noenum",
+      "ratelimit",
+      "notokenlog",
+      "pwhash",
+      "tests"
+     ],
+     "missing": [
+      "transport",
+      "sessioninvalidate"
+     ],
+     "artifact_len": 35979
+    },
+    "awesome-cursorrules": {
+     "recall": 0.7575757575757577,
+     "recalls": [
+      0.7272727272727273,
+      0.8181818181818182,
+      0.7272727272727273
+     ],
+     "min": 0.7272727272727273,
+     "max": 0.8181818181818182,
+     "sd": 0.04285495643554835,
+     "present": [
+      "tokenentropy",
+      "tokenhash",
+      "tokenexpiry",
+      "tokensingleuse",
+      "noenum",
+      "notokenlog",
+      "pwhash",
+      "tests"
+     ],
+     "missing": [
+      "ratelimit",
+      "transport",
+      "sessioninvalidate"
+     ],
+     "artifact_len": 67853
+    }
+   }
+  }
+ },
+ "means": {
+  "without": 0.6464646464646465,
+  "sota": 0.9797979797979798,
+  "ECC": 0.8695286195286195,
+  "claude-skills": 0.8249158249158249,
+  "awesome-cursorrules": 0.8207070707070708
+ }
+}

--- a/evals/run-competitors.py
+++ b/evals/run-competitors.py
@@ -77,6 +77,13 @@ def guided_prompt(bundle, task):
     return (f"Apply the following engineering guidance:\n\n{bundle}{NEUTRAL_BUILD}{task}")
 
 
+def _spread(xs):
+    lo, hi = min(xs), max(xs)
+    mean = sum(xs) / len(xs)
+    sd = (sum((x - mean) ** 2 for x in xs) / len(xs)) ** 0.5
+    return mean, lo, hi, sd
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--competitors-dir", required=True,
@@ -84,17 +91,26 @@ def main():
     ap.add_argument("--build-model", default="anthropic/claude-sonnet-4.6")
     ap.add_argument("--judge-model", default="anthropic/claude-opus-4.8")
     ap.add_argument("--only", default=None, help="comma list of competitor keys to run")
+    ap.add_argument("--ids", default=None, help="comma list of case ids to run (subset)")
+    ap.add_argument("--samples", type=int, default=1,
+                    help="generations per (case,arm); mean recall reported. >1 needs --temp>0")
+    ap.add_argument("--temp", type=float, default=0.0)
     ap.add_argument("--out", default=None)
     a = ap.parse_args()
+    if a.samples > 1 and a.temp == 0.0:
+        print("note: --samples>1 at --temp 0 gives identical deterministic runs; use --temp 0.7.\n")
     k = _rc.key()
     cases = _rc.load_cases()
+    if a.ids:
+        want = set(a.ids.split(","))
+        cases = [c for c in cases if c["id"] in want]
     manifest = json.load(open(MANIFEST, encoding="utf-8"))["competitors"]
     comps = list(manifest)
     if a.only:
         comps = [c for c in comps if c in a.only.split(",")]
     arms = ["without", "sota"] + comps
-    print(f"build={a.build_model}  judge={a.judge_model}  cases={len(cases)}  "
-          f"arms={arms}  (content-only, blind judge)\n")
+    print(f"build={a.build_model}  judge={a.judge_model}  cases={len(cases)}  arms={arms}  "
+          f"samples={a.samples}  temp={a.temp}  (content-only, blind judge)\n")
 
     results, totals = {}, {arm: 0.0 for arm in arms}
     for c in cases:
@@ -106,19 +122,30 @@ def main():
                 prompt = guided_prompt(sota_bundle(c), c["task"])
             else:
                 prompt = guided_prompt(competitor_bundle(manifest[arm], a.competitors_dir), c["task"])
-            print(f"  {c['id']:16s} {arm:20s} generating…", flush=True)
-            art = _rc.call(a.build_model, prompt, k, max_tokens=32000, temp=0.0)
-            verdict = _rc.judge(art, c["rubric"], a.judge_model, k)
-            present = [r["id"] for r in c["rubric"] if verdict.get(r["id"]) == "present"]
-            recall = len(present) / len(c["rubric"])
-            totals[arm] += recall
-            row["arms"][arm] = {"recall": recall, "present": present,
-                                "missing": [r["id"] for r in c["rubric"] if r["id"] not in present],
-                                "artifact_len": len(art)}
-            print(f"  {c['id']:16s} {arm:20s} recall={recall:.2f}", flush=True)
+            recalls, last_present, last_len = [], [], 0
+            for s in range(a.samples):
+                print(f"  {c['id']:16s} {arm:20s} gen {s+1}/{a.samples}…", flush=True)
+                art = _rc.call(a.build_model, prompt, k, max_tokens=32000, temp=a.temp)
+                verdict = _rc.judge(art, c["rubric"], a.judge_model, k)
+                last_present = [r["id"] for r in c["rubric"] if verdict.get(r["id"]) == "present"]
+                recalls.append(len(last_present) / len(c["rubric"]))
+                last_len = len(art)
+            mean, lo, hi, sd = _spread(recalls)
+            totals[arm] += mean
+            row["arms"][arm] = {"recall": mean, "recalls": recalls, "min": lo, "max": hi, "sd": sd,
+                                "present": last_present,
+                                "missing": [r["id"] for r in c["rubric"] if r["id"] not in last_present],
+                                "artifact_len": last_len}
+            spread = f"  (min {lo:.2f} max {hi:.2f} sd {sd:.02f})" if a.samples > 1 else ""
+            print(f"  {c['id']:16s} {arm:20s} recall={mean:.2f}{spread}", flush=True)
         results[c["id"]] = row
-        line = "  ".join(f"{arm}={row['arms'][arm]['recall']:.2f}" for arm in arms)
+        line = "  ".join(f"{arm[:10]}={row['arms'][arm]['recall']:.2f}" for arm in arms)
         print(f"{c['id']:16s} {line}")
+        if a.out:  # incremental save after every case — crash-safe
+            n_done = len(results)
+            json.dump({"arms": arms, "samples": a.samples, "temp": a.temp,
+                       "cases": results, "means": {arm: totals[arm]/n_done for arm in arms}},
+                      open(a.out, "w"), indent=1)
     n = len(cases)
     print("\nMEAN completeness by arm:")
     for arm in arms:
@@ -126,8 +153,6 @@ def main():
         delta = f"  (vs sota {m - totals['sota']/n:+.2f}, vs unguided {m - totals['without']/n:+.2f})" if arm not in ("without", "sota") else ""
         print(f"  {arm:20s} {m:.3f}{delta}")
     if a.out:
-        json.dump({"arms": arms, "cases": results,
-                   "means": {arm: totals[arm]/n for arm in arms}}, open(a.out, "w"), indent=1)
         print(f"saved {a.out}")
 
 


### PR DESCRIPTION
Follow-up to the competitor benchmark (#98): confirm the lead isn't a lucky sample.

**3 samples at temp 0.7 on the 3 tightest cases** (c1/c3/c7 — where a competitor
tied SOTA single-sample):

| arm | mean (3 tight cases) | vs SOTA |
|---|---|---|
| **SOTA** | **0.98** | — |
| ECC | 0.87 | −0.11 |
| claude-skills | 0.83 | −0.15 |
| awesome-cursorrules | 0.82 | −0.16 |
| unguided | 0.65 | −0.33 |

The gaps **match the single-sample full-7 run** (−0.12 to −0.17), and **on every
tight case SOTA's *worst* sample ≥ each competitor's *best* sample** — competitors
tie at the ceiling (ECC/cursorrules hit 1.00 on c1) but never beat SOTA. SOTA's own
variance is near-zero (sd 0.00 on c1/c3, 0.04 on c7). The lead is stable.

**Harness improvements:** `--samples/--temp`, `--ids` (case subset), and crash-safe
**incremental `--out` saving** (writes after every case, so a mid-run 402 keeps
partial data — fixes the write-only-at-end risk flagged in the maintenance notes).

**Deferred on budget** (balance ~$9): full-7 multi-sample, broaden task families,
as-deployed comparison — each needs a top-up; harness is ready for all three.

## Validation
- Spend/balance checked live against the OpenRouter API; per-case bands verified from the result JSON
- `./scripts/check-invariants.sh` — all 7 pass
