### PR TITLE
docs: competitor tables in % + name/link SOTA-skills + explain head-to-head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ Evaluation-harness additions (no skill-content change; not in CI — see
 - **Competitor benchmark** (`evals/run-competitors.py`,
   `evals/cases/competitors.json`, `results/2026-07-13/COMPETITOR-BENCHMARK.md`) —
   SOTA vs. the most popular competing guidance libraries on the 7 completeness
-  tasks, content-only and blind-judged. **SOTA 0.99 vs
+  tasks, content-only and blind-judged. **SOTA-skills 0.99 vs
   [affaan-m/ECC](https://github.com/affaan-m/ECC) (~230k★) 0.87,
   [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) (~40k★) 0.83,
   [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) (~23k★) 0.81**;

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -74,16 +74,20 @@ most popular competing guidance libraries on the same 7 build tasks — same rub
 same blind judge, **content-only** (SOTA's self-audit forcing function turned off,
 so its win is the guidance, not the method):
 
+Scores are % of a fixed best-practice rubric the generated code implements
+(blind-judged); higher is better.
+
 | Library | Stars | Completeness |
 |---|---|---|
-| **SOTA** | — | **0.99** |
-| [affaan-m/ECC](https://github.com/affaan-m/ECC) | ~230k | 0.87 |
-| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | ~40k | 0.83 |
-| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | ~23k | 0.81 |
-| unguided model | — | 0.58 |
+| [**SOTA-skills**](https://github.com/martinholovsky/SOTA-skills) | — | **99%** |
+| [affaan-m/ECC](https://github.com/affaan-m/ECC) | ~230k | 87% |
+| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | ~40k | 83% |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | ~23k | 81% |
+| unguided model | — | 58% |
 
-**SOTA wins or ties every one of the 21 head-to-head cases and loses none** — yet
-the competitors are no strawmen (all three beat an unguided model by +0.23–0.28).
+**SOTA-skills wins or ties every one of the 21 head-to-head cases and loses none**
+(across the 7 build tasks, per competitor: higher / equal / lower) — yet the
+competitors are no strawmen (all three beat an unguided model by +23 to +28 pts).
 Where they fall short is the same place unguided models do: the **cross-cutting
 production non-negotiables** — rate limiting, transport/TLS, tests, structured
 logging — dropped endpoint after endpoint (even the ~230k-star `affaan-m/ECC` omits rate

--- a/evals/README.md
+++ b/evals/README.md
@@ -95,7 +95,7 @@ python3 evals/run-competitors.py --competitors-dir DIR   # SOTA vs competing lib
 
 **Competitor benchmark** (`run-competitors.py`, `cases/competitors.json`): SOTA
 vs. the most popular competing guidance libraries on the 7 completeness tasks —
-content-only, blind-judged. Result (2026-07-14): **SOTA 0.99 vs
+content-only, blind-judged. Result (2026-07-14): **SOTA-skills 0.99 vs
 [affaan-m/ECC](https://github.com/affaan-m/ECC) ~230k★ 0.87,
 [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) ~40k★ 0.83,
 [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) ~23k★ 0.81** (unguided

--- a/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
+++ b/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
@@ -5,15 +5,20 @@ guidance actually produce more complete code than the most popular competing
 skill/rules libraries on the same "build X" tasks? This runs them as extra arms
 on the 7 completeness tasks, same fixed rubric, same blind opus-4.8 judge.
 
-**Answer: yes — SOTA leads all three, and never loses a single case.**
+**Answer: yes — [SOTA-skills](https://github.com/martinholovsky/SOTA-skills) leads
+all three, and never loses a single case.** Scores are % of a fixed best-practice
+rubric the generated code implements (blind-judged); higher is better.
 
-| arm | mean completeness | vs SOTA | vs unguided | per-case vs SOTA |
+| Library | Completeness | vs SOTA-skills | vs unguided | Tasks won / tied / lost¹ |
 |---|---|---|---|---|
-| **SOTA** | **0.99** | — | +0.40 | — |
-| [affaan-m/ECC](https://github.com/affaan-m/ECC) (~230k★) | 0.87 | **−0.12** | +0.28 | 5 win / 2 tie / 0 loss |
-| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) (~40.3k★) | 0.83 | **−0.16** | +0.24 | 7 win / 0 tie / 0 loss |
-| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) (~22.6k★) | 0.81 | **−0.17** | +0.23 | 6 win / 1 tie / 0 loss |
-| unguided | 0.58 | −0.40 | — | — |
+| [**SOTA-skills**](https://github.com/martinholovsky/SOTA-skills) | **99%** | — | +40 pts | — |
+| [affaan-m/ECC](https://github.com/affaan-m/ECC) (~230k★) | 87% | **−12 pts** | +28 pts | 5 / 2 / 0 |
+| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) (~40.3k★) | 83% | **−16 pts** | +24 pts | 7 / 0 / 0 |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) (~22.6k★) | 81% | **−17 pts** | +23 pts | 6 / 1 / 0 |
+| unguided | 58% | −40 pts | — | — |
+
+¹ across the 7 build tasks, how many SOTA-skills scored higher / equal / lower vs
+that competitor (single-sample).
 
 SOTA wins or ties **every one of the 21 head-to-head cases; it loses none.** And
 the competitors are **not strawmen** — all three lift completeness +0.23 to +0.28
@@ -62,15 +67,15 @@ principle 5* + the matched rules are designed to close.
 
 The main table is single-sample (temp 0). To check the lead isn't a lucky draw, we
 re-ran **3 samples at temp 0.7** on the **3 tightest cases** — c1, c3, c7, the ones
-where a competitor *tied* SOTA in the single-sample run (`competitor-benchmark-3sample.json`):
+where a competitor *tied* SOTA-skills in the single-sample run (`competitor-benchmark-3sample.json`):
 
-| arm | mean (3 tight cases) | vs SOTA |
+| Library | Completeness (3 tight cases) | vs SOTA-skills |
 |---|---|---|
-| **SOTA** | **0.98** | — |
-| [affaan-m/ECC](https://github.com/affaan-m/ECC) | 0.87 | −0.11 |
-| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | 0.83 | −0.15 |
-| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | 0.82 | −0.16 |
-| unguided | 0.65 | −0.33 |
+| [**SOTA-skills**](https://github.com/martinholovsky/SOTA-skills) | **98%** | — |
+| [affaan-m/ECC](https://github.com/affaan-m/ECC) | 87% | −11 pts |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | 83% | −15 pts |
+| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | 82% | −16 pts |
+| unguided | 65% | −33 pts |
 
 The gaps (−0.11 to −0.16) are **the same** as the single-sample full-7 run
 (−0.12 to −0.17), and **on every one of these cases SOTA's *worst* sample is ≥ each

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -41,21 +41,29 @@ The simulation is a faithful proxy, and the self-audit gate caught real bugs liv
 Content-only (SOTA's self-audit **off**), same rubric, blind judge, on the 7
 completeness tasks. Targets validated live via the GitHub API.
 
-One consolidated view — every competitor's standing in a single table:
+One consolidated view — every competitor's standing in a single table. Scores are
+**% of a fixed best-practice rubric the generated code actually implements**
+(blind-judged); higher is better.
 
-| Library | Stars | Completeness (7 tasks) | Confidence (3 tightest, 3×) | Gap vs SOTA | Head-to-head vs SOTA |
+| Library | Stars | Completeness (7 tasks) | Confidence (3 tightest, 3×) | Gap vs SOTA-skills | Tasks won / tied / lost¹ |
 |---|---|---|---|---|---|
-| **SOTA** | — | **0.99** | **0.98** | — | — |
-| [affaan-m/ECC](https://github.com/affaan-m/ECC) | ~230k | 0.87 | 0.87 | −0.12 | 5 win / 2 tie / 0 loss |
-| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | ~40k | 0.83 | 0.82 | −0.16 | 7 win / 0 tie / 0 loss |
-| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | ~23k | 0.81 | 0.83 | −0.17 | 6 win / 1 tie / 0 loss |
-| unguided model | — | 0.58 | 0.65 | −0.40 | — |
+| [**SOTA-skills**](https://github.com/martinholovsky/SOTA-skills) | — | **99%** | **98%** | — | — |
+| [affaan-m/ECC](https://github.com/affaan-m/ECC) | ~230k | 87% | 87% | −12 pts | 5 / 2 / 0 |
+| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | ~40k | 83% | 82% | −16 pts | 7 / 0 / 0 |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | ~23k | 81% | 83% | −17 pts | 6 / 1 / 0 |
+| unguided model | — | 58% | 65% | −40 pts | — |
 
-SOTA **wins or ties all 21 single-sample cases and loses none.** The confidence
-check confirms it isn't noise: gaps match the full run, and **SOTA's worst sample
-≥ each competitor's best sample** on every tight case. Competitors are legitimate
-(all beat unguided by +0.17–0.28) but drop the cross-cutting non-negotiables (rate
-limiting, transport, tests) — even the ~230k-star [affaan-m/ECC](https://github.com/affaan-m/ECC)
+¹ **Tasks won / tied / lost** — across the 7 build tasks, how many
+SOTA-skills scored *higher than* / *equal to* / *lower than* that competitor
+(single-sample). E.g. `5 / 2 / 0` = SOTA-skills beat [affaan-m/ECC](https://github.com/affaan-m/ECC)
+on 5 tasks, tied on 2, and never lost.
+
+SOTA-skills **wins or ties all 21 head-to-head cases and loses none.** The
+confidence check confirms it isn't noise: gaps match the full run, and
+**SOTA-skills' worst sample ≥ each competitor's best sample** on every tight case.
+Competitors are legitimate (all beat an unguided model by +17 to +28 pts) but drop
+the cross-cutting non-negotiables (rate limiting, transport, tests) — even the
+~230k-star [affaan-m/ECC](https://github.com/affaan-m/ECC)
 omits rate limiting on 3 of 7 tasks. Full method + honest limits (one task family, content-only, bundle-size
 asymmetry): [COMPETITOR-BENCHMARK](2026-07-13/COMPETITOR-BENCHMARK.md).
 


### PR DESCRIPTION
Feedback fixes on the consolidated competitor table.

- **Percentages** instead of decimals (99% / 87% / …); gaps as points (−12 pts) —
  easier to read.
- **The library's own row is now `[SOTA-skills](https://github.com/martinholovsky/SOTA-skills)`**
  — named and linked like every competitor (HTTP 200 verified), so copy&paste
  carries the link.
- **Head-to-head explained.** Renamed to "Tasks won / tied / lost" with a footnote:
  across the 7 build tasks, how many SOTA-skills scored higher / equal / lower vs
  that competitor (single-sample). So `5 / 2 / 0` = beat on 5, tied 2, lost none.

Applied to `RESULTS.md`, `COMPETITOR-BENCHMARK.md` (both tables), `WHY-IT-WORKS.md`,
and the competitor prose in `evals/README` + `CHANGELOG`.

## Validation
- SOTA-skills repo link HTTP 200; all percentages re-derived from the same JSON means
- `./scripts/check-invariants.sh` — all 7 pass
