### PR TITLE
feat(docs-workflow): add rules/01 §8 'The documentation baseline' — must-have docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`sota-docs-workflow` rules/01 §8 "The documentation baseline"** — the must-have
+  doc set every repo should carry, closing a real gap (the individual docs were
+  covered but scattered, and the community-health files SECURITY/CODE_OF_CONDUCT/
+  SUPPORT/GOVERNANCE were absent entirely). Enumerates *always* (README + LICENSE +
+  CHANGELOG) vs *trigger-based* (CONTRIBUTING/CODE_OF_CONDUCT/SECURITY once public,
+  runbooks once on-call, AGENTS.md for AI-assisted repos, ADR log, CODEOWNERS), with
+  GitHub's community-health-file search precedence (`.github/` → root → `docs/`,
+  verified against GitHub docs) and the single-canonical-home rule so the baseline
+  itself doesn't become sprawl. Two audit-checklist lines added; SKILL index + BUILD
+  step updated.
+
 ### Changed
 
 - **`evals/results/RESULTS.md` now embeds the five-domain breadth chart** and

--- a/skills/sota-docs-workflow/SKILL.md
+++ b/skills/sota-docs-workflow/SKILL.md
@@ -44,7 +44,9 @@ When creating docs or setting up workflow:
    (`rules/01` §2, §4).
 3. **README = what / why / 5-minute quickstart / honest status**, then links
    out (`rules/01` §3). Runbooks are alert-linked and command-exact
-   (`rules/01` §5).
+   (`rules/01` §5). Ship the **documentation baseline** — README + LICENSE +
+   CHANGELOG always; SECURITY/CONTRIBUTING/CODE_OF_CONDUCT once public — each with
+   one canonical home, not scattered copies (`rules/01` §8).
 4. **Reference is generated** from OpenAPI/docstrings/rustdoc/godoc with
    warnings-as-errors; doc comments carry the why, contract, and failure
    modes; examples run in CI (`rules/02` §1–4).
@@ -118,7 +120,7 @@ evidence (a doc you executed, a PR you read) — no findings from vibes.
 
 | File | Read this when... |
 |---|---|
-| `rules/01-documentation-architecture.md` | Writing/structuring/auditing any docs: Diátaxis modes, docs-as-code CI (link checks, doc tests), README front-door, decay control (ownership, freshness, aggressive deletion), runbooks, onboarding docs, discoverability, AGENTS.md/CLAUDE.md and llms.txt. |
+| `rules/01-documentation-architecture.md` | Writing/structuring/auditing any docs: Diátaxis modes, docs-as-code CI (link checks, doc tests), README front-door, decay control (ownership, freshness, aggressive deletion), runbooks, onboarding docs, discoverability, AGENTS.md/CLAUDE.md and llms.txt, and the repo **documentation baseline** (must-have docs + community-health files: LICENSE/SECURITY/CONTRIBUTING/CODE_OF_CONDUCT, and where GitHub looks for them). |
 | `rules/02-api-reference-changelogs.md` | API/library reference docs: generation from source (OpenAPI/docstrings/rustdoc/godoc), docstring content (why/contract/failures), runnable examples and doctests, error documentation, versioned docs, Keep a Changelog discipline, migration guides. |
 | `rules/03-code-review-pr-workflow.md` | PR and review process: PR sizing and slicing, description discipline (what/why/how-tested), review SLAs and WIP limits, reviewer/author conduct, blocking vs non-blocking comments, draft and stacked PRs, automation boundaries, reviewing AI-generated code. |
 | `rules/04-commits-branches-releases.md` | Git history and shipping: atomic/bisectable commits, message discipline, Conventional Commits and when they pay, trunk-based vs gitflow honesty, SemVer semantics, breaking-change pipeline, tag immutability, release notes vs changelog, release automation. |

--- a/skills/sota-docs-workflow/rules/01-documentation-architecture.md
+++ b/skills/sota-docs-workflow/rules/01-documentation-architecture.md
@@ -214,8 +214,47 @@ Docs are now read by agents as well as humans. Same content, two consumers.
   command blocks, tables over prose for facts. These were good practices for
   humans already; agents just raised the price of ignoring them.
 
