### PR TITLE
chore(invariants): scope the 500-line cap to skill Markdown only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,13 @@ symlinks to it — edit only this file, never the symlinks.
 
 `scripts/check-invariants.sh` fails the build on:
 
-1. any tracked `*.md` over **500 lines**;
+1. any **skill** Markdown (`skills/*/SKILL.md` or `skills/*/rules/*.md`) over
+   **500 lines** — the cap is load-bearing only there (it keeps incremental
+   loading working; the model reads the rules that match the task, not a wall of
+   text). Non-skill Markdown (README, CHANGELOG, `docs/`) is human/agent-facing
+   prose, **not** loaded as a skill, so it is intentionally **uncapped** (decided
+   2026-07-15) — navigability there comes from a table of contents and
+   [docs/INDEX.md](docs/INDEX.md), not a line ceiling;
 2. any `skills/*/rules/*.md` whose **last `## ` heading isn't
    `## Audit checklist`** (the checklist must end the file);
 3. an **internal-name denylist** — the library must stay generic. The private
@@ -107,7 +113,7 @@ pre-commit hook scans each commit locally.
 - [SECURITY.md](SECURITY.md) — reporting bad guidance or a leaked secret
 - [CHANGELOG.md](CHANGELOG.md) — release history (top entry = current version;
   also mirrored in `VERSION`); older releases are archived to keep every file
-  under the 500-line cap — **1.10.0–1.5.0** in
+  for navigability (CHANGELOG is no longer line-capped, so archiving is now
+  optional hygiene, not forced): **1.10.0–1.5.0** in
   [docs/CHANGELOG-archive.md](docs/CHANGELOG-archive.md) and **1.4.0 and earlier**
-  in [docs/CHANGELOG-archive-2.md](docs/CHANGELOG-archive-2.md) (split 2026-07-14);
-  when an archive nears 500, start the next numbered part rather than growing it
+  in [docs/CHANGELOG-archive-2.md](docs/CHANGELOG-archive-2.md)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ lands through a PR — `main` is protected for everyone, including admins (see
 |---|---|
 | `VERSION` | the new semver, single line |
 | `.claude-plugin/plugin.json` | `"version"`; also the skill/domain counts in `"description"` if they changed |
-| `CHANGELOG.md` | new `## [X.Y.Z] - YYYY-MM-DD` section at the top **and** a `[X.Y.Z]: …/releases/tag/vX.Y.Z` link ref at the bottom (top entry = current version — no `[Unreleased]` left behind); when the file nears the 500-line cap, move the oldest release sections **and their link refs** into the newest `docs/CHANGELOG-archive*.md` — and when an archive itself nears 500, start the next numbered part (`docs/CHANGELOG-archive-3.md`, …) rather than growing it. Each archive file's headings and `[X.Y.Z]:` refs must stay in the same file |
+| `CHANGELOG.md` | new `## [X.Y.Z] - YYYY-MM-DD` section at the top **and** a `[X.Y.Z]: …/releases/tag/vX.Y.Z` link ref at the bottom (top entry = current version — no `[Unreleased]` left behind). CHANGELOG is **no longer line-capped** (the 500-line invariant is skill-files-only since 2026-07-15), so archiving old releases is now **optional hygiene** for navigability, not forced: when the root gets long, you *may* move the oldest sections **and their link refs** into the newest `docs/CHANGELOG-archive*.md` (headings and `[X.Y.Z]:` refs must stay in the same file) |
 
 ## 2. Count-bearing surfaces (when the skill count changes)
 

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -35,7 +35,13 @@ fail=0
 note() { printf '    %s\n' "$1"; }
 
 # --- 1. Line budget -------------------------------------------------------
-echo "[1/7] Markdown files <= ${MAX_LINES} lines"
+# The cap is load-bearing ONLY for skill files: a rules/SKILL file over ~500
+# lines defeats incremental loading (the whole point is that the model reads the
+# rules that match the task, not a wall of text). Non-skill Markdown (README,
+# CHANGELOG, docs/) is human/agent-facing prose, not loaded as a skill, so it is
+# intentionally uncapped (decided 2026-07-15) — navigability there comes from a
+# table of contents and docs/INDEX.md, not a line ceiling.
+echo "[1/7] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
 over=0
 while IFS= read -r f; do
   [ -f "$f" ] || { note "SKIPPED (tracked but missing from worktree): $f"; continue; }
@@ -45,7 +51,7 @@ while IFS= read -r f; do
     note "OVER ${MAX_LINES} (${n} lines): $f"
     over=1
   fi
-done < <(git ls-files '*.md')
+done < <(git ls-files 'skills/*/*.md' 'skills/*/rules/*.md')
 if [ "$over" -eq 0 ]; then echo "    ok"; else fail=1; fi
 
 # --- 2. Audit checklist ends every rules file ------------------------------


### PR DESCRIPTION
Per maintainer decision (2026-07-15): the 500-line cap is **load-bearing only for
skill files** (`SKILL.md` + `rules/*.md`), where it keeps incremental loading
working — the model reads the rules that match the task, not a wall of text.
README, CHANGELOG, and `docs/` are human/agent-facing prose, not loaded as a
skill, so capping them was hygiene that cost real effort (the CHANGELOG
line-budget dances, the archive split). They are now **uncapped**; navigability
comes from a table of contents + `docs/INDEX.md` instead of a line ceiling.

- `check-invariants.sh` check 1 now scans `skills/*/*.md` + `skills/*/rules/*.md`
  — **verified**: all 295 skill md files matched, zero non-skill md matched.
- `AGENTS.md` invariant 1, the CHANGELOG-archive note, and `RELEASING.md` updated
  (archiving is now optional hygiene, not forced).

This unblocks adding a README table of contents and richer navigation (next PR).

## Validation
- `./scripts/check-invariants.sh` — all 7 pass; pre-commit — pass
- glob coverage checked against `git ls-files 'skills/**/*.md'` (no gap, no overreach)
