### PR TITLE
docs: label the as-deployed 'widens SOTA's lead' claim as a prediction

### DIFF
--- a/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
+++ b/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
@@ -52,8 +52,10 @@ principle 5* + the matched rules are designed to close.
   SOTA's non-negotiables to the competitors), so the only variable is the pasted
   guidance. **SOTA's self-audit forcing function is *not* used here** — the number
   is content-only, so SOTA's win is its guidance, not its method. In real
-  deployment SOTA's self-audit widens the gap (it lifts SOTA to 0.99 *with* the
-  gate in `run-completeness.py`; here SOTA reaches 0.987 on content alone).
+  deployment SOTA-skills also runs its self-audit (measured: SOTA reaches 0.99
+  *with* the gate in `run-completeness.py`, vs 0.987 on content alone here).
+  Whether that *widens* the lead in an as-deployed run is a prediction, **not
+  measured** — a competitor deployed with its own method could improve too.
 - **Each competitor's best-matching content** for "build a secure Python/FastAPI
   backend feature," at a token budget in the same ballpark as a SOTA arm, pinned
   by commit SHA in [`evals/cases/competitors.json`](../../cases/competitors.json).

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -96,7 +96,9 @@ filler is too small to dilute the anchor); scaling the test up needs a top-up.
 - **Competitor breadth** — the head-to-head is one task family (Python/FastAPI
   backend); frontend/data/mobile untested.
 - **As-deployed competitor comparison** — each library with its own method (not
-  content-only); would only widen SOTA's lead.
+  content-only). SOTA-skills' self-audit is *off* in this run, so an as-deployed
+  run would *plausibly* favor SOTA-skills — but that is a prediction, **not
+  measured** (a competitor's own method could help it too).
 - **Full-7 multi-sample** of the competitor arms (only the 3 tightest done).
 
 ## The three-layer story


### PR DESCRIPTION
Reported question: is the RESULTS.md "Not yet measured" section true?

**Validated all three claims against the files:**
- *Competitor breadth — one task family (Python/FastAPI backend)* — **true.** All 7
  tasks are Python backend (5 explicitly FastAPI; c2 upload handler, c3 worker).
- *Full-7 multi-sample — only 3 tightest done* — **true.** Multi-sample file has
  exactly c1/c3/c7; single-sample has all 7.
- *As-deployed — "would only widen SOTA's lead"* — the "not done" is true, **but the
  "would only widen" is an unverified prediction stated as fact** — a competitor
  deployed with its own method could improve too. That violated the repo's own
  honesty standard.

**Fix:** softened the as-deployed wording in `RESULTS.md` and
`COMPETITOR-BENCHMARK.md` to mark it explicitly as a prediction ("not measured"),
while keeping the measured facts (SOTA content-only 0.987; with its self-audit
0.99). No other instances remain.

## Validation
- Claims cross-checked against `competitance.jsonl`/`competitor-benchmark*.json`
- `./scripts/check-invariants.sh` — all 7 pass
