### PR TITLE
docs: accuracy sweep — hedge unmeasured claims, fix numbers (4-way doc audit)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,8 @@ pre-commit hook scans each commit locally.
 - [docs/MAINTENANCE.md](docs/MAINTENANCE.md) — accuracy sweep runbook +
   eval harness (keeping fast-moving claims true and measuring efficacy)
 - [docs/WHY-IT-WORKS.md](docs/WHY-IT-WORKS.md) — the measured-efficacy case
-  (lift **vs. an unguided model**, not vs. other libraries) + the design
+  (lift **vs. an unguided model**, plus a scoped head-to-head vs. named competing
+  libraries) + the design
   benefits; keep its numbers in sync with the eval results when they change
 - [docs/WHY-COMPLETENESS-RESIDUAL.md](docs/WHY-COMPLETENESS-RESIDUAL.md) — why a
   with-library build still occasionally drops a cross-cutting rule (a salience /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Accuracy sweep (4-way doc audit against the result JSONs).** Corrected claims stated more strongly than the data: the **web-search recovers/can't-recover** claims (freshness + completeness) were never measured — now marked as predictions; the live-agent 0.99 was called *identical* to the 0.99 simulation (actually 0.987 vs 0.988) — softened to *matching*; `claude-skills` 3-tightest confidence 83% → **82%** (recomputed 0.8249); DECAY guidance/filler sizes were tokens mislabeled as KB (18.7 KB → **~18.6K tokens / ~72 KB**); freshness **+0.65** was mis-attributed to the 32-case set (it's a 20-case run; 32-case is +0.53); `completeness-blind-spot` upload 0.55 → **0.58** (multi-sample mean); ROADMAP item 6 and the AGENTS.md WHY-IT-WORKS pointer were stale (competitor benchmark is done, WHY now carries a scoped vs-libraries section); star counts dated. Cited literature was spot-verified accurate (Chroma 2025 '18 models') and left as-is.
+
 ### Added
 
 - **Competitor-benchmark bar chart** (`assets/benchmark-{light,dark}.svg` +

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ performance, API evolvability, per-language idioms, SLOs, test-suite health.
 **Measured, not asserted** — library vs. an *unguided model* (same model, no
 library); clean, blind-judged, stable across samples ([results & method →](docs/WHY-IT-WORKS.md)):
 
-- **Completeness +0.39** — from a bare "build X" prompt, best-practice coverage goes ~60% → ~100% (7 tasks): the model stops silently dropping tests, rate limiting, structured logging, and TLS. Web search can't recover this.
+- **Completeness +0.39** — from a bare "build X" prompt, best-practice coverage goes ~60% → ~100% (7 tasks): the model stops silently dropping tests, rate limiting, structured logging, and TLS. Web search likely can't recover this (an agent won't search "should I add rate limiting").
 - **Freshness +0.53** — current-2026 facts (RFCs, CVEs, EOLs) 0.44 → 0.97, where an unguided model is *confidently wrong*.
 - **Routing +0.10** — the right skills load for the task (0.90 → 1.00), even ones a keyword read misses; with the library, results barely move run-to-run.
 

--- a/docs/CONTEXT-MANAGEMENT.md
+++ b/docs/CONTEXT-MANAGEMENT.md
@@ -66,9 +66,9 @@ Fight the attention shape; don't out-muscle it with volume.
   | anchor (guidance at turn 1) | 1.00 | 1.00 | 1.00 |
   | reminder (guidance + per-prompt reminder) | 1.00 | 1.00 | 1.00 |
 
-  **No decay at this scale** — an 18.7 KB guidance block loaded at turn 1 was still
+  **No decay at this scale** — an ~18.6K-token (~72 KB) guidance block loaded at turn 1 was still
   fully applied after 30 unrelated turns. That *bounds* the problem (moderate
-  sessions are safe here) but does **not** find the breaking point: the ~3.3 KB of
+  sessions are safe here) but does **not** find the breaking point: the ~3.2K tokens of
   filler is small next to the guidance, so it can't dilute it. A real decay test
   needs much larger intervening context (or a smaller anchor); the harness takes
   `--depths` and a bigger filler to scale up. Logged as roadmap item 5, still open

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@ release. The 2026-07-01 cycle is fully executed and kept below as history.
 
 ## Open tasks — next-session pick-up *(as of v1.15.0, 2026-07-13)*
 
