### PR TITLE
docs(results): embed the breadth chart in RESULTS.md, consolidate the story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`evals/results/RESULTS.md` now embeds the five-domain breadth chart** and
+  carries the full breadth story inline (chart + table + 0.7-baseline threshold +
+  the "why the baseline predicts the lift" mechanism), so the scoreboard is
+  self-contained instead of splitting the visual off into `BREADTH.md`. `BREADTH.md`
+  stays as the per-domain-notes and raw-data appendix.
+
 ## [1.16.0] - 2026-07-16
 
 The competitor + breadth release: a fair, blind, reproducible head-to-head against

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -83,9 +83,17 @@ single-sample). Read it on the library's own row: `0 / 2 / 5` on the
 [affaan-m/ECC](https://github.com/affaan-m/ECC) row = ECC **won 0, tied 2, lost 5**.
 **No competitor won a single task against SOTA-skills** (on backend).
 
-**Breadth — the lead tracks the unguided baseline, not the domain**
-([BREADTH.md](2026-07-13/BREADTH.md), 5 domains). SOTA-skills leads where a base
-model ships *incomplete* code, and ties where it's already near-complete:
+**Breadth — the lead tracks the unguided baseline, not the domain** (5 domains).
+SOTA-skills leads where a base model ships *incomplete* code and ties where it's
+already near-complete. Ordered by unguided baseline, the green lead appears only
+where the unguided bar is low:
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../../assets/breadth-dark.svg">
+    <img alt="Completeness % by domain (unguided / best competitor / SOTA-skills), ordered by unguided baseline: hard frontend 53/83/93, Python backend 58/87/99, Go backend 67/87/97, simple frontend 77/97/97, IaC 87/100/100. SOTA-skills leads where the baseline is low and ties where it is high." src="../../assets/breadth-light.svg" width="100%">
+  </picture>
+</p>
 
 | Domain | Unguided | SOTA-skills | best competitor | SOTA lead |
 |---|---|---|---|---|
@@ -98,7 +106,12 @@ model ships *incomplete* code, and ties where it's already near-complete:
 Clean threshold near **0.7 baseline**: below it (production backend in any language,
 complex/security-sensitive frontend) SOTA-skills leads by ~10 pts; above it (simple
 UI, templated infra) everyone converges. So the win isn't "backend" — it's **wherever
-the base model's default is incomplete.**
+the base model's default is incomplete.** The mechanism: the library forces in the
+concerns a base model silently omits, and that headroom is large only when the missing
+pieces need non-trivial added logic (rate-limit middleware, a server-side auth check),
+small when they're a well-known template field the model already emits (a K8s
+`securityContext`, a React controlled input). Per-domain notes + raw data:
+[BREADTH.md](2026-07-13/BREADTH.md).
 
 SOTA-skills **wins or ties all 21 head-to-head cases and loses none.** The
 confidence check confirms it isn't noise: gaps match the full run, and


### PR DESCRIPTION
Adds the five-domain **breadth chart** (`assets/breadth-{light,dark}.svg`, theme-aware
`<picture>`) to `evals/results/RESULTS.md` §3, and pulls the full breadth story inline
so the scoreboard is self-contained rather than spread across files:

- **chart** (was only in `BREADTH.md`) + the existing **table**
- the **0.7-baseline threshold** finding
- the **"why the baseline predicts the lift" mechanism** (was only in `BREADTH.md`)

`BREADTH.md` remains as the per-domain-notes and raw-data appendix. The backend
competitor bar chart stays too — the two charts show different cuts (per-competitor
head-to-head vs cross-domain generalization).

Validated: embedded paths resolve (`../../assets/breadth-*.svg`), both SVGs
well-formed, all 7 invariants pass. CHANGELOG `[Unreleased]` note added.
