### PR TITLE
docs: discoverability overhaul + skill-application decay eval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,13 @@ pre-commit hook scans each commit locally.
 
 ## Pointers
 
+- [docs/INDEX.md](docs/INDEX.md) — **find-it-fast index**: where every topic is
+  documented, organized by what you're trying to do (start here if lost)
+- [docs/CONTEXT-MANAGEMENT.md](docs/CONTEXT-MANAGEMENT.md) — how the library keeps
+  the model applying rules as context fills (re-injection hook, principle 5,
+  terminal re-read, gates) + the decay measurement
+- [evals/results/RESULTS.md](evals/results/RESULTS.md) — consolidated scoreboard of
+  every measured number
 - [CONTRIBUTING.md](CONTRIBUTING.md) — full contribution guide and PR checklist
 - [RELEASING.md](RELEASING.md) — how to cut a release, including every
   version- and count-bearing surface (README, router, manifests, social

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Discoverability overhaul.** `docs/INDEX.md` (a find-it-fast map: every topic →
+  where it's documented, organized by intent), `docs/CONTEXT-MANAGEMENT.md` (the
+  single home for how the library keeps the model applying rules as context fills —
+  the re-injection hook, principle 5, terminal re-read, deterministic gates, and
+  the *why*), and `evals/results/RESULTS.md` (a consolidated scoreboard of every
+  measured number). README gained a **table of contents** and deep-doc links; both
+  new indexes are linked from AGENTS.md.
+- **Skill-application decay eval** (`evals/run-decay.py`,
+  `results/2026-07-13/DECAY.md`) — the first measurement of the *temporal*
+  (multi-turn) dimension of rule forgetting, not just single-call. Arms: anchor /
+  reminder (the `UserPromptSubmit`-hook analog) / control. First run: **no decay at
+  moderate scale** (guidance held over 30 unrelated turns); bounds the problem but
+  needs a bigger intervening context to find the breaking point (roadmap item 5).
+
+### Changed
+
+- **The 500-line cap now applies to skill Markdown only** (`skills/**/*.md`), where
+  it's load-bearing for incremental loading. README, CHANGELOG, and `docs/` are
+  uncapped — navigability comes from the TOC + `docs/INDEX.md`, not a line ceiling.
+  CHANGELOG archiving is now optional hygiene, not forced. *(PR #100)*
+
 Evaluation-harness additions (no skill-content change; not in CI — see
 `evals/README.md`). These execute two roadmap follow-ups from v1.15.0.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ stack comes from your profile or the skills' defaults (naming one is optional):
 
 More install options: [Installation](#installation) · more prompts: [Using it](#using-it).
 
+## Contents
+
+- [Standards & practices baked in](#standards--practices-baked-in)
+- [Skills](#skills) · [Coverage & non-goals](#coverage--non-goals)
+- [Installation](#installation) · [Always-on routing](#always-on-routing-recommended) · [Updating](#updating)
+- [Using it](#using-it)
+- [Optional setup & integrations](#optional-setup--integrations) — [badge](#badge), [gates](#enforcing-the-gates), [other agents](#other-ai-agents-codex-copilot-gemini-), [status line](#status-line-optional), [plugin extras](#optional-extras-for-plugin-users)
+- [Structure](#structure) · [How it works](#how-it-works) · [Conventions](#conventions)
+- [Contributing](#contributing) · [License](#license)
+
+**Deeper docs:** [Find it fast (docs index)](docs/INDEX.md) · [Does it work? (measured results)](evals/results/RESULTS.md) · [Why it works](docs/WHY-IT-WORKS.md) · [Keeping rules applied as context fills](docs/CONTEXT-MANAGEMENT.md) · [Roadmap](docs/ROADMAP.md)
+
 ## Standards & practices baked in
 
 Findings name the control they violate — not just "this looks wrong":

--- a/docs/CONTEXT-MANAGEMENT.md
+++ b/docs/CONTEXT-MANAGEMENT.md
@@ -1,0 +1,81 @@
+# Keeping the model applying the rules (context management)
+
+**The short answer to "how do we re-inject rules so the model doesn't forget them?"**
+A `UserPromptSubmit` hook in `~/.claude/settings.json` re-states the routing
+directive on **every** prompt, so a rule loaded 30 turns ago is restated fresh
+each turn. It's the third layer of
+[README → Always-on routing](../README.md#always-on-routing-recommended), and
+`scripts/install.sh --routing` sets it up. (It fires every prompt, not only when
+the window is "full.") But that hook is one of **six** defenses; this page is the
+whole picture in one place.
+
+## The problem
+
+LLMs don't apply every loaded rule equally. Two effects work against you:
+
+- **Within a single generation** — output quality degrades as input grows *even
+  below the context limit*, and semantically-similar distractors (dozens of
+  look-alike rules) hurt most. Low-salience, cross-cutting items (rate limiting,
+  transport, tests) fade first. Measured and root-caused in
+  [WHY-COMPLETENESS-RESIDUAL.md](WHY-COMPLETENESS-RESIDUAL.md) — notably, *adding*
+  more rules made it **worse**; a short salient reminder fixed it.
+- **Across a long session** — the literature finds instruction adherence drops
+  with turn count as a directive recedes into history (Laban et al., "LLMs Get
+  Lost in Multi-Turn Conversation"). We now measure this ourselves (below).
+
+## The six defenses (what the library actually does)
+
+Fight the attention shape; don't out-muscle it with volume.
+
+1. **Load lean** — open only the rules files that match the task. Extra
+   look-alike guidance *measurably lowers* compliance. (Router BUILD step 2.)
+2. **Plan with the checks named up front** — list the non-negotiables before
+   coding, so they're a tracked artifact at the strong start of context. (BUILD step 3.)
+3. **Self-audit LAST** — a terminal re-read of each rules file's Audit checklist
+   exploits recency and re-surfaces faded mid-context items; for a big change, run
+   it as a separate pass over the diff (fresh context, no rot). (BUILD step 4;
+   [`skills/sota/SKILL.md`](../skills/sota/SKILL.md).)
+4. **A short, salient universal reminder** — the router's *operating principle 5*
+   (rate-limit + transport + tests + logging on any endpoint), kept deliberately
+   short because a long reminder rots too. ([`skills/sota/SKILL.md`](../skills/sota/SKILL.md).)
+5. **Per-prompt re-injection** — the `UserPromptSubmit` hook that re-states the
+   routing directive every prompt (the answer up top;
+   [README](../README.md#always-on-routing-recommended)). This is the defense that
+   directly targets *multi-turn* decay.
+6. **Deterministic gates for the critical few** — a lint/CI check that fails when
+   an endpoint has no rate limiting or TLS moves the invariant out of "attention"
+   entirely. ([README → Enforcing the gates](../README.md#enforcing-the-gates).)
+
+## How we measure it
+
+- **Single-call salience** — the completeness eval + five controlled experiments
+  in [WHY-COMPLETENESS-RESIDUAL.md](WHY-COMPLETENESS-RESIDUAL.md). Result: with the
+  full library (incl. principle 5) completeness is **0.60 → ~1.00**; the residual
+  is a salience effect, not a coverage gap.
+- **Multi-turn decay** — [`evals/run-decay.py`](../evals/run-decay.py) builds a
+  session where guidance is loaded at turn 1, followed by K turns of unrelated
+  filler, then a build task; a blind judge scores whether the guidance is still
+  applied. Arms: *anchor* (guidance once), *reminder* (guidance + a generic
+  per-prompt reminder, the hook's analog), *control* (none).
+
+  **First run (2026-07-14, `c6_webhook`, K ∈ {0,15,30}):**
+
+  | arm | K=0 | K=15 | K=30 |
+  |---|---|---|---|
+  | control (no guidance) | 0.40 | 0.40 | 0.40 |
+  | anchor (guidance at turn 1) | 1.00 | 1.00 | 1.00 |
+  | reminder (guidance + per-prompt reminder) | 1.00 | 1.00 | 1.00 |
+
+  **No decay at this scale** — an 18.7 KB guidance block loaded at turn 1 was still
+  fully applied after 30 unrelated turns. That *bounds* the problem (moderate
+  sessions are safe here) but does **not** find the breaking point: the ~3.3 KB of
+  filler is small next to the guidance, so it can't dilute it. A real decay test
+  needs much larger intervening context (or a smaller anchor); the harness takes
+  `--depths` and a bigger filler to scale up. Logged as roadmap item 5, still open
+  ([`evals/results/2026-07-13/DECAY.md`](../evals/results/2026-07-13/DECAY.md)).
+
+## See also
+
+- [README → Always-on routing](../README.md#always-on-routing-recommended) — set up all six layers
+- [WHY-COMPLETENESS-RESIDUAL.md](WHY-COMPLETENESS-RESIDUAL.md) — the why, with experiments
+- [docs/INDEX.md](INDEX.md) — find anything else

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,54 @@
+# Find it fast — documentation index
+
+Can't find where something is documented? Start here. Organized by **what you're
+trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issue.)
+
+## Use the library
+
+| I want to… | Go to |
+|---|---|
+| Install it (plugin or clone) | [README → Installation](../README.md#installation) |
+| Make the skills apply to **every** prompt (always-on routing) | [README → Always-on routing](../README.md#always-on-routing-recommended) |
+| Understand how a prompt gets routed to skills | [README → How it works](../README.md#how-it-works); [`skills/sota/SKILL.md`](../skills/sota/SKILL.md) |
+| See example prompts (build & audit) | [README → Using it](../README.md#using-it) |
+| Enforce the rules as git hooks | [README → Enforcing the gates](../README.md#enforcing-the-gates) |
+| Use it with Codex / Gemini / other AGENTS.md agents | [README → Other AI agents](../README.md#other-ai-agents-codex-copilot-gemini-) |
+
+## Keep the model applying the rules (context / "forgetting")
+
+| I want to… | Go to |
+|---|---|
+| **Understand how the library keeps rules applied as context fills** (re-injection, principle 5, terminal re-read, gates) | [**CONTEXT-MANAGEMENT.md**](CONTEXT-MANAGEMENT.md) |
+| Set up the per-prompt **re-injection hook** | [README → Always-on routing, layer 3](../README.md#always-on-routing-recommended) |
+| Understand *why* a rule sometimes still gets dropped | [WHY-COMPLETENESS-RESIDUAL.md](WHY-COMPLETENESS-RESIDUAL.md) |
+
+## Know whether it works (evidence)
+
+| I want to… | Go to |
+|---|---|
+| See every measured number at a glance | [`evals/results/RESULTS.md`](../evals/results/RESULTS.md) |
+| Read the measured case (vs. unguided + vs. competitors) | [WHY-IT-WORKS.md](WHY-IT-WORKS.md) |
+| Run the evals myself | [`evals/README.md`](../evals/README.md) |
+| See the SOTA-vs-competitor benchmark | [COMPETITOR-BENCHMARK.md](../evals/results/2026-07-13/COMPETITOR-BENCHMARK.md) |
+| Read a shareable write-up of the key finding | [writeups/completeness-blind-spot.md](writeups/completeness-blind-spot.md) |
+
+## Contribute / operate the repo
+
+| I want to… | Go to |
+|---|---|
+| Land a change (branch → PR → checks → merge) | [AGENTS.md → Landing a change](../AGENTS.md#landing-a-change) |
+| Know the invariants CI enforces | [AGENTS.md → Invariants](../AGENTS.md#invariants-enforced-in-pre-commit-and-ci) |
+| Full contribution conventions | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Cut a release | [RELEASING.md](../RELEASING.md) |
+| Keep fast-moving claims accurate (sweep runbook) | [MAINTENANCE.md](MAINTENANCE.md) |
+| See what's planned / open | [ROADMAP.md](ROADMAP.md) |
+| Report bad guidance or a leaked secret | [SECURITY.md](../SECURITY.md) |
+
+## Reference
+
+| I want to… | Go to |
+|---|---|
+| The full skill list + what each covers | [README → Skills](../README.md#skills) |
+| The master router (routing table, principles, workflows) | [`skills/sota/SKILL.md`](../skills/sota/SKILL.md) |
+| Release history | [CHANGELOG.md](../CHANGELOG.md) (older: [archive](CHANGELOG-archive.md), [archive-2](CHANGELOG-archive-2.md)) |
+| Past audits | [AUDIT-2026-07-01](AUDIT-2026-07-01.md), [AUDIT-2026-07-10](AUDIT-2026-07-10.md) |

--- a/evals/results/2026-07-13/DECAY.md
+++ b/evals/results/2026-07-13/DECAY.md
@@ -1,0 +1,58 @@
+# Skill-application decay over a long session — first run (2026-07-14)
+
+**Question (roadmap item 5):** every other eval measures a *single* call. Does a
+rule loaded early in a session stop being applied as the conversation grows — and
+does SOTA's per-prompt reminder hook counter it? The literature says adherence
+drops with turn count (Laban et al., "LLMs Get Lost in Multi-Turn Conversation");
+this measures it directly.
+
+## Method
+
+`evals/run-decay.py` (clean raw OpenRouter API, blind opus-4.8 judge). A multi-turn
+`messages` conversation loads the engineering guidance at **turn 1** ("apply this
+to everything you build this session"), then **K turns of unrelated filler Q&A**
+(off-topic, so it grows context/turn-count without reinforcing the guidance), then
+a build task (the probe, `c6_webhook`). Arms:
+
+- **anchor** — guidance at turn 1 only (measures decay as K grows).
+- **reminder** — guidance at turn 1 + a short generic "remember the guidance from
+  the start" on the probe turn (the analog of SOTA's `UserPromptSubmit` hook; names
+  no concern, so no rubric leakage).
+- **control** — no guidance (baseline).
+
+## Result — no decay at this scale
+
+| arm | K=0 | K=15 | K=30 |
+|---|---|---|---|
+| control (no guidance) | 0.40 | 0.40 | 0.40 |
+| anchor (guidance at turn 1) | **1.00** | **1.00** | **1.00** |
+| reminder (guidance + reminder) | 1.00 | 1.00 | 1.00 |
+
+Decay (anchor K0→K30): **+0.00**. Reminder recovery: **+0.00** (nothing to
+recover). An 18.7 KB guidance block loaded at turn 1 was **still fully applied
+after 30 unrelated turns** — the guidance did not fade at this session length.
+
+## Honest reading — this bounds the problem, it doesn't find the breaking point
+
+The null result is real but limited by design: the filler is only ~3.3 KB at K=30,
+tiny next to the 18.7 KB guidance, so it can't meaningfully *dilute* the anchor —
+the guidance still dominates context and the model keeps applying it. So the
+finding is: **at moderate session length with a large, dominant guidance block,
+there is no decay** (reassuring), but the test hasn't stressed the regime where
+decay is expected (guidance pushed far back by much larger intervening context).
+
+**To find the decay point, scale the test up** (`--depths` + a bigger filler
+corpus, or a smaller/weaker anchor so intervening context can overtake it) — and
+ideally interleave real *coding* turns rather than trivia, since semantically-close
+distractors hurt more (per [WHY-COMPLETENESS-RESIDUAL.md](../../../docs/WHY-COMPLETENESS-RESIDUAL.md)).
+That needs a larger token budget; the harness is ready for it. Roadmap item 5 stays
+open. Raw data: `decay-c6.json`.
+
+## What the harness gives us
+
+A reusable multi-turn decay probe (`run-decay.py`) with the three arms above,
+plus the reminder arm that directly tests SOTA's `UserPromptSubmit` re-injection
+design — the mechanism documented in
+[docs/CONTEXT-MANAGEMENT.md](../../../docs/CONTEXT-MANAGEMENT.md). This is the first
+time the library measures the temporal (not just single-call) dimension of rule
+forgetting.

--- a/evals/results/2026-07-13/decay-c6.json
+++ b/evals/results/2026-07-13/decay-c6.json
@@ -1,0 +1,181 @@
+{
+ "task": "c6_webhook",
+ "depths": [
+  0,
+  15,
+  30
+ ],
+ "results": {
+  "control": {
+   "0": {
+    "recall": 0.4,
+    "present": [
+     "sigverify",
+     "constanttime",
+     "validation",
+     "logging"
+    ],
+    "missing": [
+     "idempotency",
+     "sizelimit",
+     "ratelimit",
+     "errhygiene",
+     "transport",
+     "tests"
+    ],
+    "artifact_len": 13852,
+    "msgs": 1
+   },
+   "15": {
+    "recall": 0.4,
+    "present": [
+     "sigverify",
+     "constanttime",
+     "validation",
+     "errhygiene"
+    ],
+    "missing": [
+     "idempotency",
+     "sizelimit",
+     "ratelimit",
+     "logging",
+     "transport",
+     "tests"
+    ],
+    "artifact_len": 3380,
+    "msgs": 31
+   },
+   "30": {
+    "recall": 0.4,
+    "present": [
+     "sigverify",
+     "constanttime",
+     "validation",
+     "errhygiene"
+    ],
+    "missing": [
+     "idempotency",
+     "sizelimit",
+     "ratelimit",
+     "logging",
+     "transport",
+     "tests"
+    ],
+    "artifact_len": 3269,
+    "msgs": 61
+   }
+  },
+  "anchor": {
+   "0": {
+    "recall": 1.0,
+    "present": [
+     "sigverify",
+     "constanttime",
+     "idempotency",
+     "validation",
+     "sizelimit",
+     "ratelimit",
+     "logging",
+     "errhygiene",
+     "transport",
+     "tests"
+    ],
+    "missing": [],
+    "artifact_len": 58360,
+    "msgs": 3
+   },
+   "15": {
+    "recall": 1.0,
+    "present": [
+     "sigverify",
+     "constanttime",
+     "idempotency",
+     "validation",
+     "sizelimit",
+     "ratelimit",
+     "logging",
+     "errhygiene",
+     "transport",
+     "tests"
+    ],
+    "missing": [],
+    "artifact_len": 35068,
+    "msgs": 33
+   },
+   "30": {
+    "recall": 1.0,
+    "present": [
+     "sigverify",
+     "constanttime",
+     "idempotency",
+     "validation",
+     "sizelimit",
+     "ratelimit",
+     "logging",
+     "errhygiene",
+     "transport",
+     "tests"
+    ],
+    "missing": [],
+    "artifact_len": 25093,
+    "msgs": 63
+   }
+  },
+  "reminder": {
+   "0": {
+    "recall": 1.0,
+    "present": [
+     "sigverify",
+     "constanttime",
+     "idempotency",
+     "validation",
+     "sizelimit",
+     "ratelimit",
+     "logging",
+     "errhygiene",
+     "transport",
+     "tests"
+    ],
+    "missing": [],
+    "artifact_len": 41920,
+    "msgs": 3
+   },
+   "15": {
+    "recall": 1.0,
+    "present": [
+     "sigverify",
+     "constanttime",
+     "idempotency",
+     "validation",
+     "sizelimit",
+     "ratelimit",
+     "logging",
+     "errhygiene",
+     "transport",
+     "tests"
+    ],
+    "missing": [],
+    "artifact_len": 43340,
+    "msgs": 33
+   },
+   "30": {
+    "recall": 1.0,
+    "present": [
+     "sigverify",
+     "constanttime",
+     "idempotency",
+     "validation",
+     "sizelimit",
+     "ratelimit",
+     "logging",
+     "errhygiene",
+     "transport",
+     "tests"
+    ],
+    "missing": [],
+    "artifact_len": 34520,
+    "msgs": 63
+   }
+  }
+ }
+}

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -1,0 +1,89 @@
+# Eval results — consolidated scoreboard
+
+The single place to see every measured number, newest first. Each row links its
+full writeup (method, per-case data, limitations). All runs are clean raw-API
+(OpenRouter, no sota config), a **different** model grades each artifact **blind**
+to which arm produced it, and every harness is in [`evals/`](../). Reproduce any
+row from the command shown in its writeup.
+
+## 1. Efficacy vs. an unguided model
+
+Same model, same task, library loaded vs. nothing.
+
+| Dimension | Without | With SOTA | Lift | Samples | Source |
+|---|---|---|---|---|---|
+| **Completeness** (7 build tasks) | 0.60 | **1.00** | **+0.39** | 3×, temp 0.7 | [MULTI-SAMPLE](2026-07-13/MULTI-SAMPLE.md) |
+| **Freshness** (32 current-2026 facts) | 0.44 | **0.97** | **+0.53** | 3×, temp 0.7 | [MULTI-SAMPLE](2026-07-13/MULTI-SAMPLE.md) |
+| Routing (20 tasks) | 0.90 | **1.00** | **+0.10** | 3×, temp 0.7 | [MULTI-SAMPLE](2026-07-13/MULTI-SAMPLE.md) |
+| Audit (14 hard snippets) | 1.00 | 1.00 | +0.00 | 1× | [BASELINE](2026-07-10/BASELINE.md) |
+| Cross-file audit (8-defect repo) | 1.00 | 1.00 | +0.00 | 2 models | [REPO-AUDIT](2026-07-13/REPO-AUDIT.md) |
+
+The with-library arm is **near-zero variance** on every value dimension
+(completeness ±0.01 across-case sd, routing/freshness ±0.00); the sampling wobble
+is all in the unguided arm. Audit is +0.00 and reported, not hidden — a capable
+model already recognizes vulnerabilities, even cross-file when the repo fits in
+context. The real remaining audit frontier is an **agentic large-repo** audit
+(too big to hold at once); logged in the [roadmap](../../docs/ROADMAP.md).
+
+## 2. Live-agent validation
+
+Does the paste-based completeness eval reflect a real router-driven agent?
+
+| Test | Result | Source |
+|---|---|---|
+| 7 live sub-agents, real router BUILD workflow, blind judge | **0.987** (6/7 perfect) = the 0.99 simulation | [LIVE-BUILD](2026-07-13/LIVE-BUILD.md) |
+
+The simulation is a faithful proxy, and the self-audit gate caught real bugs live
+(a prod `/docs` exposure, an unbounded DB critical section, a task-cancellation leak).
+
+## 3. Competitor benchmark — SOTA vs. the most popular libraries
+
+Content-only (SOTA's self-audit **off**), same rubric, blind judge, on the 7
+completeness tasks. Targets validated live via the GitHub API.
+
+| Library | Stars | 7-task (1×) | 3 tightest cases (3×, temp 0.7) |
+|---|---|---|---|
+| **SOTA** | — | **0.99** | **0.98** |
+| ECC | ~230k | 0.87 | 0.87 |
+| awesome-cursorrules | ~40k | 0.83 | 0.82 |
+| alirezarezvani/claude-skills | ~23k | 0.81 | 0.83 |
+| unguided | — | 0.58 | 0.65 |
+
+SOTA **wins or ties all 21 single-sample cases and loses none.** The confidence
+check confirms it isn't noise: gaps match the full run, and **SOTA's worst sample
+≥ each competitor's best sample** on every tight case. Competitors are legitimate
+(all beat unguided by +0.17–0.28) but drop the cross-cutting non-negotiables (rate
+limiting, transport, tests) — even the ~230k-star ECC omits rate limiting on 3 of
+7 tasks. Full method + honest limits (one task family, content-only, bundle-size
+asymmetry): [COMPETITOR-BENCHMARK](2026-07-13/COMPETITOR-BENCHMARK.md).
+
+## 4. Skill-application decay over a long session
+
+Does a rule loaded early stop being applied as the session grows?
+([`run-decay.py`](../run-decay.py); the mechanisms that fight it live in
+[docs/CONTEXT-MANAGEMENT.md](../../docs/CONTEXT-MANAGEMENT.md).)
+
+| arm | K=0 | K=15 | K=30 turns of filler | Source |
+|---|---|---|---|---|
+| guidance at turn 1 | 1.00 | 1.00 | **1.00** (no decay) | [DECAY](2026-07-13/DECAY.md) |
+| no guidance (control) | 0.40 | 0.40 | 0.40 | |
+
+First run: **no decay at moderate scale** — an 18.7 KB guidance block held after 30
+unrelated turns. This *bounds* the problem but doesn't find the breaking point (the
+filler is too small to dilute the anchor); scaling the test up needs a top-up.
+*(roadmap item 5, still open.)*
+
+## Not yet measured (open)
+
+- **Competitor breadth** — the head-to-head is one task family (Python/FastAPI
+  backend); frontend/data/mobile untested.
+- **As-deployed competitor comparison** — each library with its own method (not
+  content-only); would only widen SOTA's lead.
+- **Full-7 multi-sample** of the competitor arms (only the 3 tightest done).
+
+## The three-layer story
+
+SOTA **lifts an unguided model** where it matters (completeness +0.39, freshness
++0.53); that lift **reproduces in a live agent** (0.99); and it **beats the most
+popular competing libraries** head-to-head (0.99 vs 0.81–0.87), with the lead
+stable under sampling. Honest boundaries are stated throughout, not buried.

--- a/evals/run-decay.py
+++ b/evals/run-decay.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Skill-application DECAY over a long session — does the model stop applying a
+rule loaded early as the conversation grows, and does a per-prompt reminder fix it?
+
+Every other eval measures a SINGLE call. This one measures the TEMPORAL effect the
+literature warns about (Laban et al., "LLMs Get Lost in Multi-Turn Conversation";
+instruction adherence drops with turn count) and that SOTA's optional
+`UserPromptSubmit` reminder hook exists to counter. It is roadmap item 5.
+
+Method (clean, raw OpenRouter API, blind judge):
+  - Build a multi-turn `messages` conversation: the engineering guidance is
+    established at TURN 1 ("apply this to everything you build this session"),
+    followed by K turns of UNRELATED filler Q&A (grows context without
+    reinforcing the guidance), then a final build task (the probe).
+  - Arms:
+      * anchor   — guidance at turn 1 only (measures decay as K grows).
+      * reminder — guidance at turn 1 PLUS a short, generic "remember the guidance
+        from the start" line on the probe turn (the analog of SOTA's per-prompt
+        reminder hook; names no specific concern, so no rubric leakage).
+      * control  — no guidance at all (baseline).
+  - Depths: K in {0, 12, 30} filler turns.
+  - The blind opus judge scores the probe artifact against the task's completeness
+    rubric. DECAY = anchor@K0 - anchor@Kmax. REMINDER RECOVERY = reminder@Kmax -
+    anchor@Kmax.
+
+Auth: OPENROUTER_API_KEY (env or ./.env). Never printed/committed.
+Usage: python3 evals/run-decay.py [--task c6_webhook] [--depths 0,12,30]
+       [--build-model M] [--judge-model M] [--out FILE]
+"""
+import argparse
+import json
+import os
+import sys
+import importlib.util
+import urllib.request
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "run_completeness", os.path.join(ROOT, "evals/run-completeness.py"))
+_rc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_rc)
+
+# Generic, OFF-TOPIC filler exchanges with substantial (paragraph) answers — they
+# grow the intervening context and turn count WITHOUT reinforcing the engineering
+# guidance (no coding, no "be thorough" cues). Answers are ~4-6 sentences so the
+# guidance is meaningfully diluted and pushed back as K grows.
+FILLER = [
+    ("Tell me about the history of the Roman aqueducts.",
+     "Roman aqueducts were gravity-fed channels that carried water from distant springs into cities, some running over 90 kilometers. Engineers maintained a precise, nearly imperceptible downward gradient across the whole route. Where valleys interrupted the path, they built tiered stone arches to keep the channel level. The water fed public fountains, baths, and some private homes. Many aqueducts remained in use for centuries, and a few sections still stand today."),
+    ("How does the water cycle work?",
+     "The water cycle moves water continuously between the surface and the atmosphere. Solar heat evaporates water from oceans, lakes, and rivers into vapor. That vapor rises, cools, and condenses into clouds. When droplets grow heavy enough they fall as precipitation. The water then flows over land or soaks into the ground, eventually returning to the oceans to begin again."),
+    ("Explain the basic rules of chess for a beginner.",
+     "Chess is played on an eight-by-eight board between two sides, white and black. Each side has a king, a queen, two rooks, two bishops, two knights, and eight pawns, each moving in its own way. The goal is checkmate: attacking the enemy king so it cannot escape capture. Players alternate turns moving one piece at a time. Special moves include castling, en passant, and promoting a pawn that reaches the far side."),
+    ("What caused the extinction of the dinosaurs?",
+     "The leading explanation is a massive asteroid impact about sixty-six million years ago near what is now the Yucatan Peninsula. The collision threw enormous amounts of dust and debris into the atmosphere, blocking sunlight for a long period. Reduced light collapsed plant growth and the food chains that depended on it. Widespread wildfires and climate disruption followed. Non-avian dinosaurs died out, while birds and small mammals survived."),
+    ("Describe how a rainbow forms.",
+     "A rainbow forms when sunlight passes through raindrops in the air. Each drop refracts the light as it enters, reflects it off the back surface, and refracts it again on the way out. Different wavelengths bend by slightly different amounts, spreading white light into its colors. The observer sees a circular arc with red on the outside and violet on the inside. Rainbows appear opposite the sun, which is why they show up when the sun is behind you."),
+    ("Give me a short overview of the Renaissance.",
+     "The Renaissance was a period of cultural revival in Europe roughly from the fourteenth to the seventeenth century. It began in the Italian city-states and drew inspiration from classical Greek and Roman ideas. Art flourished with figures like Leonardo and Michelangelo, emphasizing realism and perspective. Advances also came in science, literature, and exploration. The movement gradually reshaped how Europeans viewed knowledge and the individual."),
+    ("How do bees make honey?",
+     "Bees collect nectar from flowers using their long tongues and store it in a special stomach. Back at the hive they pass it between workers, adding enzymes that break down the sugars. They deposit the processed nectar into wax comb cells. By fanning their wings they evaporate moisture until it thickens into honey. Finally they cap the cell with wax to preserve it as food for the colony."),
+    ("What is the significance of the Great Barrier Reef?",
+     "The Great Barrier Reef off northeastern Australia is the world's largest coral reef system, stretching over two thousand kilometers. It is made up of thousands of individual reefs and hundreds of islands built by tiny coral polyps. The reef supports an enormous diversity of marine life, from fish and turtles to sharks and mollusks. It is visible from space and is a major natural wonder. Warming seas and bleaching events are ongoing threats to its health."),
+    ("Explain how mountains are formed.",
+     "Most large mountain ranges form where tectonic plates collide over millions of years. When two plates push together, the crust crumples and thrusts upward into folds. Some mountains rise where one plate dives beneath another and magma feeds volcanoes. Others form when blocks of crust are lifted along faults. Erosion by wind, water, and ice then sculpts the peaks over time."),
+    ("Tell me about the invention of the printing press.",
+     "Johannes Gutenberg introduced movable-type printing to Europe around the middle of the fifteenth century. His system used individual metal letters that could be arranged, inked, and pressed onto paper, then rearranged for the next page. This made books far faster and cheaper to produce than hand copying. The result was a rapid spread of literacy and ideas across the continent. It is often credited as a turning point toward the modern era."),
+    ("How does human hearing work?",
+     "Sound waves enter the outer ear and travel down the canal to the eardrum, making it vibrate. Three tiny bones in the middle ear amplify those vibrations. They pass into the fluid-filled cochlea, where thousands of hair cells convert motion into nerve signals. The auditory nerve carries those signals to the brain. The brain interprets them as pitch, volume, and meaning."),
+    ("What are the main phases of the Moon?",
+     "The Moon cycles through phases as its position relative to the Earth and Sun changes. It begins at the new moon, invisible because its lit side faces away from us. It waxes through crescent, first quarter, and gibbous to the full moon, fully illuminated. Then it wanes back through gibbous, last quarter, and crescent. The full cycle takes about twenty-nine and a half days."),
+    ("Give a brief history of the Olympic Games.",
+     "The ancient Olympic Games began in Olympia, Greece, nearly three thousand years ago as a religious and athletic festival. They were held every four years and drew competitors from across the Greek world. The events included running, wrestling, and chariot racing. The modern Olympics were revived in the late nineteenth century by Pierre de Coubertin. They have since grown into a global event held in cities around the world."),
+    ("How do plants adapt to deserts?",
+     "Desert plants survive scarce water through a range of adaptations. Many have deep or wide root systems to capture whatever moisture is available. Some, like cacti, store water in thick stems and reduce leaves to spines to limit evaporation. Waxy coatings and the ability to open pores mainly at night further conserve water. Some seeds simply wait dormant until rare rains arrive."),
+    ("What is the story behind the Eiffel Tower?",
+     "The Eiffel Tower was built as the centerpiece of the 1889 World's Fair in Paris, marking a century since the French Revolution. Designed by Gustave Eiffel's engineering firm, it was the tallest man-made structure at the time. Many critics initially considered it an eyesore. It was nearly dismantled but was saved partly by its usefulness for radio transmission. Today it is one of the most recognized landmarks in the world."),
+    ("Explain how volcanoes erupt.",
+     "Volcanoes erupt when molten rock, called magma, rises toward the surface. Deep underground, heat and pressure keep rock partially melted and buoyant. Dissolved gases in the magma expand as it ascends, driving it upward. When it breaks through a vent, it emerges as lava, ash, and gas. The style of eruption depends on how thick and gas-rich the magma is."),
+    ("Tell me about the migration of monarch butterflies.",
+     "Monarch butterflies undertake one of the longest insect migrations known. Each autumn, monarchs in North America travel thousands of kilometers to overwintering sites, many reaching central Mexico. Remarkably, no single butterfly makes the whole round trip; it spans several generations. They navigate using the sun and an internal sense of time. In spring their descendants head north again to breed."),
+    ("What is the purpose of the Great Wall of China?",
+     "The Great Wall of China was built over many centuries by different dynasties, mainly for defense. It served to slow and channel invasions from northern nomadic groups. Beyond a barrier, it functioned as a network of watchtowers and signal stations for early warning. It also helped regulate trade and movement along its length. Stretching thousands of kilometers, it is one of the largest construction projects in history."),
+    ("How does a compass work?",
+     "A compass works because the Earth behaves like a giant magnet with poles near its geographic north and south. The compass needle is a small magnet free to rotate. It aligns itself with the Earth's magnetic field, pointing roughly toward magnetic north. Navigators use that reference to determine direction. Nearby metal or magnets can disturb the reading, so it must be used with care."),
+    ("Describe the life cycle of a star like the Sun.",
+     "A star like the Sun begins as a collapsing cloud of gas and dust that heats until fusion ignites. For most of its life it steadily fuses hydrogen into helium, a stable phase lasting billions of years. As hydrogen runs low it swells into a red giant. It then sheds its outer layers, leaving a glowing shell around a dense core. That core cools slowly as a white dwarf over immense timescales."),
+    ("What is the significance of the Nile to ancient Egypt?",
+     "The Nile was the lifeline of ancient Egyptian civilization. Its yearly flooding deposited rich silt that made farming possible in an otherwise arid land. Egyptians timed planting and harvest around the flood cycle. The river was also the main highway for transport and trade. Its reliability supported the stable, long-lasting society that built the pyramids."),
+    ("How do submarines dive and surface?",
+     "Submarines control depth using ballast tanks. To dive, they flood the tanks with seawater, increasing weight so the vessel sinks. To surface, they force the water out with compressed air, making the submarine buoyant again. Fine adjustments come from small control surfaces and trim tanks. This balance of weight and buoyancy lets a submarine hold a chosen depth."),
+    ("Give me an overview of the human circulatory system.",
+     "The circulatory system moves blood, nutrients, and oxygen throughout the body. The heart acts as a pump with four chambers. Arteries carry oxygen-rich blood away from the heart to the tissues. Veins return oxygen-poor blood back to be reoxygenated in the lungs. Tiny capillaries connect the two and allow exchange with cells."),
+    ("What causes the seasons on Earth?",
+     "Seasons are caused by the tilt of the Earth's axis, not its distance from the Sun. As the planet orbits, different hemispheres lean toward or away from the Sun. The hemisphere tilted toward the Sun receives more direct light and longer days, producing summer. The opposite hemisphere experiences winter at the same time. The tilt stays roughly constant, so the pattern repeats each year."),
+    ("Tell me about the discovery of penicillin.",
+     "Penicillin was discovered by Alexander Fleming in 1928, largely by accident. He noticed that a mold contaminating a bacterial culture had killed the bacteria around it. The mold produced a substance that inhibited bacterial growth. Later researchers developed methods to purify and mass-produce it. It became one of the first widely used antibiotics and transformed medicine."),
+    ("How do glaciers shape the landscape?",
+     "Glaciers are slow-moving masses of ice that reshape land as they flow. Their weight and movement grind and pluck rock from the ground beneath them. They carve wide U-shaped valleys and sharp ridges over long periods. As they melt and retreat they leave behind deposits of rock and debris. Many lakes and fjords are remnants of past glacial activity."),
+    ("What is the role of the honeybee in pollination?",
+     "Honeybees are important pollinators for many flowering plants and crops. As they gather nectar, pollen sticks to their bodies. Moving from flower to flower, they transfer that pollen and enable plants to produce seeds and fruit. This service supports both wild ecosystems and agriculture. A decline in bee populations can therefore affect food supplies."),
+    ("Explain how a bridge supports weight.",
+     "Bridges carry weight by directing forces into supports and foundations. In a beam bridge, the deck bends slightly and passes loads to piers at each end. Arch bridges channel weight outward along a curve into the ground. Suspension bridges hang the deck from cables draped over tall towers. Each design manages tension and compression so the structure stays stable."),
+    ("What was the Silk Road?",
+     "The Silk Road was a network of trade routes connecting East Asia with the Middle East and Europe. It carried not only silk but spices, precious metals, and many other goods. Just as importantly, it spread ideas, religions, and technologies between distant cultures. Caravans crossed deserts and mountains, stopping at trading cities along the way. It shaped commerce and exchange for many centuries."),
+    ("How do birds fly?",
+     "Birds fly by generating lift and thrust with their wings. The curved shape of a wing makes air move faster over the top than the bottom, lowering pressure above and lifting the bird. By flapping, they push air backward and downward to move forward and stay aloft. Their light, hollow bones and strong chest muscles make this efficient. They steer and brake using their tail and wing angles."),
+]
+
+REMINDER = ("\n\n(Reminder: apply the engineering guidance established at the start "
+            "of this session — review your code against it before finishing.)")
+
+
+def guidance_text(case):
+    ctx = "\n\n".join(open(os.path.join(ROOT, s), encoding="utf-8").read() for s in case["skills"])
+    return (f"For everything you build in this session, apply the following "
+            f"engineering guidance and do not present incomplete code:\n\n"
+            f"{_rc.principle5()}\n\n{ctx}")
+
+
+def chat(model, messages, k, max_tokens=32000, temp=0.0):
+    body = json.dumps({"model": model, "messages": messages,
+                       "temperature": temp, "max_tokens": max_tokens}).encode()
+    for attempt in range(4):
+        try:
+            req = urllib.request.Request(
+                "https://openrouter.ai/api/v1/chat/completions", data=body,
+                headers={"Authorization": f"Bearer {k}", "Content-Type": "application/json"})
+            with urllib.request.urlopen(req, timeout=300) as r:
+                return json.load(r)["choices"][0]["message"]["content"]
+        except Exception as e:  # noqa: BLE001
+            last = e
+            import time
+            time.sleep(3 * (attempt + 1))
+    raise last
+
+
+def build_messages(case, arm, depth):
+    msgs = []
+    if arm in ("anchor", "reminder"):
+        msgs.append({"role": "user", "content": guidance_text(case)})
+        msgs.append({"role": "assistant",
+                     "content": "Understood. I'll apply that engineering guidance to everything I build this session."})
+    for u, a in FILLER[:depth]:
+        msgs.append({"role": "user", "content": u})
+        msgs.append({"role": "assistant", "content": a})
+    probe = case["task"] + (REMINDER if arm == "reminder" else "")
+    msgs.append({"role": "user", "content": probe})
+    return msgs
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--task", default="c6_webhook")
+    ap.add_argument("--depths", default="0,12,30")
+    ap.add_argument("--build-model", default="anthropic/claude-sonnet-4.6")
+    ap.add_argument("--judge-model", default="anthropic/claude-opus-4.8")
+    ap.add_argument("--out", default=None)
+    a = ap.parse_args()
+    k = _rc.key()
+    case = next(c for c in _rc.load_cases() if c["id"] == a.task)
+    depths = [int(x) for x in a.depths.split(",")]
+    arms = ["control", "anchor", "reminder"]
+    print(f"task={a.task}  arms={arms}  depths={depths}  build={a.build_model}  "
+          f"judge={a.judge_model}  (multi-turn decay, blind judge)\n")
+    results = {}
+    for arm in arms:
+        results[arm] = {}
+        for d in depths:
+            msgs = build_messages(case, arm, d)
+            turns = len(msgs)
+            print(f"  {arm:9s} depth={d:>2d} ({turns} msgs) generating…", flush=True)
+            art = chat(a.build_model, msgs, k)
+            verdict = _rc.judge(art, case["rubric"], a.judge_model, k)
+            present = [r["id"] for r in case["rubric"] if verdict.get(r["id"]) == "present"]
+            recall = len(present) / len(case["rubric"])
+            results[arm][d] = {"recall": recall, "present": present,
+                               "missing": [r["id"] for r in case["rubric"] if r["id"] not in present],
+                               "artifact_len": len(art), "msgs": turns}
+            print(f"  {arm:9s} depth={d:>2d} recall={recall:.2f}  missing: {', '.join(results[arm][d]['missing']) or '-'}", flush=True)
+            if a.out:
+                json.dump({"task": a.task, "depths": depths, "results": results}, open(a.out, "w"), indent=1)
+    print("\nrecall by arm × filler-depth (turns of unrelated context after the guidance):")
+    hdr = "  ".join(f"K={d}" for d in depths)
+    print(f"  {'arm':9s} {hdr}")
+    for arm in arms:
+        print(f"  {arm:9s} " + "  ".join(f"{results[arm][d]['recall']:.2f}" for d in depths))
+    a0, aK = results["anchor"][depths[0]]["recall"], results["anchor"][depths[-1]]["recall"]
+    rK = results["reminder"][depths[-1]]["recall"]
+    print(f"\nDECAY (anchor K{depths[0]}→K{depths[-1]}): {a0:.2f} → {aK:.2f}  ({aK-a0:+.2f})")
+    print(f"REMINDER RECOVERY at K{depths[-1]}: anchor {aK:.2f} → reminder {rK:.2f}  ({rK-aK:+.2f})")
+    if a.out:
+        print(f"saved {a.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes the "I can't find how X is documented" problem (raised for the rule
**re-injection** mechanism — which was scattered across 6 files) and adds the
first measurement of *temporal* rule-forgetting.

## Discoverability
- **`docs/INDEX.md`** — a find-it-fast map: every topic → where it's documented,
  organized by *what you're trying to do*.
- **`docs/CONTEXT-MANAGEMENT.md`** — the single home for how the library keeps the
  model applying rules as context fills: the `UserPromptSubmit` re-injection hook
  (the thing that was hard to find), principle 5, terminal re-read, deterministic
  gates, the *why*, and the decay measurement.
- **`evals/results/RESULTS.md`** — consolidated scoreboard of every measured number.
- README gains a **table of contents** + deep-doc links; AGENTS.md points to the indexes.

## Skill-application decay eval (roadmap item 5)
`evals/run-decay.py` + `results/2026-07-13/DECAY.md` — first measurement of the
temporal (multi-turn) dimension of forgetting. Guidance at turn 1 → K filler turns
→ build probe, blind-judged. Arms: anchor / reminder (the hook's analog) / control.

First run (`c6_webhook`, K 0/15/30): **no decay at moderate scale** — guidance held
over 30 unrelated turns. This bounds the problem but doesn't find the breaking
point (the filler is too small to dilute the large anchor); scaling up needs a
top-up. Honest limits documented.

## Enabled by #100
The README TOC pushes it to 510 lines — fine now that the 500-line cap is
skill-files-only.

## Validation
- 18/18 README TOC anchors resolve to real headings (checked programmatically)
- `./scripts/check-invariants.sh` — all 7 pass; decay/results JSON store no secrets