-Nothing is blocking; v1.15.0 shipped clean. Ordered by value. **Items 1, 2, 3
+Nothing is blocking; v1.15.0 shipped clean. Ordered by value. **Items 1, 2, 3, 6
 were executed and item 7 started 2026-07-13/14 (post-v1.15.0, all Unreleased in
 CHANGELOG, PRs #88–#93) — see notes.** The README now surfaces the measured
 lifts as a scannable list and shows the clone/script install right after the
@@ -30,8 +30,8 @@ plugin method (PRs #92–#93).
    cross-cutting concerns present in every applicable build; the self-audit gate
    **caught and fixed real gaps** live (c6: prod `/docs` exposure + unbounded DB
    critical section; c3: orphaned-task cancellation bug). The blind-judge scalar
-   (run once credit was restored) is **0.99 mean, 6/7 perfect — identical to the
-   0.99 simulation and vs 0.60 base**, proving the paste-based eval is a faithful
+   (run once credit was restored) is **0.99 mean, 6/7 perfect — matching the
+   0.99 simulation (0.987 vs 0.988) and far above the 0.60 base**, proving the paste-based eval is a faithful
    proxy for the live router flow (`evals/results/2026-07-13/live-build.json`).
 3. **Cross-file / repo-level audit eval.** **DONE 2026-07-13** —
    [`evals/results/2026-07-13/REPO-AUDIT.md`](../evals/results/2026-07-13/REPO-AUDIT.md),
@@ -55,8 +55,9 @@ plugin method (PRs #92–#93).
 5. **Multi-turn / agentic amplification test** *(new)*. The forgetting was
    measured in a *single* call; the literature says chains/subagents make it
    worse. Build the same task across a subagent chain and see if the fixes hold.
-6. **Deferred — competitor-library benchmark** (Unexplored, below): only if a
-   "better than library X" claim is wanted; needs a named target.
+6. **Competitor-library benchmark** — **DONE 2026-07-14** (see "Unexplored ideas"
+   below for the full result): SOTA-skills beats the fair peers on completeness,
+   content-only. The honesty gate is cleared for a *scoped* "vs library X" claim.
 7. **Distribution over coverage** (item 6): marketplace visibility, a published
    before/after demo, badge→verifiable-audit. **Started 2026-07-13/14:** (a) the
    README now leads with the measured lifts as a scannable list (completeness
@@ -95,7 +96,7 @@ The audit's verdict was "content is trustworthy; the gap is that nothing
    control** (+0.09/+0.14/+0.09 across sonnet-4.6/sonnet-5/opus-4.8) — the
    contamination concern is resolved, the lift is real. **Audit +0.00**;
    **Freshness +0.50–0.65** (base model confidently wrong on 2026 facts, but a
-   web-search agent recovers most of it). **Completeness +0.39** (0.60→0.99 over
+   web-search agent would likely recover most of it — predicted, untested). **Completeness +0.39** (0.60→0.99 over
    7 tasks, full library, `cases/completeness.jsonl` + `run-completeness.py`,
    blind opus judge) — the **thesis, validated**: from a bare "build X" prompt the
    base model skips tests/rate-limits/logging/transport ~40% of the time; the

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -19,7 +19,7 @@ per-case data, and honest limitations are in the
 | Dimension | What it tests | Clean lift |
 |---|---|---|
 | **Completeness** | best practices embedded from a bare "build X" prompt (7 tasks) | **+0.39** (0.60 → 0.99) |
-| **Freshness** | current 2026 facts (RFCs, CVEs, EOLs, versions, spec editions; 32) | **+0.50 to +0.65** |
+| **Freshness** | current 2026 facts (RFCs, CVEs, EOLs, versions, spec editions; 32) | **+0.50–0.53** (32-case; +0.65 on a 20-case run) |
 | Routing | which skill area applies to a task | +0.09 to +0.14 |
 | Audit | recognizing a textbook vulnerability | +0.00 |
 
@@ -39,19 +39,21 @@ most for *building* software are the two that are large:
   dense rules context makes some items fade (a measured attention effect — see
   [WHY-COMPLETENESS-RESIDUAL.md](WHY-COMPLETENESS-RESIDUAL.md), where *adding* the
   "missing" rule made it worse and a short salient reminder fixed it). This gap is
-  **not** recoverable by "just verify via web search": an agent won't search
+  unlikely to be recoverable by "just verify via web search" (untested — no search
+  arm was run; the reasoning is direct): an agent won't search
   *"should I add rate limiting"* — it simply omits it. That makes completeness the
   library's most defensible, least-redundant value. And it is not a
   paste-simulation artifact: seven **live** agents driven through the real router
-  BUILD workflow scored **0.99 (6/7 perfect)**, identical to the simulation
+  BUILD workflow scored **0.99 (6/7 perfect)**, matching the simulation (0.987 vs 0.988)
   ([live-agent validation](../evals/results/2026-07-13/LIVE-BUILD.md)).
 - **Freshness — the base model is confidently wrong.** On current-2026 facts it
   doesn't merely lack knowledge, it *fabricates* plausible answers (in our 32-case
   set: inventing RFC 9334 for the Entity Attestation Token — it's 9711 — or
   claiming PostgreSQL 17 added `uuidv7()` when it was 18). The library carries the
   verified fact (with-library **0.97**, dead steady across samples; without **0.44
-  ±0.03**). A web-search agent recovers much of this gap, so we report freshness
-  as *partly* redundant for tool-using agents — stated plainly rather than inflated.
+  ±0.03**). A web-search agent would *likely* recover much of this gap (searchable facts —
+  predicted, not measured in this harness), so we report freshness as *plausibly*
+  partly redundant for tool-using agents — stated plainly rather than inflated.
 - **Audit +0.00 is reported, not hidden.** On isolated snippets a capable model
   already recognizes the vulnerability — even the 14 *harder* cases (subtle IDOR,
   SSRF allowlist bypass, TOCTOU, prototype pollution, multi-vuln) score 1.00 in
@@ -70,7 +72,8 @@ case-by-case unreliability ([multi-sample writeup](../evals/results/2026-07-13/M
 ## Vs. competing libraries
 
 The comparisons above are vs. *nothing*. We also ran SOTA head-to-head against the
-most popular competing guidance libraries on the same 7 build tasks — same rubric,
+most-starred competing guidance libraries (by GitHub stars, snapshot 2026-07-14)
+on the same 7 build tasks — same rubric,
 same blind judge, **content-only** (SOTA's self-audit forcing function turned off,
 so its win is the guidance, not the method):
 

--- a/docs/writeups/completeness-blind-spot.md
+++ b/docs/writeups/completeness-blind-spot.md
@@ -32,7 +32,7 @@ Two real examples, base model with nothing added:
 | Task | Base-model coverage | What it silently dropped |
 |---|---|---|
 | Payment **webhook receiver** | **0.50** | idempotency, body-size limit, rate limiting, transport/TLS, tests |
-| Profile-picture **upload** | **0.55** | safe storage location, decompression-bomb defense, rate limiting, error hygiene, tests |
+| Profile-picture **upload** | **0.58** | safe storage location, decompression-bomb defense, rate limiting, error hygiene, tests |
 
 Across 7 such tasks the base model averages **0.60** — it embeds ~60% of best
 practices and *systematically* skips the same peripheral four: tests, rate
@@ -80,8 +80,8 @@ different — our number is from a **single call**, so chains only amplify it.
 
 ## Why this is the most useful thing a skill library can fix
 
-Note which failure this is. A tool-using agent can recover a **freshness** gap by
-searching the web. It cannot recover this one: **an agent will not search "should
+Note which failure this is. A tool-using agent can *plausibly* recover a **freshness** gap by
+searching the web (predicted, untested). It should not recover this one: **an agent will not search "should
 I add rate limiting"** — it just omits it. Completeness is the gap that web access
 doesn't close, which makes it the highest-value thing to engineer against.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -116,7 +116,7 @@ python3 evals/judge-live-build.py --builds DIR   # same blind opus judge + rubri
 ```
 
 Result (2026-07-13, 7 live sub-agent builds): **0.99 mean, 6/7 perfect** —
-identical to the 0.99 paste-based simulation and vs 0.60 unguided base, so the
+matching the 0.99 paste-based simulation (0.987 vs 0.988) and far above the 0.60 unguided base, so the
 simulation is a faithful proxy for the real router flow
 ([`results/2026-07-13/LIVE-BUILD.md`](results/2026-07-13/LIVE-BUILD.md)).
 
@@ -126,9 +126,9 @@ simulation is a faithful proxy for the real router flow
 outputs). Writeup: [`results/2026-07-10/BASELINE.md`](results/2026-07-10/BASELINE.md).
 Headline (clean, by dimension): **completeness +0.39** (0.60→0.99 over 7 build
 tasks — from a bare "build X" prompt the library embeds the tests/rate-limits/
-logging/transport a base model skips; the thesis, and the part web-search can't
-replace), **freshness +0.50–0.65** (32 cases of 2026 facts; base model
-*confidently wrong*, but a web-search agent recovers most of it), **routing
+logging/transport a base model skips; the thesis, and the part web-search likely can't
+replace — predicted, not measured here), **freshness +0.50–0.53** (32-case set; base model
+*confidently wrong*, but a web-search agent would likely recover most of it — predicted, not measured here), **routing
 +0.09–0.14**, **audit +0.00** (even the 14 harder cases saturate). The lift is
 only "small" if you measure the easy dimensions. Run:
 `python3 evals/run-completeness.py`.

--- a/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
+++ b/evals/results/2026-07-13/COMPETITOR-BENCHMARK.md
@@ -76,7 +76,7 @@ where a competitor *tied* SOTA-skills in the single-sample run (`competitor-benc
 |---|---|---|
 | [**SOTA-skills**](https://github.com/martinholovsky/SOTA-skills) | **98%** | — |
 | [affaan-m/ECC](https://github.com/affaan-m/ECC) | 87% | −11 pts |
-| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | 83% | −15 pts |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | 82% | −15 pts |
 | [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | 82% | −16 pts |
 | unguided | 65% | −33 pts |
 

--- a/evals/results/2026-07-13/DECAY.md
+++ b/evals/results/2026-07-13/DECAY.md
@@ -29,13 +29,13 @@ a build task (the probe, `c6_webhook`). Arms:
 | reminder (guidance + reminder) | 1.00 | 1.00 | 1.00 |
 
 Decay (anchor K0→K30): **+0.00**. Reminder recovery: **+0.00** (nothing to
-recover). An 18.7 KB guidance block loaded at turn 1 was **still fully applied
+recover). An ~18.6K-token (~72 KB) guidance block loaded at turn 1 was **still fully applied
 after 30 unrelated turns** — the guidance did not fade at this session length.
 
 ## Honest reading — this bounds the problem, it doesn't find the breaking point
 
-The null result is real but limited by design: the filler is only ~3.3 KB at K=30,
-tiny next to the 18.7 KB guidance, so it can't meaningfully *dilute* the anchor —
+The null result is real but limited by design: the filler is only ~3.2K tokens (~13 KB) at K=30,
+tiny next to the ~18.6K-token guidance, so it can't meaningfully *dilute* the anchor —
 the guidance still dominates context and the model keeps applying it. So the
 finding is: **at moderate session length with a large, dominant guidance block,
 there is no decay** (reassuring), but the test hasn't stressed the regime where

--- a/evals/results/2026-07-13/LIVE-BUILD.md
+++ b/evals/results/2026-07-13/LIVE-BUILD.md
@@ -11,7 +11,7 @@ paste over-state what an actual agent does?
 sub-agents were each handed only the bare "build X" completeness task plus the
 standing sota directive (consult the router, follow BUILD mode). The blind opus
 judge scores the live-agent builds at **0.99 mean completeness (6/7 perfect)** —
-identical to the 0.99 the paste-based simulation produces, and far above the 0.60
+matching the 0.99 the paste-based simulation produces (0.987 live vs 0.988 simulated), and far above the 0.60
 unguided base. All seven independently followed the workflow, and the terminal
 self-audit gate demonstrably recovered the cross-cutting concerns and caught real
 gaps — the exact mechanism the simulation credits for the completeness lift, now
@@ -108,7 +108,7 @@ python3 evals/judge-live-build.py --builds <live-build-dir> \
 ```
 
 `live-build.json` holds the per-case present/missing detail. The live-agent mean
-(**0.99**) equals the paste-based simulation (**0.99**) — which is the point: it
+(**0.987**) matches the paste-based simulation (**0.988**) — which is the point: it
 confirms `run-completeness.py`'s pasted-content arm is a faithful proxy for what a
 real router-driven agent produces, so the 0.60→0.99 completeness lift is not an
 artifact of the simulation. Roadmap item 2 is fully closed: the live flow both

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -57,7 +57,7 @@ One consolidated view — every competitor's standing in a single table. Scores 
 | [**SOTA-skills**](https://github.com/martinholovsky/SOTA-skills) | — | **99%** | **98%** | — | — |
 | [affaan-m/ECC](https://github.com/affaan-m/ECC) | ~230k | 87% | 87% | −12 pts | 0 / 2 / 5 |
 | [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) | ~40k | 83% | 82% | −16 pts | 0 / 0 / 7 |
-| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | ~23k | 81% | 83% | −17 pts | 0 / 1 / 6 |
+| [alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills) | ~23k | 81% | 82% | −17 pts | 0 / 1 / 6 |
 | unguided model | — | 58% | 65% | −40 pts | — |
 
 ¹ **This library's record against SOTA-skills**, across the 7 build tasks (how many
@@ -86,7 +86,7 @@ Does a rule loaded early stop being applied as the session grows?
 | guidance at turn 1 | 1.00 | 1.00 | **1.00** (no decay) | [DECAY](2026-07-13/DECAY.md) |
 | no guidance (control) | 0.40 | 0.40 | 0.40 | |
 
-First run: **no decay at moderate scale** — an 18.7 KB guidance block held after 30
+First run: **no decay at moderate scale** — an ~18.6K-token (~72 KB) guidance block held after 30
 unrelated turns. This *bounds* the problem but doesn't find the breaking point (the
 filler is too small to dilute the anchor); scaling the test up needs a top-up.
 *(roadmap item 5, still open.)*


### PR DESCRIPTION
Ran four adversarial auditors over the docs, cross-checking every claim against
the result JSONs, then verified each finding against primary sources before fixing.

## Unmeasured claims stated as fact → now predictions
- **"a web-search agent recovers the freshness gap" / "web search can't recover
  completeness"** — there is **no web-search arm** in any harness or result file
  (verified). Reworded to explicit predictions ("likely / predicted, not measured
  here") in README, WHY-IT-WORKS, ROADMAP, evals/README, completeness-blind-spot.

## Wrong / overstated numbers → corrected against the JSONs
- live-agent **"identical to the 0.99 simulation"** → "matching (0.987 vs 0.988)".
- `alirezarezvani/claude-skills` 3-tightest confidence **83% → 82%** (mean 0.8249).
- DECAY: tokens mislabeled as KB — **18.7 KB → ~18.6K tokens (~72 KB)**; 3.3 KB →
  ~3.2K tokens (~13 KB) (measured: guidance 74,419 B, filler 12,997 B).
- freshness **+0.65 mis-attributed to the 32-case set** → 32-case is +0.50–0.53;
  +0.65 is a smaller 20-case per-model run.
- `completeness-blind-spot` upload **0.55 → 0.58** (multi-sample mean).

## Stale internal inconsistencies
- ROADMAP item 6 (competitor benchmark) marked **DONE**; header note includes it.
- AGENTS.md WHY pointer "not vs. other libraries" → carries the scoped head-to-head;
  "most popular" → "most-starred (by GitHub stars, dated 2026-07-14)".

## Verified correct, left as-is
All other headline numbers; the **literature citations** (Chroma 2025 "18 models
incl. Claude Opus 4" spot-verified against the source via WebFetch); the
won/tied/lost counts and "wins or ties all 21" arithmetic.

## Validation
- Every fixed number recomputed from the source JSON; residual-overclaim greps clean
- `./scripts/check-invariants.sh` — all 7 pass; gitleaks pass
