### PR TITLE
docs(evals): confirm #3 adds no routing regression (with-arm held 1.00)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Regression-tested (our [context-rot finding](docs/WHY-COMPLETENESS-RESIDUAL.md)
   warns added text can lower salience): the 3× completeness eval held at **0.991
   with-arm / +0.385 lift** (vs 0.996 / +0.395 — Δ −0.005, within sampling noise;
-  no cross-cutting concern systematically dropped). Raw:
-  `evals/results/2026-07-13/completeness-3sample-postadopt.json`; summary in
-  `evals/results/RESULTS.md`.
+  no cross-cutting concern systematically dropped), and the 3× routing eval (which
+  pastes the whole router, so it sees principle 6) **held at 1.00** with-arm, no
+  misses. Raw: `evals/results/2026-07-13/completeness-3sample-postadopt.json` +
+  `routing-3sample-postadopt.json`; summary in `evals/results/RESULTS.md`.
 
 ### Fixed
 

--- a/evals/results/2026-07-13/routing-3sample-postadopt.json
+++ b/evals/results/2026-07-13/routing-3sample-postadopt.json
@@ -1,0 +1,246 @@
+{
+ "without-library": {
+  "recall": 0.9083333333333332,
+  "recalls": [
+   0.9083333333333332,
+   0.9083333333333332,
+   0.9083333333333332
+  ],
+  "misses": {
+   "r01": [
+    "sota-testing"
+   ],
+   "r02": [
+    "sota-sandboxing"
+   ],
+   "r07": [
+    "sota-code-security"
+   ],
+   "r09": [
+    "sota-web-frameworks"
+   ]
+  },
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-web-frameworks",
+    "sota-code-security"
+   ],
+   "r02": [
+    "sota-kubernetes",
+    "sota-devsecops",
+    "sota-code-security"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-identity-access"
+   ],
+   "r04": [
+    "sota-network-security",
+    "sota-security-compliance"
+   ],
+   "r05": [
+    "sota-shell-scripting",
+    "sota-cli-ux"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-identity-access",
+    "sota-secrets-management",
+    "sota-code-security"
+   ],
+   "r07": [
+    "sota-llm-engineering",
+    "sota-python",
+    "sota-data-engineering"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-code-security",
+    "sota-web-frameworks"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-javascript-typescript",
+    "sota-ux-writing"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure",
+    "sota-identity-access"
+   ],
+   "r11": [
+    "sota-ux-writing",
+    "sota-copywriting"
+   ],
+   "r12": [
+    "sota-performance",
+    "sota-observability",
+    "sota-databases"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases",
+    "sota-testing"
+   ],
+   "r15": [
+    "sota-llm-engineering",
+    "sota-sandboxing",
+    "sota-code-security",
+    "sota-threat-modeling"
+   ],
+   "r16": [
+    "sota-mobile",
+    "sota-async-concurrency",
+    "sota-databases"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-identity-access",
+    "sota-security-compliance"
+   ],
+   "r18": [
+    "sota-observability",
+    "sota-cloud-infrastructure"
+   ],
+   "r19": [
+    "sota-threat-modeling",
+    "sota-security-compliance",
+    "sota-code-security"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-identity-access",
+    "sota-devsecops",
+    "sota-security-compliance"
+   ]
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "recalls": [
+   1.0,
+   1.0,
+   1.0
+  ],
+  "misses": {},
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-testing"
+   ],
+   "r02": [
+    "sota-kubernetes",
+    "sota-sandboxing",
+    "sota-devsecops",
+    "sota-shell-scripting"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-code-security",
+    "sota-identity-access",
+    "sota-threat-modeling",
+    "sota-testing"
+   ],
+   "r04": [
+    "sota-network-security"
+   ],
+   "r05": [
+    "sota-shell-scripting",
+    "sota-secrets-management"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-secrets-management",
+    "sota-identity-access"
+   ],
+   "r07": [
+    "sota-llm-engineering",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-databases",
+    "sota-testing"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-code-security",
+    "sota-api-design",
+    "sota-threat-modeling",
+    "sota-secrets-management"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-web-frameworks",
+    "sota-javascript-typescript",
+    "sota-testing"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure",
+    "sota-secrets-management",
+    "sota-identity-access"
+   ],
+   "r11": [
+    "sota-ux-writing",
+    "sota-frontend-design"
+   ],
+   "r12": [
+    "sota-databases",
+    "sota-performance",
+    "sota-observability"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases"
+   ],
+   "r15": [
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-llm-engineering",
+    "sota-threat-modeling"
+   ],
+   "r16": [
+    "sota-mobile",
+    "sota-async-concurrency",
+    "sota-databases",
+    "sota-testing"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-api-design",
+    "sota-databases",
+    "sota-security-compliance"
+   ],
+   "r18": [
+    "sota-observability",
+    "sota-testing"
+   ],
+   "r19": [
+    "sota-threat-modeling",
+    "sota-code-security",
+    "sota-identity-access",
+    "sota-secrets-management",
+    "sota-api-design"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-identity-access",
+    "sota-devsecops",
+    "sota-network-security",
+    "sota-security-compliance"
+   ]
+  }
+ }
+}

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -34,7 +34,10 @@ guidance text can lower salience. Result: with-arm **0.991** (was 0.996), lift
 **+0.385** (was +0.395) — statistically unchanged (Δ −0.005, inside the run's
 sampling noise; the two dipped cases have an **empty aggregate missing-set**, i.e.
 no cross-cutting concern was systematically dropped, and c7 — the prior wobbler —
-went to 1.00). The changes are kept. Raw: `2026-07-13/completeness-3sample-postadopt.json`.
+went to 1.00). Routing was re-run too (principle 6 is added to the router, which
+the routing eval pastes whole): with-arm **held at 1.00** (n=3, no misses), lift
++0.09. The changes are kept. Raw:
+`2026-07-13/completeness-3sample-postadopt.json` + `routing-3sample-postadopt.json`.
 
 ## 2. Live-agent validation
 


### PR DESCRIPTION
Follow-up to #112. Operating principle 6 ("claim done only with evidence") lives in
the router `skills/sota/SKILL.md`, which the routing eval pastes **whole** — so
routing is on #3's measured path and needed its own regression check.

**3× routing eval (temp 0.7):** with-library **1.00** (n=3, no misses), lift +0.09
— unchanged from baseline (with 1.00 / +0.10). No regression.

Both measured paths from #112 are now confirmed clean: completeness held (0.991,
+0.385) and routing held (1.00). Raw: `evals/results/2026-07-13/routing-3sample-postadopt.json`.
RESULTS.md + CHANGELOG updated.
