### PR TITLE
evals(routing): measure the description-selection path — cross-refs are +0.00 (honest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   misses. Raw: `evals/results/2026-07-13/completeness-3sample-postadopt.json` +
   `routing-3sample-postadopt.json`; summary in `evals/results/RESULTS.md`.
 
+- **Description-based routing eval** (`evals/run-desc-routing.py`,
+  `evals/cases/desc-routing.jsonl`, `results/2026-07-13/desc-routing-3sample.json`)
+  — the first measurement of the skill **auto-loader** path (pick a skill from the
+  description catalogue), distinct from the router table. A/Bs the catalogue with vs
+  without the negative cross-references added above, on 10 adversarially-confusable
+  tasks. **Honest +0.00:** the model never routed to the warned-against sibling in
+  *either* arm (distractor-pick 0.00 across all cases/samples), so the cross-ref had
+  nothing to fix — the description-selection path is already saturated for a frontier
+  model, like audit. The cross-refs are kept as zero-cost defensive clarity; no
+  routing lift is claimed. Summary in `evals/results/RESULTS.md` §5.
+
 ### Fixed
 
 - **Accuracy sweep (4-way doc audit against the result JSONs).** Corrected claims stated more strongly than the data: the **web-search recovers/can't-recover** claims (freshness + completeness) were never measured — now marked as predictions; the live-agent 0.99 was called *identical* to the 0.99 simulation (actually 0.987 vs 0.988) — softened to *matching*; `claude-skills` 3-tightest confidence 83% → **82%** (recomputed 0.8249); DECAY guidance/filler sizes were tokens mislabeled as KB (18.7 KB → **~18.6K tokens / ~72 KB**); freshness **+0.65** was mis-attributed to the 32-case set (it's a 20-case run; 32-case is +0.53); `completeness-blind-spot` upload 0.55 → **0.58** (multi-sample mean); ROADMAP item 6 and the AGENTS.md WHY-IT-WORKS pointer were stale (competitor benchmark is done, WHY now carries a scoped vs-libraries section); star counts dated. Cited literature was spot-verified accurate (Chroma 2025 '18 models') and left as-is.

--- a/evals/cases/desc-routing.jsonl
+++ b/evals/cases/desc-routing.jsonl
@@ -1,0 +1,14 @@
+# Description-based routing golden set — adversarially-confusable single-skill picks.
+# Each task shares surface keywords with the `distractor` (the tempting wrong sibling
+# that carries a "Not for … — use …" cross-ref) but the correct pick is `expect`.
+# Metric of interest: does the cross-ref reduce distractor-picks? See run-desc-routing.py.
+{"id": "q1_react_ui", "task": "Build a Next.js dashboard page using React server components that fetches data and renders a sortable table, handling hydration and client/server data fetching correctly.", "expect": "sota-web-frameworks", "distractor": "sota-api-design"}
+{"id": "q2_sigma_detection", "task": "Write a Sigma detection rule that flags lateral movement via anomalous Kerberos TGS requests in Windows security logs, and map it to MITRE ATT&CK.", "expect": "sota-detection-engineering", "distractor": "sota-observability"}
+{"id": "q3_latency_opt", "task": "Our checkout endpoint's p99 latency is 1.2s under load. Profile it, find the bottleneck, and optimize throughput.", "expect": "sota-performance", "distractor": "sota-async-concurrency"}
+{"id": "q4_data_race", "task": "Under concurrency we're hitting intermittent data races and an occasional deadlock between two goroutines sharing a map. Fix the synchronization.", "expect": "sota-async-concurrency", "distractor": "sota-performance"}
+{"id": "q5_code_vuln_review", "task": "Review this Python request handler at the code level for injection, XSS, and insecure deserialization vulnerabilities.", "expect": "sota-code-security", "distractor": "sota-threat-modeling"}
+{"id": "q6_appcode_audit", "task": "Audit our application's source code for exploitable vulnerabilities like SQL injection and SSRF in the request-handling functions.", "expect": "sota-code-security", "distractor": "sota-devsecops"}
+{"id": "q7_pod_hardening", "task": "Harden our Kubernetes workloads: set securityContext runAsNonRoot, drop Linux capabilities, and enforce a read-only root filesystem on the pods.", "expect": "sota-kubernetes", "distractor": "sota-devsecops"}
+{"id": "q8_bash_review", "task": "Review this Bash deployment script for unquoted variable expansions, command injection, and unsafe use of eval.", "expect": "sota-shell-scripting", "distractor": "sota-cli-ux"}
+{"id": "q9_etl_pipeline", "task": "Design an ETL pipeline that ingests Kafka event streams, transforms them, and loads them into our analytics warehouse with schema evolution.", "expect": "sota-data-engineering", "distractor": "sota-databases"}
+{"id": "q10_ui_microcopy", "task": "Write the button labels, empty-state text, and inline validation error messages for our checkout UI.", "expect": "sota-ux-writing", "distractor": "sota-docs-workflow"}