+## §8 The documentation baseline — what every repo carries
+
+Docs aren't just "whatever got written." A small **baseline set** should exist,
+each with **one home** (§4 — the baseline is a floor, never a license to
+duplicate). Create each when its trigger fires, not preemptively: an unmaintained
+`CONTRIBUTING` or `CODE_OF_CONDUCT` full of rules nobody follows is itself a
+finding, not a checkbox win.
+
+**Always (any repo shared with anyone):**
+
+- **README** — the front door (§3): what, why, ≤5-minute quickstart, honest status.
+- **LICENSE** — without one, default copyright applies and **no one may legally
+  reuse the code** (choosealicense.com). Choose deliberately; it **cannot** be
+  inherited from an org default — GitHub requires it in each repo.
+- **CHANGELOG** — user-facing change history, updated in the PR that makes the
+  change (rules/02 §6); absent it, users reverse-engineer releases from commits.
+
+**When the trigger fires (conditionally required):**
+
+| Trigger | Doc |
+|---|---|
+| Public, or accepts outside contributions | `CONTRIBUTING.md` (how to propose changes) + `CODE_OF_CONDUCT.md` (behavior + an enforcement contact) |
+| Handles anything security-relevant | `SECURITY.md` — how to report a vulnerability **privately** (a channel or advisory, never "open an issue") + supported-version policy |
+| Users need a place to ask / triage routing | `SUPPORT.md` — where questions go, so issues stay for bugs |
+| On-call / production service | runbooks (§5) + an incident/postmortem template |
+| AI-assisted repo | `AGENTS.md`/`CLAUDE.md` (§7) |
+| Architectural decisions accrue | an ADR log (`sota-architecture`) |
+| Multi-maintainer / org project | `CODEOWNERS`, plus `GOVERNANCE.md`/`MAINTAINERS` when decision rights aren't obvious |
+
+**Placement.** GitHub recognizes the community-health files (`CODE_OF_CONDUCT`,
+`CONTRIBUTING`, `SECURITY`, `SUPPORT`, `GOVERNANCE`, `FUNDING`) from **`.github/`,
+then the repo root, then `docs/`** (that precedence); an org-level **public**
+`.github` repo supplies defaults for repos lacking their own (GitHub docs). Keep
+exactly one canonical copy — per repo or via the org default, not both. README and
+LICENSE live at the repo root (GitHub surfaces them in the repo header) and are
+**not** inheritable community-health files.
+
 ## Audit checklist
 
+- [ ] Baseline present for the repo's stage: README + LICENSE + CHANGELOG always; CONTRIBUTING/CODE_OF_CONDUCT/SECURITY/SUPPORT once public or contribution-accepting; runbooks once on-call — each with one canonical home (no duplicate copies across root/`.github`/`docs`).
+- [ ] `SECURITY.md` gives a private vulnerability-reporting channel (not "open an issue") and a supported-version policy; `LICENSE` is present and intentional (its absence = all-rights-reserved, blocking reuse).
 - [ ] Docs classified by Diátaxis mode; no page mixes tutorial/how-to/reference/explanation; titles declare the mode.
 - [ ] Tutorials run end-to-end on a clean environment (verified recently, versions pinned).
 - [ ] Docs live in-repo, change via reviewed PRs, and behavior-changing code PRs touch docs.


### PR DESCRIPTION
Answers "which docs should always exist?" — a gap in `sota-docs-workflow`.

## The gap (validated)
The skill already covers the **anti-sprawl** side well (rules/01 §4: *"every fact
has one home; everything else links to it,"* audit-enforced). But the **must-have
baseline** was only implicit — the individual docs were mentioned scattered across
sections, and grep confirmed the **community-health files** (`SECURITY.md`,
`CODE_OF_CONDUCT.md`, `SUPPORT.md`, `GOVERNANCE.md`) were **absent entirely** from
the skill.

## What's added — rules/01 §8 "The documentation baseline"
- **Always:** README + LICENSE (absent = all-rights-reserved, blocks reuse; can't be
  an org default) + CHANGELOG.
- **Trigger-based table:** CONTRIBUTING/CODE_OF_CONDUCT (public/contributions),
  SECURITY (private vuln reporting), SUPPORT, runbooks (on-call), AGENTS.md
  (AI-assisted), ADR log, CODEOWNERS/GOVERNANCE.
- **Placement:** GitHub's community-health-file precedence **`.github/` → root →
  `docs/`** + org `.github` public-repo defaults — **verified against GitHub docs**,
  not asserted from memory.
- Ties back to the single-canonical-home rule so the baseline itself doesn't sprawl;
  anti-ceremony note (an unmaintained CONTRIBUTING is a finding, not a win).
- Two audit-checklist lines; SKILL index entry + BUILD step updated.

## Validation
- Claims web-verified: GitHub community-health file list + search locations + LICENSE
  not-inheritable (GitHub docs); LICENSE-absence semantics (choosealicense.com).
- rules/01 **269/500** lines; `## Audit checklist` stays the last heading; all 7
  invariants pass.
