### PR TITLE
docs: full owner/repo names + links for competitor repos; consolidated table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Every competitor-repo reference now uses its full `owner/repo` name + a
+  GitHub link** (no bare "ECC"/"claude-skills"/"awesome-cursorrules", which
+  collide with unrelated same-named repos), and `evals/results/RESULTS.md` bundles
+  all competitor numbers into **one consolidated per-repo table** (completeness,
+  confidence, gap vs SOTA, head-to-head).
 - **The 500-line cap now applies to skill Markdown only** (`skills/**/*.md`), where
   it's load-bearing for incremental loading. README, CHANGELOG, and `docs/` are
   uncapped — navigability comes from the TOC + `docs/INDEX.md`, not a line ceiling.
@@ -77,8 +82,10 @@ Evaluation-harness additions (no skill-content change; not in CI — see
 - **Competitor benchmark** (`evals/run-competitors.py`,
   `evals/cases/competitors.json`, `results/2026-07-13/COMPETITOR-BENCHMARK.md`) —
   SOTA vs. the most popular competing guidance libraries on the 7 completeness
-  tasks, content-only and blind-judged. **SOTA 0.99 vs ECC (~230k★) 0.87,
-  awesome-cursorrules (~40k★) 0.83, alirezarezvani/claude-skills (~23k★) 0.81**;
+  tasks, content-only and blind-judged. **SOTA 0.99 vs
+  [affaan-m/ECC](https://github.com/affaan-m/ECC) (~230k★) 0.87,
+  [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) (~40k★) 0.83,
+  [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) (~23k★) 0.81**;
   unguided 0.58. SOTA wins or ties every one of the 21 head-to-head cases and
   loses none; competitors are legitimate (all beat unguided by +0.23–0.28) but
   drop the cross-cutting non-negotiables (rate limiting, transport, tests) SOTA

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -137,8 +137,10 @@ The audit's verdict was "content is trustworthy; the gap is that nothing
 - **Comparative benchmark vs. named competing libraries.** ~~Unexplored~~
   **DONE 2026-07-14** ([`evals/results/2026-07-13/COMPETITOR-BENCHMARK.md`](../evals/results/2026-07-13/COMPETITOR-BENCHMARK.md),
   `evals/run-competitors.py`, `evals/cases/competitors.json`). SOTA vs. the fair
-  peers, content-only, blind-judged, 7 build tasks: **SOTA 0.99 > ECC ~230k★ 0.87
-  > awesome-cursorrules ~40k★ 0.83 > alirezarezvani/claude-skills ~23k★ 0.81**
+  peers, content-only, blind-judged, 7 build tasks: **SOTA 0.99 >
+  [affaan-m/ECC](https://github.com/affaan-m/ECC) ~230k★ 0.87 >
+  [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) ~40k★ 0.83 >
+  [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) ~23k★ 0.81**
   (unguided 0.58). SOTA wins/ties every one of 21 cases, loses none; competitors
   are legitimate (all +0.23–0.28 over unguided) but drop the cross-cutting
   non-negotiables SOTA embeds. The honesty gate is **cleared** — `WHY-IT-WORKS.md`
@@ -157,23 +159,23 @@ The audit's verdict was "content is trustworthy; the gap is that nothing
   2026-new with explosive (plausibly inflated) star growth, so treat the numbers
   skeptically. Tiers:
   - **Same-kind engineering guidance a model reads to build/audit code** (the fair
-    completeness peers): **`affaan-m/ECC`** (~230k★, MIT, cross-AI — Claude/Codex/
+    completeness peers): **[affaan-m/ECC](https://github.com/affaan-m/ECC)** (~230k★, MIT, cross-AI — Claude/Codex/
     Cursor/Gemini/Kimi/Kiro; "agent harness… skills, security, research-first dev"
-    → highest-profile, PRIMARY); **`alirezarezvani/claude-skills`** (~22.6k★, MIT,
+    → highest-profile, PRIMARY); **[alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills)** (~22.6k★, MIT,
     multi-domain engineering + `audit/` + plugin, structured like SOTA → closest
-    same-kind peer); **`PatrickJS/awesome-cursorrules`** (~40.3k★, CC0, per-stack
+    same-kind peer); **[PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules)** (~40.3k★, CC0, per-stack
     `.cursorrules` → the rules-library reference); tertiary
-    `SebastienDegodez/copilot-instructions` (~190★ but genuinely same-kind: DDD/
-    clean-arch/testing rules) and `sanjeed5/awesome-cursor-rules-mdc` (~3.5k★).
+    [SebastienDegodez/copilot-instructions](https://github.com/SebastienDegodez/copilot-instructions) (~190★ but genuinely same-kind: DDD/
+    clean-arch/testing rules) and [sanjeed5/awesome-cursor-rules-mdc](https://github.com/sanjeed5/awesome-cursor-rules-mdc) (~3.5k★).
   - **Popular but a *different axis*** (compare only on a workflow/quality axis, not
-    build-completeness): **`garrytan/gstack`** (~122k★, cross-AI — a 23-tool
+    build-completeness): **[garrytan/gstack](https://github.com/garrytan/gstack)** (~122k★, cross-AI — a 23-tool
     role/workflow setup, not a rules library); **`multica-ai/andrej-karpathy-
     skills`** (~192k★ but **no license** → can't legally reuse content; mostly one
     behavior CLAUDE.md).
   - **Excluded, different category:** `x1xhlol/system-prompts-and-models-of-ai-
-    tools` (~142k★ leaked tool prompts); `JuliusBrussee/caveman` (~89k★ token
-    gimmick); `agentsmd/agents.md` (the spec/website); `travisvn/awesome-claude-
-    skills` (link list); `ComposioHQ/awesome-claude-skills` (~67k★ productivity).
+    tools` (~142k★ leaked tool prompts); [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) (~89k★ token
+    gimmick); [agentsmd/agents.md](https://github.com/agentsmd/agents.md) (the spec/website); `travisvn/awesome-claude-
+    skills` (link list); [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) (~67k★ productivity).
   Fairness controls: each competitor's *best-matching* content per task (not a
   strawman), same fixed rubric + blind opus judge + token budget, record commit
   SHAs, respect licenses (skip no-license repos for pasted content), state
@@ -182,7 +184,8 @@ The audit's verdict was "content is trustworthy; the gap is that nothing
   cross-cutting completeness the self-audit/principle-5 design recovers; expected
   non-edge = raw "does the code work". **Cost:** ~$16 per competitor per full
   completeness run (3-arm ≈ 1.5× the 2-arm) — one pilot fits the current ~$36
-  balance; the full ECC/alirezarezvani/cursorrules sweep needs a top-up. Still
+  balance; the full `affaan-m/ECC` / `alirezarezvani/claude-skills` /
+  `PatrickJS/awesome-cursorrules` sweep needs a top-up. Still
   gated on the maintainer wanting a "vs X" claim at all (2026-07-12 chose the
   honest vs-unguided framing).
 - **Cross-file / repo-level audit eval.** ~~Unexplored~~ **Explored 2026-07-13,

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -77,16 +77,16 @@ so its win is the guidance, not the method):
 | Library | Stars | Completeness |
 |---|---|---|
 | **SOTA** | — | **0.99** |
-| ECC | ~230k | 0.87 |
-| awesome-cursorrules | ~40k | 0.83 |
-| alirezarezvani/claude-skills | ~23k | 0.81 |
+| [affaan-m/ECC](https://github.com/affaan-m/ECC) | ~230k | 0.87 |
+| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | ~40k | 0.83 |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | ~23k | 0.81 |
 | unguided model | — | 0.58 |
 
 **SOTA wins or ties every one of the 21 head-to-head cases and loses none** — yet
 the competitors are no strawmen (all three beat an unguided model by +0.23–0.28).
 Where they fall short is the same place unguided models do: the **cross-cutting
 production non-negotiables** — rate limiting, transport/TLS, tests, structured
-logging — dropped endpoint after endpoint (even the ~230k-star ECC omits rate
+logging — dropped endpoint after endpoint (even the ~230k-star `affaan-m/ECC` omits rate
 limiting on 3 of 7 tasks). That is exactly what SOTA's operating principle 5 + the
 matched rules exist to close. Scope is honest: one task family (Python/FastAPI
 backend), single-sample, content-only; full method, per-arm misses, and

--- a/evals/README.md
+++ b/evals/README.md
@@ -95,8 +95,10 @@ python3 evals/run-competitors.py --competitors-dir DIR   # SOTA vs competing lib
 
 **Competitor benchmark** (`run-competitors.py`, `cases/competitors.json`): SOTA
 vs. the most popular competing guidance libraries on the 7 completeness tasks —
-content-only, blind-judged. Result (2026-07-14): **SOTA 0.99 vs ECC ~230k★ 0.87,
-awesome-cursorrules ~40k★ 0.83, alirezarezvani/claude-skills ~23k★ 0.81** (unguided
+content-only, blind-judged. Result (2026-07-14): **SOTA 0.99 vs
+[affaan-m/ECC](https://github.com/affaan-m/ECC) ~230k★ 0.87,
+[PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) ~40k★ 0.83,
+[alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) ~23k★ 0.81** (unguided
 0.58) — SOTA wins/ties every case, loses none; competitors drop the same
 cross-cutting concerns (rate limiting, transport, tests). Clone each competitor at
 the pinned SHA into `DIR`

--- a/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
+++ b/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
@@ -10,9 +10,9 @@ on the 7 completeness tasks, same fixed rubric, same blind opus-4.8 judge.
 | arm | mean completeness | vs SOTA | vs unguided | per-case vs SOTA |
 |---|---|---|---|---|
 | **SOTA** | **0.99** | — | +0.40 | — |
-| ECC (~230k★) | 0.87 | **−0.12** | +0.28 | 5 win / 2 tie / 0 loss |
-| awesome-cursorrules (~40.3k★) | 0.83 | **−0.16** | +0.24 | 7 win / 0 tie / 0 loss |
-| alirezarezvani/claude-skills (~22.6k★) | 0.81 | **−0.17** | +0.23 | 6 win / 1 tie / 0 loss |
+| [affaan-m/ECC](https://github.com/affaan-m/ECC) (~230k★) | 0.87 | **−0.12** | +0.28 | 5 win / 2 tie / 0 loss |
+| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) (~40.3k★) | 0.83 | **−0.16** | +0.24 | 7 win / 0 tie / 0 loss |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) (~22.6k★) | 0.81 | **−0.17** | +0.23 | 6 win / 1 tie / 0 loss |
 | unguided | 0.58 | −0.40 | — | — |
 
 SOTA wins or ties **every one of the 21 head-to-head cases; it loses none.** And
@@ -26,14 +26,14 @@ Most-missed rubric items per arm across the 7 tasks (what each still omits):
 
 - **unguided:** tests (7/7), rate limiting (6), transport/TLS (5), logging (4)
 - **SOTA:** session-invalidation (1 — the lone `c7` finite-constraint-budget slip)
-- **ECC (~230k★):** **rate limiting (3)**, storage-safety, image-bomb, idempotency, metrics, CSRF
-- **claude-skills:** **transport/TLS (4)**, **tests (4)**, rate limiting (2), logging, CSRF
-- **awesome-cursorrules:** **rate limiting (5)**, transport (2), storage, image-bomb, CSRF
+- **[affaan-m/ECC](https://github.com/affaan-m/ECC) (~230k★):** **rate limiting (3)**, storage-safety, image-bomb, idempotency, metrics, CSRF
+- **[alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills):** **transport/TLS (4)**, **tests (4)**, rate limiting (2), logging, CSRF
+- **[PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules):** **rate limiting (5)**, transport (2), storage, image-bomb, CSRF
 
 The pattern is consistent: competitors cover the *obvious* per-task security
 (auth, input validation, SQLi) well, but systematically drop the **cross-cutting
 production non-negotiables** — rate limiting, transport enforcement, tests,
-structured logging — on endpoint after endpoint. Even the ~230k-star ECC omits
+structured logging — on endpoint after endpoint. Even the ~230k-star `affaan-m/ECC` omits
 rate limiting on 3 of 7 tasks. That is exactly the gap SOTA's router *operating
 principle 5* + the matched rules are designed to close.
 
@@ -51,7 +51,8 @@ principle 5* + the matched rules are designed to close.
 - **Each competitor's best-matching content** for "build a secure Python/FastAPI
   backend feature," at a token budget in the same ballpark as a SOTA arm, pinned
   by commit SHA in [`evals/cases/competitors.json`](../../cases/competitors.json).
-  Licenses permit reuse (ECC/claude-skills MIT, cursorrules CC0); attributed here.
+  Licenses permit reuse (`affaan-m/ECC` + `alirezarezvani/claude-skills` MIT,
+  `PatrickJS/awesome-cursorrules` CC0); attributed here.
 - **Blind judge** (opus-4.8), same rubric as `run-completeness.py`. No artifact was
   truncated (largest 92 KB, well under the 32k-token cap). Raw per-case data:
   `competitor-benchmark.json`. Reproduce: `python3 evals/run-competitors.py
@@ -66,15 +67,15 @@ where a competitor *tied* SOTA in the single-sample run (`competitor-benchmark-3
 | arm | mean (3 tight cases) | vs SOTA |
 |---|---|---|
 | **SOTA** | **0.98** | — |
-| ECC | 0.87 | −0.11 |
-| claude-skills | 0.83 | −0.15 |
-| awesome-cursorrules | 0.82 | −0.16 |
+| [affaan-m/ECC](https://github.com/affaan-m/ECC) | 0.87 | −0.11 |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | 0.83 | −0.15 |
+| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | 0.82 | −0.16 |
 | unguided | 0.65 | −0.33 |
 
 The gaps (−0.11 to −0.16) are **the same** as the single-sample full-7 run
 (−0.12 to −0.17), and **on every one of these cases SOTA's *worst* sample is ≥ each
 competitor's *best* sample** — competitors occasionally tie SOTA at the ceiling
-(ECC/cursorrules hit 1.00 on c1; ECC ties at 0.91 on c7) but never beat it. SOTA's
+(`affaan-m/ECC` + `PatrickJS/awesome-cursorrules` hit 1.00 on c1; `affaan-m/ECC` ties at 0.91 on c7) but never beat it. SOTA's
 own variance is near-zero (sd 0.00 on c1/c3, 0.04 on c7). The lead is stable.
 *(Multi-sampling the other 4 cases and the full 7 was left for a top-up — those
 were the least contested, so the tight-case check is the informative one.)*
@@ -100,7 +101,9 @@ were the least contested, so the tight-case check is the informative one.)*
 
 The [honesty gate](../../../docs/ROADMAP.md) said: make a "better than library X"
 claim only if a fair, blind, reproducible comparison supports it. It now does —
-against the single most-starred cross-AI peer (ECC), the most-starred rules
-library (awesome-cursorrules), and the closest same-kind skills library
-(claude-skills). The claim is scoped to **completeness on backend build tasks**,
+against the single most-starred cross-AI peer ([affaan-m/ECC](https://github.com/affaan-m/ECC)),
+the most-starred rules library ([PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules)),
+and the closest same-kind skills library
+([alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills)).
+The claim is scoped to **completeness on backend build tasks**,
 content-only, and is reproducible from this repo.

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -41,20 +41,22 @@ The simulation is a faithful proxy, and the self-audit gate caught real bugs liv
 Content-only (SOTA's self-audit **off**), same rubric, blind judge, on the 7
 completeness tasks. Targets validated live via the GitHub API.
 
-| Library | Stars | 7-task (1×) | 3 tightest cases (3×, temp 0.7) |
-|---|---|---|---|
-| **SOTA** | — | **0.99** | **0.98** |
-| ECC | ~230k | 0.87 | 0.87 |
-| awesome-cursorrules | ~40k | 0.83 | 0.82 |
-| alirezarezvani/claude-skills | ~23k | 0.81 | 0.83 |
-| unguided | — | 0.58 | 0.65 |
+One consolidated view — every competitor's standing in a single table:
+
+| Library | Stars | Completeness (7 tasks) | Confidence (3 tightest, 3×) | Gap vs SOTA | Head-to-head vs SOTA |
+|---|---|---|---|---|---|
+| **SOTA** | — | **0.99** | **0.98** | — | — |
+| [affaan-m/ECC](https://github.com/affaan-m/ECC) | ~230k | 0.87 | 0.87 | −0.12 | 5 win / 2 tie / 0 loss |
+| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | ~40k | 0.83 | 0.82 | −0.16 | 7 win / 0 tie / 0 loss |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | ~23k | 0.81 | 0.83 | −0.17 | 6 win / 1 tie / 0 loss |
+| unguided model | — | 0.58 | 0.65 | −0.40 | — |
 
 SOTA **wins or ties all 21 single-sample cases and loses none.** The confidence
 check confirms it isn't noise: gaps match the full run, and **SOTA's worst sample
 ≥ each competitor's best sample** on every tight case. Competitors are legitimate
 (all beat unguided by +0.17–0.28) but drop the cross-cutting non-negotiables (rate
-limiting, transport, tests) — even the ~230k-star ECC omits rate limiting on 3 of
-7 tasks. Full method + honest limits (one task family, content-only, bundle-size
+limiting, transport, tests) — even the ~230k-star [affaan-m/ECC](https://github.com/affaan-m/ECC)
+omits rate limiting on 3 of 7 tasks. Full method + honest limits (one task family, content-only, bundle-size
 asymmetry): [COMPETITOR-BENCHMARK](2026-07-13/COMPETITOR-BENCHMARK.md).
 
 ## 4. Skill-application decay over a long session


### PR DESCRIPTION
Two requested fixes.

**1. Every competitor-repo reference now carries its full `owner/repo` name + a
GitHub link.** Bare "ECC" (especially) collides with unrelated repos; "claude-skills"
and "awesome-cursorrules" are generic too. Fixed across `RESULTS.md`,
`COMPETITOR-BENCHMARK.md`, `WHY-IT-WORKS.md`, `ROADMAP.md`, `evals/README.md`,
`CHANGELOG.md`. Verified: no bare ambiguous refs remain, and the three primaries
resolve (`affaan-m/ECC`, `alirezarezvani/claude-skills`,
`PatrickJS/awesome-cursorrules` — all HTTP 200).

**2. All competitor benchmarks bundled into one consolidated per-repo table** in
`evals/results/RESULTS.md`:

| Library | Stars | Completeness (7 tasks) | Confidence (3 tightest, 3×) | Gap vs SOTA | Head-to-head |
|---|---|---|---|---|---|
| SOTA | — | 0.99 | 0.98 | — | — |
| affaan-m/ECC | ~230k | 0.87 | 0.87 | −0.12 | 5W/2T/0L |
| PatrickJS/awesome-cursorrules | ~40k | 0.83 | 0.82 | −0.16 | 7W/0T/0L |
| alirezarezvani/claude-skills | ~23k | 0.81 | 0.83 | −0.17 | 6W/1T/0L |
| unguided | — | 0.58 | 0.65 | −0.40 | — |

Numbers re-validated against `competitor-benchmark.json`.

## Validation
- Links HTTP-checked (200); no bare `ECC`/`claude-skills`/`awesome-cursorrules` left
- `./scripts/check-invariants.sh` — all 7 pass
