### PR TITLE
docs: add competitor-benchmark bar chart (theme-aware SVG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Competitor-benchmark bar chart** (`assets/benchmark-{light,dark}.svg`,
+  regenerable via `assets/gen-benchmark-chart.py`) — a theme-aware SVG visual of
+  best-practice completeness per library (SOTA-skills 99% highlighted vs the
+  field), embedded in the README, `evals/results/RESULTS.md`, and
+  `docs/WHY-IT-WORKS.md` via `<picture>` (light/dark). Palette validated with the
+  dataviz skill's checker; alt text carries the numbers.
 - **Discoverability overhaul.** `docs/INDEX.md` (a find-it-fast map: every topic →
   where it's documented, organized by intent), `docs/CONTEXT-MANAGEMENT.md` (the
   single home for how the library keeps the model applying rules as context fills —

--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ library); clean, blind-judged, stable across samples ([results & method →](doc
 - **Freshness +0.53** — current-2026 facts (RFCs, CVEs, EOLs) 0.44 → 0.97, where an unguided model is *confidently wrong*.
 - **Routing +0.10** — the right skills load for the task (0.90 → 1.00), even ones a keyword read misses; with the library, results barely move run-to-run.
 
+And not just vs. an unguided model — **head-to-head against the most popular
+guidance libraries**, SOTA-skills leads on completeness (content-only, blind-judged;
+it wins or ties all 21 cases and loses none):
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/benchmark-dark.svg">
+    <img alt="Best-practice completeness by library: SOTA-skills 99%, affaan-m/ECC 87%, PatrickJS/awesome-cursorrules 83%, alirezarezvani/claude-skills 81%, unguided model 58%." src="assets/benchmark-light.svg" width="100%">
+  </picture>
+</p>
+
+[Consolidated table, method & honest limits →](evals/results/RESULTS.md)
+
 ## Skills
 
 | Skill | Covers |

--- a/assets/benchmark-dark.svg
+++ b/assets/benchmark-dark.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 340" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" role="img" aria-label="Best-practice completeness by library: SOTA-skills 99%, affaan-m/ECC 87%, PatrickJS/awesome-cursorrules 83%, alirezarezvani/claude-skills 81%, unguided model 58%.">
+<rect x="0.5" y="0.5" width="719" height="339" rx="12" fill="#0d1117" stroke="#30363d"/>
+<text x="24" y="40" font-size="19" font-weight="700" fill="#e6edf3">How complete is the generated code?</text>
+<text x="24" y="62" font-size="12" fill="#8b949e">% of a fixed best-practice rubric implemented — blind-judged, 7 build tasks, content-only. Higher is better.</text>
+<text x="24" y="112" font-size="12.5" font-weight="700" fill="#e6edf3">SOTA-skills</text>
+<rect x="250" y="97" width="410" height="20" rx="4" fill="#21262d"/>
+<rect x="250" y="97" width="405.9" height="20" rx="4" fill="#3fb950"/>
+<text x="663.9" y="112" font-size="13" font-weight="700" fill="#e6edf3">99%</text>
+<text x="24" y="158" font-size="12.5" font-weight="400" fill="#e6edf3">affaan-m/ECC</text>
+<rect x="250" y="143" width="410" height="20" rx="4" fill="#21262d"/>
+<rect x="250" y="143" width="356.7" height="20" rx="4" fill="#768390"/>
+<text x="614.7" y="158" font-size="13" font-weight="400" fill="#e6edf3">87%</text>
+<text x="24" y="204" font-size="12.5" font-weight="400" fill="#e6edf3">PatrickJS/awesome-cursorrules</text>
+<rect x="250" y="189" width="410" height="20" rx="4" fill="#21262d"/>
+<rect x="250" y="189" width="340.3" height="20" rx="4" fill="#768390"/>
+<text x="598.3" y="204" font-size="13" font-weight="400" fill="#e6edf3">83%</text>
+<text x="24" y="250" font-size="12.5" font-weight="400" fill="#e6edf3">alirezarezvani/claude-skills</text>
+<rect x="250" y="235" width="410" height="20" rx="4" fill="#21262d"/>
+<rect x="250" y="235" width="332.1" height="20" rx="4" fill="#768390"/>
+<text x="590.1" y="250" font-size="13" font-weight="400" fill="#e6edf3">81%</text>
+<text x="24" y="296" font-size="12.5" font-weight="400" fill="#e6edf3">unguided model</text>
+<rect x="250" y="281" width="410" height="20" rx="4" fill="#21262d"/>
+<rect x="250" y="281" width="237.8" height="20" rx="4" fill="#545d68"/>
+<text x="495.8" y="296" font-size="13" font-weight="400" fill="#e6edf3">58%</text>
+<text x="24" y="323" font-size="10.5" fill="#8b949e">SOTA-skills wins or ties all 21 head-to-head cases (loses none) · data: evals/results/RESULTS.md</text>
+</svg>

--- a/assets/benchmark-light.svg
+++ b/assets/benchmark-light.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 340" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" role="img" aria-label="Best-practice completeness by library: SOTA-skills 99%, affaan-m/ECC 87%, PatrickJS/awesome-cursorrules 83%, alirezarezvani/claude-skills 81%, unguided model 58%.">
+<rect x="0.5" y="0.5" width="719" height="339" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+<text x="24" y="40" font-size="19" font-weight="700" fill="#1f2328">How complete is the generated code?</text>
+<text x="24" y="62" font-size="12" fill="#656d76">% of a fixed best-practice rubric implemented — blind-judged, 7 build tasks, content-only. Higher is better.</text>
+<text x="24" y="112" font-size="12.5" font-weight="700" fill="#1f2328">SOTA-skills</text>
+<rect x="250" y="97" width="410" height="20" rx="4" fill="#eaeef2"/>
+<rect x="250" y="97" width="405.9" height="20" rx="4" fill="#2fa45f"/>
+<text x="663.9" y="112" font-size="13" font-weight="700" fill="#1f2328">99%</text>
+<text x="24" y="158" font-size="12.5" font-weight="400" fill="#1f2328">affaan-m/ECC</text>
+<rect x="250" y="143" width="410" height="20" rx="4" fill="#eaeef2"/>
+<rect x="250" y="143" width="356.7" height="20" rx="4" fill="#57606a"/>
+<text x="614.7" y="158" font-size="13" font-weight="400" fill="#1f2328">87%</text>
+<text x="24" y="204" font-size="12.5" font-weight="400" fill="#1f2328">PatrickJS/awesome-cursorrules</text>
+<rect x="250" y="189" width="410" height="20" rx="4" fill="#eaeef2"/>
+<rect x="250" y="189" width="340.3" height="20" rx="4" fill="#57606a"/>
+<text x="598.3" y="204" font-size="13" font-weight="400" fill="#1f2328">83%</text>
+<text x="24" y="250" font-size="12.5" font-weight="400" fill="#1f2328">alirezarezvani/claude-skills</text>
+<rect x="250" y="235" width="410" height="20" rx="4" fill="#eaeef2"/>
+<rect x="250" y="235" width="332.1" height="20" rx="4" fill="#57606a"/>
+<text x="590.1" y="250" font-size="13" font-weight="400" fill="#1f2328">81%</text>
+<text x="24" y="296" font-size="12.5" font-weight="400" fill="#1f2328">unguided model</text>
+<rect x="250" y="281" width="410" height="20" rx="4" fill="#eaeef2"/>
+<rect x="250" y="281" width="237.8" height="20" rx="4" fill="#8c959f"/>
+<text x="495.8" y="296" font-size="13" font-weight="400" fill="#1f2328">58%</text>
+<text x="24" y="323" font-size="10.5" fill="#656d76">SOTA-skills wins or ties all 21 head-to-head cases (loses none) · data: evals/results/RESULTS.md</text>
+</svg>

--- a/assets/gen-benchmark-chart.py
+++ b/assets/gen-benchmark-chart.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Generate the competitor-benchmark bar chart (light + dark SVGs) in assets/.
+
+A single-measure magnitude chart: best-practice completeness (%) per library, with
+SOTA-skills emphasized. Identity is carried by the text labels (each bar is named),
+so color is not load-bearing — the brand green marks SOTA-skills, recessive grays
+carry the rest. Numbers come from evals/results/2026-07-13/competitor-benchmark.json
+(the 7-task, content-only, blind-judged means, rounded to whole %).
+
+Regenerate: python3 assets/gen-benchmark-chart.py
+"""
+import os
+
+ROWS = [
+    ("SOTA-skills", 99, "sota"),
+    ("affaan-m/ECC", 87, "comp"),
+    ("PatrickJS/awesome-cursorrules", 83, "comp"),
+    ("alirezarezvani/claude-skills", 81, "comp"),
+    ("unguided model", 58, "base"),
+]
+
+THEMES = {
+    "light": dict(surface="#ffffff", border="#d0d7de", ink="#1f2328", muted="#656d76",
+                  track="#eaeef2", sota="#2fa45f", comp="#57606a", base="#8c959f"),
+    "dark": dict(surface="#0d1117", border="#30363d", ink="#e6edf3", muted="#8b949e",
+                 track="#21262d", sota="#3fb950", comp="#768390", base="#545d68"),
+}
+
+W, H = 720, 340
+LABEL_X, BAR_X, BAR_MAX = 24, 250, 410
+FIRST_TOP, ROW_H, BAR_H = 84, 46, 20
+FONT = "-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif"
+
+
+def svg(theme_name):
+    t = THEMES[theme_name]
+    fill = {"sota": t["sota"], "comp": t["comp"], "base": t["base"]}
+    out = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}" '
+        f'font-family="{FONT}" role="img" '
+        f'aria-label="Best-practice completeness by library: SOTA-skills 99%, '
+        f'affaan-m/ECC 87%, PatrickJS/awesome-cursorrules 83%, '
+        f'alirezarezvani/claude-skills 81%, unguided model 58%.">',
+        f'<rect x="0.5" y="0.5" width="{W-1}" height="{H-1}" rx="12" '
+        f'fill="{t["surface"]}" stroke="{t["border"]}"/>',
+        f'<text x="{LABEL_X}" y="40" font-size="19" font-weight="700" '
+        f'fill="{t["ink"]}">How complete is the generated code?</text>',
+        f'<text x="{LABEL_X}" y="62" font-size="12" fill="{t["muted"]}">'
+        f'% of a fixed best-practice rubric implemented — blind-judged, 7 build '
+        f'tasks, content-only. Higher is better.</text>',
+    ]
+    for i, (name, pct, kind) in enumerate(ROWS):
+        top = FIRST_TOP + i * ROW_H
+        by = top + 13
+        w = round(BAR_MAX * pct / 100, 1)
+        weight = "700" if kind == "sota" else "400"
+        out.append(f'<text x="{LABEL_X}" y="{by+15}" font-size="12.5" '
+                   f'font-weight="{weight}" fill="{t["ink"]}">{name}</text>')
+        out.append(f'<rect x="{BAR_X}" y="{by}" width="{BAR_MAX}" height="{BAR_H}" '
+                   f'rx="4" fill="{t["track"]}"/>')
+        out.append(f'<rect x="{BAR_X}" y="{by}" width="{w}" height="{BAR_H}" '
+                   f'rx="4" fill="{fill[kind]}"/>')
+        out.append(f'<text x="{BAR_X + w + 8}" y="{by+15}" font-size="13" '
+                   f'font-weight="{weight}" fill="{t["ink"]}">{pct}%</text>')
+    out.append(f'<text x="{LABEL_X}" y="323" font-size="10.5" fill="{t["muted"]}">'
+               f'SOTA-skills wins or ties all 21 head-to-head cases (loses none) · '
+               f'data: evals/results/RESULTS.md</text>')
+    out.append('</svg>')
+    return "\n".join(out) + "\n"
+
+
+def main():
+    here = os.path.dirname(os.path.abspath(__file__))
+    for mode in ("light", "dark"):
+        path = os.path.join(here, f"benchmark-{mode}.svg")
+        open(path, "w", encoding="utf-8").write(svg(mode))
+        print("wrote", path)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -77,6 +77,13 @@ so its win is the guidance, not the method):
 Scores are % of a fixed best-practice rubric the generated code implements
 (blind-judged); higher is better.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../assets/benchmark-dark.svg">
+    <img alt="Best-practice completeness by library: SOTA-skills 99%, affaan-m/ECC 87%, PatrickJS/awesome-cursorrules 83%, alirezarezvani/claude-skills 81%, unguided model 58%." src="../assets/benchmark-light.svg" width="100%">
+  </picture>
+</p>
+
 | Library | Stars | Completeness |
 |---|---|---|
 | [**SOTA-skills**](https://github.com/martinholovsky/SOTA-skills) | — | **99%** |

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -41,6 +41,13 @@ The simulation is a faithful proxy, and the self-audit gate caught real bugs liv
 Content-only (SOTA's self-audit **off**), same rubric, blind judge, on the 7
 completeness tasks. Targets validated live via the GitHub API.
 
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../../assets/benchmark-dark.svg">
+    <img alt="Best-practice completeness by library: SOTA-skills 99%, affaan-m/ECC 87%, PatrickJS/awesome-cursorrules 83%, alirezarezvani/claude-skills 81%, unguided model 58%." src="../../assets/benchmark-light.svg" width="100%">
+  </picture>
+</p>
+
 One consolidated view — every competitor's standing in a single table. Scores are
 **% of a fixed best-practice rubric the generated code actually implements**
 (blind-judged); higher is better.


### PR DESCRIPTION
A hero-style visual of the headline result — best-practice completeness per
library, embedded in the README benefits section, `RESULTS.md`, and `WHY-IT-WORKS.md`.

![chart](https://github.com/martinholovsky/SOTA-skills/raw/docs/benchmark-chart/assets/benchmark-light.svg)

- **SOTA-skills 99%** (brand green, bold) clearly ahead of affaan-m/ECC 87%,
  PatrickJS/awesome-cursorrules 83%, alirezarezvani/claude-skills 81%, unguided 58%.
- **Honest**: shows the real 99%, not a forced 100%.
- **Theme-aware**: `assets/benchmark-{light,dark}.svg` via `<picture>` +
  `prefers-color-scheme`; regenerable with `assets/gen-benchmark-chart.py` (numbers
  sourced from `competitor-benchmark.json`).
- **Built with the dataviz skill**: horizontal bars for magnitude, identity via
  text labels (not color-alone), fill colors validated, and rendered + eyeballed in
  both themes (no label collisions/overflow). Alt text carries the numbers.

## Validation
- SVGs are well-formed XML; rendered to PNG and visually inspected (light + dark)
- Image paths resolve from all three embed locations
- `./scripts/check-invariants.sh` — all 7 pass; gitleaks pass
