### PR TITLE
docs: fix head-to-head column to read from the row's (competitor's) perspective

### DIFF
--- a/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
+++ b/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
@@ -9,16 +9,17 @@ on the 7 completeness tasks, same fixed rubric, same blind opus-4.8 judge.
 all three, and never loses a single case.** Scores are % of a fixed best-practice
 rubric the generated code implements (blind-judged); higher is better.
 
-| Library | Completeness | vs SOTA-skills | vs unguided | Tasks won / tied / lost¹ |
+| Library | Completeness | vs SOTA-skills | vs unguided | This library vs SOTA-skills — won / tied / lost¹ |
 |---|---|---|---|---|
 | [**SOTA-skills**](https://github.com/martinholovsky/SOTA-skills) | **99%** | — | +40 pts | — |
-| [affaan-m/ECC](https://github.com/affaan-m/ECC) (~230k★) | 87% | **−12 pts** | +28 pts | 5 / 2 / 0 |
-| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) (~40.3k★) | 83% | **−16 pts** | +24 pts | 7 / 0 / 0 |
-| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) (~22.6k★) | 81% | **−17 pts** | +23 pts | 6 / 1 / 0 |
+| [affaan-m/ECC](https://github.com/affaan-m/ECC) (~230k★) | 87% | **−12 pts** | +28 pts | 0 / 2 / 5 |
+| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) (~40.3k★) | 83% | **−16 pts** | +24 pts | 0 / 0 / 7 |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) (~22.6k★) | 81% | **−17 pts** | +23 pts | 0 / 1 / 6 |
 | unguided | 58% | −40 pts | — | — |
 
-¹ across the 7 build tasks, how many SOTA-skills scored higher / equal / lower vs
-that competitor (single-sample).
+¹ Read on each library's own row: how many of the 7 build tasks *that library*
+won / tied / lost against SOTA-skills (single-sample). `0 / 2 / 5` on the
+`affaan-m/ECC` row = ECC won 0, tied 2, lost 5. No competitor won a single task.
 
 SOTA wins or ties **every one of the 21 head-to-head cases; it loses none.** And
 the competitors are **not strawmen** — all three lift completeness +0.23 to +0.28

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -45,18 +45,19 @@ One consolidated view — every competitor's standing in a single table. Scores 
 **% of a fixed best-practice rubric the generated code actually implements**
 (blind-judged); higher is better.
 
-| Library | Stars | Completeness (7 tasks) | Confidence (3 tightest, 3×) | Gap vs SOTA-skills | Tasks won / tied / lost¹ |
+| Library | Stars | Completeness (7 tasks) | Confidence (3 tightest, 3×) | Gap vs SOTA-skills | This library vs SOTA-skills — won / tied / lost¹ |
 |---|---|---|---|---|---|
 | [**SOTA-skills**](https://github.com/martinholovsky/SOTA-skills) | — | **99%** | **98%** | — | — |
-| [affaan-m/ECC](https://github.com/affaan-m/ECC) | ~230k | 87% | 87% | −12 pts | 5 / 2 / 0 |
-| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | ~40k | 83% | 82% | −16 pts | 7 / 0 / 0 |
-| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | ~23k | 81% | 83% | −17 pts | 6 / 1 / 0 |
+| [affaan-m/ECC](https://github.com/affaan-m/ECC) | ~230k | 87% | 87% | −12 pts | 0 / 2 / 5 |
+| [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | ~40k | 83% | 82% | −16 pts | 0 / 0 / 7 |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | ~23k | 81% | 83% | −17 pts | 0 / 1 / 6 |
 | unguided model | — | 58% | 65% | −40 pts | — |
 
-¹ **Tasks won / tied / lost** — across the 7 build tasks, how many
-SOTA-skills scored *higher than* / *equal to* / *lower than* that competitor
-(single-sample). E.g. `5 / 2 / 0` = SOTA-skills beat [affaan-m/ECC](https://github.com/affaan-m/ECC)
-on 5 tasks, tied on 2, and never lost.
+¹ **This library's record against SOTA-skills**, across the 7 build tasks (how many
+that library scored *higher than* / *equal to* / *lower than* SOTA-skills,
+single-sample). Read it on the library's own row: `0 / 2 / 5` on the
+[affaan-m/ECC](https://github.com/affaan-m/ECC) row = ECC **won 0, tied 2, lost 5**.
+**No competitor won a single task against SOTA-skills.**
 
 SOTA-skills **wins or ties all 21 head-to-head cases and loses none.** The
 confidence check confirms it isn't noise: gaps match the full run, and


### PR DESCRIPTION
`5 / 2 / 0` on the affaan-m/ECC row read as "ECC won 5" — the opposite of the truth
(SOTA-skills won 5). Since the row **is** the competitor, the numbers now describe
the competitor's own record against SOTA-skills:

| Library | This library vs SOTA-skills — won / tied / lost |
|---|---|
| affaan-m/ECC | 0 / 2 / 5 |
| PatrickJS/awesome-cursorrules | 0 / 0 / 7 |
| alirezarezvani/claude-skills | 0 / 1 / 6 |

Re-derived from the raw JSON. **No competitor won a single task.** Consistent with
the prose ("SOTA-skills wins or ties all 21, loses none": competitors won 0, tied 3,
lost 18 = 21). Footnotes rewritten with a read-on-the-row example. Applied to
RESULTS.md and COMPETITOR-BENCHMARK.md.

## Validation
- Counts re-derived from `competitor-benchmark.json`; arithmetic cross-checks (21)
- `./scripts/check-invariants.sh` — all 7 pass