--- a/evals/results/2026-07-13/desc-routing-3sample.json
+++ b/evals/results/2026-07-13/desc-routing-3sample.json
@@ -1,0 +1,267 @@
+{
+ "model": "anthropic/claude-sonnet-4.6",
+ "samples": 3,
+ "temp": 0.7,
+ "cases": {
+  "q1_react_ui": {
+   "task": "Build a Next.js dashboard page using React server components that fetches data and renders a sortable table, handling hydration and client/server data fetching correctly.",
+   "expect": "sota-web-frameworks",
+   "distractor": "sota-api-design",
+   "arms": {
+    "with-xref": {
+     "picks": [
+      "sota-web-frameworks",
+      "sota-web-frameworks",
+      "sota-web-frameworks"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    },
+    "without-xref": {
+     "picks": [
+      "sota-web-frameworks",
+      "sota-web-frameworks",
+      "sota-web-frameworks"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    }
+   }
+  },
+  "q2_sigma_detection": {
+   "task": "Write a Sigma detection rule that flags lateral movement via anomalous Kerberos TGS requests in Windows security logs, and map it to MITRE ATT&CK.",
+   "expect": "sota-detection-engineering",
+   "distractor": "sota-observability",
+   "arms": {
+    "with-xref": {
+     "picks": [
+      "sota-detection-engineering",
+      "sota-detection-engineering",
+      "sota-detection-engineering"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    },
+    "without-xref": {
+     "picks": [
+      "sota-detection-engineering",
+      "sota-detection-engineering",
+      "sota-detection-engineering"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    }
+   }
+  },
+  "q3_latency_opt": {
+   "task": "Our checkout endpoint's p99 latency is 1.2s under load. Profile it, find the bottleneck, and optimize throughput.",
+   "expect": "sota-performance",
+   "distractor": "sota-async-concurrency",
+   "arms": {
+    "with-xref": {
+     "picks": [
+      "sota-performance",
+      "sota-performance",
+      "sota-performance"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    },
+    "without-xref": {
+     "picks": [
+      "sota-performance",
+      "sota-performance",
+      "sota-performance"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    }
+   }
+  },
+  "q4_data_race": {
+   "task": "Under concurrency we're hitting intermittent data races and an occasional deadlock between two goroutines sharing a map. Fix the synchronization.",
+   "expect": "sota-async-concurrency",
+   "distractor": "sota-performance",
+   "arms": {
+    "with-xref": {
+     "picks": [
+      "sota-golang",
+      "sota-golang",
+      "sota-golang"
+     ],
+     "correct": 0.0,
+     "distractor": 0.0
+    },
+    "without-xref": {
+     "picks": [
+      "sota-golang",
+      "sota-golang",
+      "sota-golang"
+     ],
+     "correct": 0.0,
+     "distractor": 0.0
+    }
+   }
+  },
+  "q5_code_vuln_review": {
+   "task": "Review this Python request handler at the code level for injection, XSS, and insecure deserialization vulnerabilities.",
+   "expect": "sota-code-security",
+   "distractor": "sota-threat-modeling",
+   "arms": {
+    "with-xref": {
+     "picks": [
+      "sota-code-security",
+      "sota-code-security",
+      "sota-code-security"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    },
+    "without-xref": {
+     "picks": [
+      "sota-code-security",
+      "sota-code-security",
+      "sota-code-security"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    }
+   }
+  },
+  "q6_appcode_audit": {
+   "task": "Audit our application's source code for exploitable vulnerabilities like SQL injection and SSRF in the request-handling functions.",
+   "expect": "sota-code-security",
+   "distractor": "sota-devsecops",
+   "arms": {
+    "with-xref": {
+     "picks": [
+      "sota-code-security",
+      "sota-code-security",
+      "sota-code-security"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    },
+    "without-xref": {
+     "picks": [
+      "sota-code-security",
+      "sota-code-security",
+      "sota-code-security"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    }
+   }
+  },
+  "q7_pod_hardening": {
+   "task": "Harden our Kubernetes workloads: set securityContext runAsNonRoot, drop Linux capabilities, and enforce a read-only root filesystem on the pods.",
+   "expect": "sota-kubernetes",
+   "distractor": "sota-devsecops",
+   "arms": {
+    "with-xref": {
+     "picks": [
+      "sota-sandboxing",
+      "sota-sandboxing",
+      "sota-sandboxing"
+     ],
+     "correct": 0.0,
+     "distractor": 0.0
+    },
+    "without-xref": {
+     "picks": [
+      "sota-sandboxing",
+      "sota-sandboxing",
+      "sota-sandboxing"
+     ],
+     "correct": 0.0,
+     "distractor": 0.0
+    }
+   }
+  },
+  "q8_bash_review": {
+   "task": "Review this Bash deployment script for unquoted variable expansions, command injection, and unsafe use of eval.",
+   "expect": "sota-shell-scripting",
+   "distractor": "sota-cli-ux",
+   "arms": {
+    "with-xref": {
+     "picks": [
+      "sota-shell-scripting",
+      "sota-shell-scripting",
+      "sota-shell-scripting"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    },
+    "without-xref": {
+     "picks": [
+      "sota-shell-scripting",
+      "sota-shell-scripting",
+      "sota-shell-scripting"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    }
+   }
+  },
+  "q9_etl_pipeline": {
+   "task": "Design an ETL pipeline that ingests Kafka event streams, transforms them, and loads them into our analytics warehouse with schema evolution.",
+   "expect": "sota-data-engineering",
+   "distractor": "sota-databases",
+   "arms": {
+    "with-xref": {
+     "picks": [
+      "sota-data-engineering",
+      "sota-data-engineering",
+      "sota-data-engineering"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    },
+    "without-xref": {
+     "picks": [
+      "sota-data-engineering",
+      "sota-data-engineering",
+      "sota-data-engineering"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    }
+   }
+  },
+  "q10_ui_microcopy": {
+   "task": "Write the button labels, empty-state text, and inline validation error messages for our checkout UI.",
+   "expect": "sota-ux-writing",
+   "distractor": "sota-docs-workflow",
+   "arms": {
+    "with-xref": {
+     "picks": [
+      "sota-ux-writing",
+      "sota-ux-writing",
+      "sota-ux-writing"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    },
+    "without-xref": {
+     "picks": [
+      "sota-ux-writing",
+      "sota-ux-writing",
+      "sota-ux-writing"
+     ],
+     "correct": 1.0,
+     "distractor": 0.0
+    }
+   }
+  }
+ },
+ "summary": {
+  "with-xref": {
+   "correct": 0.8,
+   "distractor": 0.0
+  },
+  "without-xref": {
+   "correct": 0.8,
+   "distractor": 0.0
+  }
+ }
+}

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -125,6 +125,31 @@ unrelated turns. This *bounds* the problem but doesn't find the breaking point (
 filler is too small to dilute the anchor); scaling the test up needs a top-up.
 *(roadmap item 5, still open.)*
 
+## 5. Description-based routing — do the negative cross-refs help? (A/B, +0.00)
+
+Skill descriptions carry negative cross-references ("Not for X — use sota-Y") to
+disambiguate confusable siblings. This is the path a skill **auto-loader** uses
+(pick from the description catalogue), distinct from the router table §1 measures.
+[`run-desc-routing.py`](../run-desc-routing.py) A/Bs the *same* catalogue with vs
+without those clauses on 10 adversarially-confusable tasks (each names the correct
+skill and the tempting sibling), 3× temp 0.7, objective name-match scoring.
+
+| arm | correct | distractor-pick | Source |
+|---|---|---|---|
+| with cross-refs | 0.80 | **0.00** | [desc-routing-3sample.json](2026-07-13/desc-routing-3sample.json) |
+| without cross-refs | 0.80 | **0.00** | |
+
+**Honest +0.00.** The model **never** routed to the warned-against sibling in
+*either* arm (distractor-pick 0.00 across all 10 cases × 3 samples, perfectly
+steady) — so the cross-ref had nothing to fix here. The two non-`expect` picks are
+*defensible co-answers*, not distractor mis-routes (a goroutine-race task → the Go
+language skill; pod-securityContext hardening → `sota-sandboxing`, which covers pod
+security), and they are identical in both arms. Like audit (+0.00), a capable model
+already does the easy version: the description-selection path is **saturated** for a
+frontier model on these pairs. The cross-refs are kept anyway — zero runtime cost,
+harmless, and plausibly useful for weaker/smaller models or genuinely ambiguous
+phrasings outside this set (a prediction, not measured). No routing lift is claimed.
+
 ## Not yet measured (open)
 
 - **Competitor breadth — DONE (5 domains).** The lead tracks the unguided baseline,

--- a/evals/run-desc-routing.py
+++ b/evals/run-desc-routing.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Description-based skill-routing eval — does the negative cross-reference in a
+skill description ("Not for X — use sota-Y") reduce mis-routing when a model picks
+a skill purely from the description catalogue (the path a skill *auto-loader* uses,
+as opposed to the router table that `run-clean.py --cases router.jsonl` measures)?
+
+Two arms over the SAME adversarially-confusable tasks, same catalogue except:
+  with-xref     — descriptions exactly as committed (carry the "Not for … — use …")
+  without-xref  — the same descriptions with only that one sentence stripped
+
+Each case names the correct skill (`expect`) and the tempting wrong sibling
+(`distractor`) that shares surface keywords. Metric: **distractor-pick rate** (what
+the cross-ref is designed to cut) and primary-correct rate. Scoring is objective —
+exact skill-name match on the model's answer, no LLM judge.
+
+Auth: OPENROUTER_API_KEY (env or ./.env). Never printed or committed.
+Run: python3 evals/run-desc-routing.py --samples 3 --temp 0.7 \
+        --out evals/results/2026-07-13/desc-routing.json
+"""
+import argparse, glob, json, os, re, statistics, sys
+import urllib.request
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CASES = os.path.join(ROOT, "evals/cases/desc-routing.jsonl")
+# Strips exactly the added cross-ref sentence(s): each starts "Not for " and, by
+# construction, contains no internal period, so this removes one sentence cleanly.
+XREF_RE = re.compile(r"\s*Not for [^.]*\.")
+
+
+def load_env_key():
+    k = os.environ.get("OPENROUTER_API_KEY")
+    if k:
+        return k
+    envp = os.path.join(ROOT, ".env")
+    if os.path.exists(envp):
+        for line in open(envp, encoding="utf-8"):
+            line = line.strip()
+            if line.startswith("OPENROUTER_API_KEY="):
+                return line.split("=", 1)[1].strip().strip("'\"")
+    sys.exit("OPENROUTER_API_KEY not found in env or ./.env")
+
+
+def parse_desc(path):
+    """(name, description) from a SKILL.md frontmatter — handles both an inline
+    scalar (`description: text…`) and a folded/literal block (`description: >-`)."""
+    fm = open(path, encoding="utf-8").read().split("\n---", 1)[0]
+    name = re.search(r"(?m)^name:\s*(.+)$", fm).group(1).strip()
+    rest = re.search(r"(?m)^description:(.*)$", fm).group(1).strip()
+    if rest and rest not in (">-", ">", "|", "|-", "|+", ">+"):
+        return name, rest.strip("'\"")  # inline (single-line) description
+    grab, out = False, []             # block scalar: gather indented lines
+    for ln in fm.splitlines():
+        if ln.startswith("description:"):
+            grab = True
+            continue
+        if grab:
+            if re.match(r"^\S", ln):  # next top-level key
+                break
+            out.append(ln.strip())
+    return name, " ".join(x for x in out if x)
+
+
+def catalogue(strip_xref):
+    items = []
+    for d in sorted(glob.glob(os.path.join(ROOT, "skills/sota-*"))):
+        if not os.path.isdir(d):
+            continue
+        name, desc = parse_desc(os.path.join(d, "SKILL.md"))
+        if strip_xref:
+            desc = XREF_RE.sub("", desc).strip()
+        items.append((name, desc))
+    return items
+
+
+def build_prompt(items, task):
+    cat = "\n".join(f"- {n}: {d}" for n, d in items)
+    return ("You are selecting the single most relevant skill for a task from a "
+            "library. Here is the catalogue (skill name: description).\n\n"
+            f"{cat}\n\nTASK: {task}\n\n"
+            "Respond with ONLY the exact name of the single most relevant skill "
+            "(for example: sota-python). No explanation — just the name.")
+
+
+def call(model, key, prompt, temp, tries=4):
+    body = json.dumps({"model": model, "messages": [{"role": "user", "content": prompt}],
+                       "temperature": temp}).encode()
+    for attempt in range(tries):
+        try:
+            req = urllib.request.Request("https://openrouter.ai/api/v1/chat/completions", data=body,
+                                         headers={"Authorization": f"Bearer {key}",
+                                                  "Content-Type": "application/json"})
+            with urllib.request.urlopen(req, timeout=180) as r:
+                return json.load(r)["choices"][0]["message"]["content"]
+        except Exception as e:  # transient network/5xx — retry with linear backoff
+            if attempt == tries - 1:
+                raise
+            import time
+            time.sleep(3 * (attempt + 1))
+
+
+def pick_from(txt, names):
+    """First sota-* token in the reply that is a real skill name."""
+    for tok in re.findall(r"sota-[a-z0-9-]+", txt):
+        if tok in names:
+            return tok
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="anthropic/claude-sonnet-4.6")
+    ap.add_argument("--samples", type=int, default=1)
+    ap.add_argument("--temp", type=float, default=0.0)
+    ap.add_argument("--out", default=None)
+    a = ap.parse_args()
+    key = load_env_key()
+    cases = [json.loads(l) for l in open(CASES, encoding="utf-8")
+             if l.strip() and not l.startswith("#")]
+    names = [os.path.basename(d) for d in glob.glob(os.path.join(ROOT, "skills/sota-*"))
+             if os.path.isdir(d)]
+    arms = {"with-xref": catalogue(False), "without-xref": catalogue(True)}
+    print(f"model={a.model}  cases={len(cases)}  samples={a.samples}  temp={a.temp}  "
+          f"arms={list(arms)}  (clean API, objective name-match scoring)\n")
+    result = {"model": a.model, "samples": a.samples, "temp": a.temp, "cases": {}}
+    agg = {arm: {"correct": [], "distractor": []} for arm in arms}
+    for c in cases:
+        result["cases"][c["id"]] = {"task": c["task"], "expect": c["expect"],
+                                    "distractor": c["distractor"], "arms": {}}
+        for arm, items in arms.items():
+            picks = [pick_from(call(a.model, key, build_prompt(items, c["task"]), a.temp), names)
+                     for _ in range(a.samples)]
+            corr = statistics.mean(1.0 if p == c["expect"] else 0.0 for p in picks)
+            dist = statistics.mean(1.0 if p == c["distractor"] else 0.0 for p in picks)
+            agg[arm]["correct"].append(corr)
+            agg[arm]["distractor"].append(dist)
+            result["cases"][c["id"]]["arms"][arm] = {"picks": picks, "correct": corr, "distractor": dist}
+            print(f"  {c['id']:<20} {arm:<14} correct={corr:.2f} distractor={dist:.2f} picks={picks}")
+    result["summary"] = {arm: {"correct": statistics.mean(agg[arm]["correct"]),
+                               "distractor": statistics.mean(agg[arm]["distractor"])} for arm in arms}
+    print("\nSUMMARY")
+    for arm in arms:
+        s = result["summary"][arm]
+        print(f"  {arm:<14} correct={s['correct']:.3f}  distractor-pick={s['distractor']:.3f}")
+    wx, wo = result["summary"]["with-xref"], result["summary"]["without-xref"]
+    print(f"\n  Δ correct           (with − without) = {wx['correct'] - wo['correct']:+.3f}")
+    print(f"  Δ distractor-pick   (with − without) = {wx['distractor'] - wo['distractor']:+.3f}"
+          "   (negative = cross-refs help)")
+    if a.out:
+        json.dump(result, open(a.out, "w"), indent=1)
+        print("saved", a.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Closes the last unmeasured path from the Dev-AID adoption (#112). #1 (negative
routing cross-refs) was landed off every existing measured path — this new A/B eval
measures it directly.

**New eval** (`evals/run-desc-routing.py` + `evals/cases/desc-routing.jsonl`): the
first measurement of the skill **auto-loader** path — pick the single best skill from
the description **catalogue** (name + description for all 40 skills), which is how a
loader selects, *distinct* from the router table `run-clean.py` measures. A/Bs the
*same* catalogue **with vs without** the "Not for X — use sota-Y" clauses on 10
adversarially-confusable tasks (each names the correct skill + the tempting sibling),
3× temp 0.7, **objective name-match scoring** (no LLM judge).

## Result — honest +0.00

| arm | correct | distractor-pick |
|---|---|---|
| with cross-refs | 0.80 | **0.00** |
| without cross-refs | 0.80 | **0.00** |

Δ correct +0.00, Δ distractor-pick +0.00. The model **never** routed to the
warned-against sibling in *either* arm — the cross-ref had nothing to fix. The two
non-`expect` picks are *defensible co-answers* (goroutine-race → the Go skill;
pod-securityContext → `sota-sandboxing`, which covers pod security), identical in
both arms. Like audit (+0.00), a frontier model already does the easy version: the
description-selection path is **saturated**. Cross-refs kept as zero-cost defensive
clarity; **no routing lift is claimed**.

All three Dev-AID adoptions now carry a measured result: completeness held (0.991),
routing held (1.00), and #1 = +0.00 here.

## Validation

- Harness validated locally before the paid run: all 40 skills parse (fixed inline
  vs block-scalar description formats), the two arms differ by **exactly** the 9
  cross-ref sentences, case names valid.
- All 7 invariants pass. RESULTS.md §5 + CHANGELOG updated in-change.
