### PR TITLE
feat(audit): decision-ledger review — audit the decisions, not just the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   audit-*process* change, and recommends stopping additions to the audit path until
   an agentic one exists:
   [`evals/results/2026-07-20/AUDIT-PROCESS.md`](evals/results/2026-07-20/AUDIT-PROCESS.md).
+- **Decision-ledger review in AUDIT mode** — `sota/rules/01-audit-methodology.md`
+  gains **§6**, and the router's AUDIT workflow a **step 5**. Code passes find defects
+  in what was built; they cannot find the defect where the code faithfully implements
+  a choice that **stopped being right** — a datastore picked for scale that never
+  arrived, a rewrite justified by a benchmark that no longer reproduces, an expired
+  constraint still shaping the design. Reconstruct the expensive-to-reverse decisions
+  (ADRs, design docs, CHANGELOG, the PRs that introduced each major component) and
+  classify each **JUSTIFIED / STALE / UNJUSTIFIED / UNVERIFIABLE**, with STALE
+  (sound when made, inputs since expired) kept distinct from UNJUSTIFIED (the stated
+  reasoning never supported it). Where a decision rests on a **number**, re-run that
+  measurement *this session* — a benchmark in a two-year-old ADR is a historical
+  claim, not a current fact — or mark the decision unverifiable and say what would
+  confirm it. Ledger-vs-code is checked **both** directions (recorded-but-not-
+  implemented is as much a finding as implemented-but-not-recorded). Verdicts carry a
+  severity and feed the roadmap. Report structure gains a **Decision ledger** section;
+  one audit-checklist line added; §7–§9 renumbered.
+  `sota-architecture` rules/01 §4 owns *writing* ADRs and is cross-referenced, not
+  duplicated — this is the audit side. Verified the gap on current `main` first:
+  zero hits for ADR/decision-record/stale-justification anywhere under `skills/sota/`.
+  **Unmeasured, deliberately:** four audit instruments now saturate at +0.00
+  (recall, cross-file, silent-control, precision), so no current eval can score an
+  audit-*process* change — see
+  [`evals/results/2026-07-20/AUDIT-PROCESS.md`](evals/results/2026-07-20/AUDIT-PROCESS.md).
+  No efficacy claim is made, and this is the **last** planned audit-path addition
+  until an agentic instrument exists.
 - **Adversarial verification in AUDIT mode** — `sota/rules/01-audit-methodology.md`
   gains **§6 "Try to kill your own findings"**, and the router's AUDIT workflow step 6
   changes from *verify* to **refute**. Re-reading your own finding re-runs the

--- a/evals/results/2026-07-20/AUDIT-PROCESS.md
+++ b/evals/results/2026-07-20/AUDIT-PROCESS.md
@@ -137,6 +137,45 @@ generic "audit this", scored on whether the right questions get asked unprompted
 the same frontier the [cross-file audit](../2026-07-13/REPO-AUDIT.md) and
 [silent-control](SILENT-FAILURE.md) runs both hit.
 
+## 5. Post-decision-ledger regression (same day, after §6 was added)
+
+`rules/01` grew 365 → 428 lines and the router 433 → 443 when the decision-ledger
+section landed. Both are pasted whole by an eval, so both were re-run.
+
+| Eval | Before | After decision-ledger | Verdict |
+|---|---|---|---|
+| Routing (20, 3×@0.7) | with 1.00 / lift +0.10 | **with 1.00** / lift +0.11 | held |
+| Audit precision (30, 3×@0.7) | 1.00 / 1.00 / 1.00 | **1.00 / 1.00 / 1.00** | held |
+
+No salience cost detected from any of today's four audit-path additions.
+
+Two evals were **proven unaffected instead of re-run**, on the same
+input-identity argument as §1: the completeness set loads 17 skill files, **none**
+of them touched today, and its `principle5()` extract is still byte-identical
+(sha `2a36f20d8e51`); the silent-control set pastes the `sota-code-security`
+rules, **unchanged** since PR #119.
+
+### The ablation arm caught its own breakage
+
+The first run of this regression **aborted**:
+
+```
+§6 markers not found — ablation would silently no-op
+```
+
+Adding the decision-ledger section renumbered *Adversarial verification* from §6
+to §7, and `run-adjudication.py` had hardcoded `"## 6. Adversarial verification"`.
+Without the guard the ablation would have found nothing to remove, silently
+returned the **full** corpus as the "ablated" arm, and reported a fake +0.00
+contribution that looked exactly like the real one.
+
+That is the failure this whole line of work is about — a control (the ablation)
+that appears to run and does nothing — and it was caught only because the runner
+was written to abort rather than proceed. The markers now match on section
+**title** rather than number, and the ablation additionally asserts that it
+removed a non-trivial block and that the section is genuinely gone. Both guards
+were watched to fire before being trusted.
+
 ## Appendix — a live false positive, caught by push protection
 
 Case `fa22` originally used a vendor's **published documentation test key**

--- a/evals/results/2026-07-20/adjudication-postledger-3sample.json
+++ b/evals/results/2026-07-20/adjudication-postledger-3sample.json
@@ -1,0 +1,174 @@
+{
+ "_meta": {
+  "model": "anthropic/claude-sonnet-4.6",
+  "cases": 30,
+  "samples": 3,
+  "temp": 0.7,
+  "metric": "audit precision"
+ },
+ "without-library": {
+  "accuracy": 1.0,
+  "sensitivity": 1.0,
+  "specificity": 1.0,
+  "runs": [
+   {
+    "accuracy": 1.0,
+    "sensitivity": 1.0,
+    "specificity": 1.0
+   },
+   {
+    "accuracy": 1.0,
+    "sensitivity": 1.0,
+    "specificity": 1.0
+   },
+   {
+    "accuracy": 1.0,
+    "sensitivity": 1.0,
+    "specificity": 1.0
+   }
+  ],
+  "wrong": [],
+  "predictions": {
+   "fa01": "UPHELD",
+   "fa02": "UPHELD",
+   "fa03": "UPHELD",
+   "fa04": "UPHELD",
+   "fa05": "UPHELD",
+   "fa06": "UPHELD",
+   "fa07": "UPHELD",
+   "fa08": "UPHELD",
+   "fa09": "UPHELD",
+   "fa10": "UPHELD",
+   "fa11": "UPHELD",
+   "fa12": "UPHELD",
+   "fa13": "UPHELD",
+   "fa14": "UPHELD",
+   "fa15": "UPHELD",
+   "fa16": "REFUTED",
+   "fa17": "REFUTED",
+   "fa18": "REFUTED",
+   "fa19": "REFUTED",
+   "fa20": "REFUTED",
+   "fa21": "REFUTED",
+   "fa22": "REFUTED",
+   "fa23": "REFUTED",
+   "fa24": "REFUTED",
+   "fa25": "REFUTED",
+   "fa26": "REFUTED",
+   "fa27": "REFUTED",
+   "fa28": "REFUTED",
+   "fa29": "REFUTED",
+   "fa30": "REFUTED"
+  }
+ },
+ "with-library": {
+  "accuracy": 1.0,
+  "sensitivity": 1.0,
+  "specificity": 1.0,
+  "runs": [
+   {
+    "accuracy": 1.0,
+    "sensitivity": 1.0,
+    "specificity": 1.0
+   },
+   {
+    "accuracy": 1.0,
+    "sensitivity": 1.0,
+    "specificity": 1.0
+   },
+   {
+    "accuracy": 1.0,
+    "sensitivity": 1.0,
+    "specificity": 1.0
+   }
+  ],
+  "wrong": [],
+  "predictions": {
+   "fa01": "UPHELD",
+   "fa02": "UPHELD",
+   "fa03": "UPHELD",
+   "fa04": "UPHELD",
+   "fa05": "UPHELD",
+   "fa06": "UPHELD",
+   "fa07": "UPHELD",
+   "fa08": "UPHELD",
+   "fa09": "UPHELD",
+   "fa10": "UPHELD",
+   "fa11": "UPHELD",
+   "fa12": "UPHELD",
+   "fa13": "UPHELD",
+   "fa14": "UPHELD",
+   "fa15": "UPHELD",
+   "fa16": "REFUTED",
+   "fa17": "REFUTED",
+   "fa18": "REFUTED",
+   "fa19": "REFUTED",
+   "fa20": "REFUTED",
+   "fa21": "REFUTED",
+   "fa22": "REFUTED",
+   "fa23": "REFUTED",
+   "fa24": "REFUTED",
+   "fa25": "REFUTED",
+   "fa26": "REFUTED",
+   "fa27": "REFUTED",
+   "fa28": "REFUTED",
+   "fa29": "REFUTED",
+   "fa30": "REFUTED"
+  }
+ },
+ "with-library-ablated": {
+  "accuracy": 1.0,
+  "sensitivity": 1.0,
+  "specificity": 1.0,
+  "runs": [
+   {
+    "accuracy": 1.0,
+    "sensitivity": 1.0,
+    "specificity": 1.0
+   },
+   {
+    "accuracy": 1.0,
+    "sensitivity": 1.0,
+    "specificity": 1.0
+   },
+   {
+    "accuracy": 1.0,
+    "sensitivity": 1.0,
+    "specificity": 1.0
+   }
+  ],
+  "wrong": [],
+  "predictions": {
+   "fa01": "UPHELD",
+   "fa02": "UPHELD",
+   "fa03": "UPHELD",
+   "fa04": "UPHELD",
+   "fa05": "UPHELD",
+   "fa06": "UPHELD",
+   "fa07": "UPHELD",
+   "fa08": "UPHELD",
+   "fa09": "UPHELD",
+   "fa10": "UPHELD",
+   "fa11": "UPHELD",
+   "fa12": "UPHELD",
+   "fa13": "UPHELD",
+   "fa14": "UPHELD",
+   "fa15": "UPHELD",
+   "fa16": "REFUTED",
+   "fa17": "REFUTED",
+   "fa18": "REFUTED",
+   "fa19": "REFUTED",
+   "fa20": "REFUTED",
+   "fa21": "REFUTED",
+   "fa22": "REFUTED",
+   "fa23": "REFUTED",
+   "fa24": "REFUTED",
+   "fa25": "REFUTED",
+   "fa26": "REFUTED",
+   "fa27": "REFUTED",
+   "fa28": "REFUTED",
+   "fa29": "REFUTED",
+   "fa30": "REFUTED"
+  }
+ }
+}

--- a/evals/results/2026-07-20/routing-3sample-postledger.json
+++ b/evals/results/2026-07-20/routing-3sample-postledger.json
@@ -1,0 +1,251 @@
+{
+ "_meta": {
+  "model": "anthropic/claude-sonnet-4.6",
+  "kind": "routing",
+  "cases": 20,
+  "samples": 3,
+  "temp": 0.7,
+  "ablate": false
+ },
+ "without-library": {
+  "recall": 0.8916666666666666,
+  "recalls": [
+   0.9083333333333332,
+   0.8833333333333332,
+   0.8833333333333332
+  ],
+  "misses": {
+   "r01": [
+    "sota-testing"
+   ],
+   "r02": [
+    "sota-sandboxing"
+   ],
+   "r07": [
+    "sota-code-security"
+   ],
+   "r09": [
+    "sota-web-frameworks"
+   ],
+   "r20": [
+    "sota-devsecops"
+   ]
+  },
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-web-frameworks",
+    "sota-code-security"
+   ],
+   "r02": [
+    "sota-kubernetes",
+    "sota-devsecops",
+    "sota-code-security"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-identity-access"
+   ],
+   "r04": [
+    "sota-network-security",
+    "sota-security-compliance"
+   ],
+   "r05": [
+    "sota-shell-scripting",
+    "sota-cli-ux"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-identity-access",
+    "sota-secrets-management",
+    "sota-code-security"
+   ],
+   "r07": [
+    "sota-llm-engineering",
+    "sota-api-design",
+    "sota-data-engineering"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-code-security",
+    "sota-network-security"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-javascript-typescript",
+    "sota-ux-writing"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure",
+    "sota-identity-access"
+   ],
+   "r11": [
+    "sota-ux-writing",
+    "sota-copywriting"
+   ],
+   "r12": [
+    "sota-performance",
+    "sota-observability",
+    "sota-databases"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases",
+    "sota-performance"
+   ],
+   "r15": [
+    "sota-llm-engineering",
+    "sota-sandboxing",
+    "sota-code-security",
+    "sota-threat-modeling"
+   ],
+   "r16": [
+    "sota-mobile",
+    "sota-async-concurrency",
+    "sota-databases"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-security-compliance"
+   ],
+   "r18": [
+    "sota-observability",
+    "sota-cloud-infrastructure"
+   ],
+   "r19": [
+    "sota-threat-modeling",
+    "sota-security-compliance",
+    "sota-identity-access"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-identity-access",
+    "sota-secrets-management",
+    "sota-security-compliance"
+   ]
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "recalls": [
+   1.0,
+   1.0,
+   1.0
+  ],
+  "misses": {},
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-code-security",
+    "sota-testing",
+    "sota-sandboxing"
+   ],
+   "r02": [
+    "sota-sandboxing",
+    "sota-kubernetes",
+    "sota-devsecops",
+    "sota-shell-scripting"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-code-security",
+    "sota-threat-modeling",
+    "sota-testing"
+   ],
+   "r04": [
+    "sota-network-security"
+   ],
+   "r05": [
+    "sota-shell-scripting"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-secrets-management",
+    "sota-code-security"
+   ],
+   "r07": [
+    "sota-llm-engineering",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-databases",
+    "sota-testing"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-code-security",
+    "sota-api-design",
+    "sota-threat-modeling",
+    "sota-secrets-management"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-web-frameworks",
+    "sota-javascript-typescript",
+    "sota-testing"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure",
+    "sota-secrets-management",
+    "sota-identity-access"
+   ],
+   "r11": [
+    "sota-ux-writing"
+   ],
+   "r12": [
+    "sota-databases",
+    "sota-performance",
+    "sota-observability"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases"
+   ],
+   "r15": [
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-llm-engineering",
+    "sota-threat-modeling"
+   ],
+   "r16": [
+    "sota-mobile",
+    "sota-async-concurrency",
+    "sota-databases",
+    "sota-testing"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-code-security",
+    "sota-api-design"
+   ],
+   "r18": [
+    "sota-observability",
+    "sota-testing"
+   ],
+   "r19": [
+    "sota-threat-modeling",
+    "sota-code-security",
+    "sota-identity-access",
+    "sota-secrets-management"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-identity-access",
+    "sota-devsecops",
+    "sota-network-security",
+    "sota-shell-scripting"
+   ]
+  }
+ }
+}

--- a/evals/run-adjudication.py
+++ b/evals/run-adjudication.py
@@ -38,8 +38,21 @@ run_clean = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(run_clean)
 ROOT = run_clean.ROOT
 
-SEC6_START = "## 6. Adversarial verification"
-SEC6_END = "## 7. Report structure"
+# Match the section by its TITLE, not its number. The first version hardcoded
+# "## 6. Adversarial verification" / "## 7. Report structure"; inserting the
+# decision-ledger section renumbered both and the ablation stopped matching. The
+# guard in library_context() caught it (it aborts rather than silently returning
+# an unablated corpus) — keep that guard, and stop depending on the numbering.
+SEC_ABLATE_TITLE = "Adversarial verification"
+SEC_NEXT_TITLE = "Report structure"
+
+
+def _section_bounds(text, title, next_title):
+    """Byte offsets of a '## N. <title>' section, whatever N happens to be."""
+    import re
+    a = re.search(rf"^## \d+\. {re.escape(title)}", text, re.M)
+    b = re.search(rf"^## \d+\. {re.escape(next_title)}", text, re.M)
+    return (a.start() if a else -1), (b.start() if b else -1)
 
 # NEUTRAL by design. An earlier draft listed the ways a claim can fail (misread
 # mechanism, upstream guard, unreachable, already mitigated, inflated severity) —
@@ -57,10 +70,17 @@ def library_context(ablate=False):
     meth = open(os.path.join(ROOT, "skills/sota/rules/01-audit-methodology.md"),
                 encoding="utf-8").read()
     if ablate:
-        i, j = meth.find(SEC6_START), meth.find(SEC6_END)
-        if i < 0 or j < 0:
-            raise SystemExit("§6 markers not found — ablation would silently no-op")
+        i, j = _section_bounds(meth, SEC_ABLATE_TITLE, SEC_NEXT_TITLE)
+        if i < 0 or j < 0 or j <= i:
+            raise SystemExit(
+                f"ablation target section not found (looked for '## N. {SEC_ABLATE_TITLE}' "
+                f"through '## N. {SEC_NEXT_TITLE}'). Refusing to run: a silent no-op "
+                f"ablation would report a fake +0.00 contribution.")
+        removed = meth[i:j]
         meth = meth[:i] + meth[j:]
+        if SEC_ABLATE_TITLE in meth or len(removed) < 500:
+            raise SystemExit(f"ablation removed only {len(removed)} chars or left the "
+                             f"section behind — refusing to run.")
     router = open(os.path.join(ROOT, "skills/sota/SKILL.md"), encoding="utf-8").read()
     i, j = router.find("## Operating principles"), router.find("## Routing table")
     return f"{router[i:j].strip()}\n\n---\n\n{meth}"

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -276,7 +276,17 @@ For a **full project audit**, work in passes:
    whose tests still pass when the body is replaced with a no-op. This class is
    invisible to the other passes — the code isn't wrong, it's inert — and to
    pattern-based SAST for the same reason.
-5. **Findings.** Emit every finding in the canonical cross-domain format
+5. **Decision-ledger review.** Code passes find defects in what was built; they
+   cannot find the defect where the code faithfully implements a choice that
+   **stopped being right** — a store picked for scale that never arrived, a
+   rewrite justified by a benchmark that no longer reproduces, an expired
+   constraint still shaping the design. Reconstruct the expensive-to-reverse
+   decisions (ADRs, design docs, CHANGELOG, the PRs that introduced each major
+   component) and classify each **JUSTIFIED / STALE / UNJUSTIFIED /
+   UNVERIFIABLE**. Where a decision rests on a number, **re-measure it this
+   session** — a benchmark in a two-year-old ADR is a historical claim, not a
+   current fact. Full procedure: `rules/01-audit-methodology.md` §6.
+6. **Findings.** Emit every finding in the canonical cross-domain format
    (`file:line | rule | severity | effort | fix`) — skill-local block formats
    are fine within a domain pass but must carry an effort field so the
    roll-up can be sequenced — deduplicate across domains,
@@ -289,7 +299,7 @@ For a **full project audit**, work in passes:
    - **Medium** — deviation from SOTA with real but bounded impact.
    - **Low** — hygiene, polish, future-proofing.
    - **Info** — no direct risk: observations, tech-debt notes, future-proofing.
-6. **Refute before reporting.** Re-reading your own finding re-runs the reasoning
+7. **Refute before reporting.** Re-reading your own finding re-runs the reasoning
    that produced it — it is the weakest check available. Every Critical/High gets
    an **independent pass prompted to kill it** (a separate agent, or a
    fresh-context hostile read), working from the code at the pinned commit rather
@@ -299,7 +309,7 @@ For a **full project audit**, work in passes:
    are dropped or downgraded **with the refutation recorded**, so the next auditor
    doesn't re-raise them. Absence claims ("no X found") get a refuter too, and
    carry the heavier burden of principle 3. Full procedure and failure modes:
-   `rules/01-audit-methodology.md` §6.
+   `rules/01-audit-methodology.md` §7.
 
 ## Library map (rules files per skill)
 

--- a/skills/sota/rules/01-audit-methodology.md
+++ b/skills/sota/rules/01-audit-methodology.md
@@ -95,7 +95,7 @@ option where capability is equivalent.
 | Licenses | cargo-deny (Rust); trivy license scan; syft SBOM license fields | Filter against the project's allowed-license policy. |
 
 Run each tool against the pinned commit; record the exact tool version and
-command line (needed for §8 reproducibility).
+command line (needed for §9 reproducibility).
 
 ### Triage discipline — tool output is raw material, not findings
 
@@ -182,7 +182,7 @@ not ready to ship:
    this query", with the changed line), referencing the relevant skill's
    rules file for the full pattern. Never "sanitize input".
 8. **Effort estimate** — trivial / small / medium / large. Severity says
-   what hurts; effort enables the roadmap in §7.
+   what hurts; effort enables the roadmap in §8.
 
 Two asymmetries the evidence standard has to carry:
 
@@ -197,17 +197,72 @@ Two asymmetries the evidence standard has to carry:
 - **"The control is present" is not "the control works."** Evidence for a
   positive observation must show *effect*, not existence — the log line it
   emitted, the request it rejected, the test that fails when it's disabled.
-  See `sota-code-security` rules/10; this applies to §7's positive-observations
+  See `sota-code-security` rules/10; this applies to §8's positive-observations
   section too, where an inert control praised as a strength is the worst
   possible reporting error.
 
 The library's short finding format (`file:line | rule | severity | effort | fix`)
 is the working format during passes; expand each surviving finding into the
 full evidence block for the report. Skill-local block formats are fine during
-a single-domain pass, but they must carry the effort field — §7's roadmap is
+a single-domain pass, but they must carry the effort field — §8's roadmap is
 sequenced by risk-reduction-per-effort and can't be built without it.
 
-## 6. Adversarial verification — try to kill your own findings
+## 6. Decision-ledger review — audit the decisions, not just the code
+
+Code review finds defects in what was built. It cannot find the defect where the
+code is a faithful implementation of a choice that **stopped being right** — a
+datastore picked for a scale that never arrived, a benchmark-justified rewrite
+whose benchmark no longer reproduces, a constraint that expired two years ago and
+is still shaping the design. That class is invisible to every pass above and is
+often the most expensive thing in the repo.
+
+`sota-architecture` rules/01 §4 owns **writing** ADRs. This is the audit side:
+reading them back and asking whether they still hold.
+
+**Reconstruct the ledger.** Sources, in order of reliability: ADRs
+(`docs/adr/`), design docs and RFCs, the CHANGELOG, PR descriptions on the
+commits that introduced each major component, and — last — comments. Where no
+record exists, the decision is still there, just undocumented: infer it from the
+code and label it *reconstructed, unconfirmed*. A major component with no
+discoverable rationale is itself a finding.
+
+**For each significant decision, classify it:**
+
+- **JUSTIFIED** — the reasoning holds and the evidence still reproduces.
+- **STALE** — sound when made, no longer: the constraint expired, the alternative
+  got better, the load never materialized, the dependency went EOL. Not a mistake;
+  a decision that has outlived its inputs. Say what changed.
+- **UNJUSTIFIED** — the stated reasoning does not support the decision, or the
+  evidence cited was never checked. Distinguish this from STALE plainly; it is a
+  judgment about the decision as made.
+- **UNVERIFIABLE** — no rationale survives and none can be reconstructed. Record
+  it rather than guessing.
+
+**Re-measure anything a decision rests on.** When the justification is a number —
+a benchmark, a latency or throughput target, a recall/false-positive rate, "X is
+faster than Y", "this doesn't scale" — **re-run it this session** and report the
+result, including in heavyweight environments when that is the only honest way to
+check. A number in a two-year-old ADR is a historical claim, not a current fact.
+If you cannot re-run it, mark the decision UNVERIFIABLE and say precisely what
+would confirm it (principles 0 and 6 apply here with full force). Respect the
+repo's documented environment constraints and teardown rules when you do.
+
+**Check the ledger against reality, both directions.** A decision recorded but
+never implemented is as much a finding as one implemented but never recorded —
+the ADR says "we use the outbox pattern", the code dual-writes. And a superseded
+ADR still describing current behavior misleads every future reader.
+
+**Report as findings.** STALE and UNJUSTIFIED entries carry a severity like any
+other finding (impact of continuing on the current path × likelihood it bites),
+and feed §8's roadmap — reversing an expensive decision is usually *large* effort
+and belongs sequenced, not buried in prose. Quote both sides: the recorded
+rationale and what you measured.
+
+Scope it: the decisions worth this treatment are the expensive-to-reverse ones —
+datastore, broker, service boundaries, auth model, tenancy model, language or
+framework, build/deploy topology. Do not ledger-review every merged PR.
+
+## 7. Adversarial verification — try to kill your own findings
 
 Re-reading your own finding is the weakest possible check: you re-run the
 reasoning that produced it and reach the same conclusion. Confirmation bias is
@@ -254,7 +309,7 @@ Two failure modes to avoid:
   file at the pinned commit. A refutation built on the finding's prose only
   tests your writing.
 
-## 7. Report structure
+## 8. Report structure
 
 Deliver in exactly this order:
 
@@ -265,22 +320,26 @@ Deliver in exactly this order:
    covered (with the recorded exclusions from §1), standards asserted
    against, tools run with exact versions and commands, audit date. This
    makes the audit reproducible and bounds its claims.
-3. **Findings** — grouped Critical → High → Medium → Low → Info; within a
+3. **Decision ledger** — the §6 table: each significant decision →
+   JUSTIFIED / STALE / UNJUSTIFIED / UNVERIFIABLE, with the recorded rationale
+   and the evidence you re-checked. Omit the section only if the repo has no
+   discoverable decisions; say so if you do.
+4. **Findings** — grouped Critical → High → Medium → Low → Info; within a
    severity, ordered by exploitability. Each in the full §5 evidence block, and
-   each Critical/High having survived the §6 refutation pass.
-4. **Prioritized remediation roadmap** — *not a finding dump in severity
+   each Critical/High having survived the §7 refutation pass.
+5. **Prioritized remediation roadmap** — *not a finding dump in severity
    order*. Sequence by **risk-reduction-per-effort**: quick critical wins
    first (trivial/small fixes to Critical/High), then high-impact larger
    work, then hardening. Group related fixes that share a root cause or a
    code area into one work item. The reader should be able to start work
    from the roadmap alone.
-5. **Positive observations** — what is already done well (good patterns,
+6. **Positive observations** — what is already done well (good patterns,
    solid boundaries, tooling in place), so it is preserved through
    remediation rather than accidentally regressed.
-6. **Appendix** — full triaged tool output, the inventory from §2, DFDs and
+7. **Appendix** — full triaged tool output, the inventory from §2, DFDs and
    trust-boundary sketches, suppression-comment review.
 
-## 8. Audit hygiene
+## 9. Audit hygiene
 
 - **Reproducible**: pin the commit; record exact tool versions and full
   command lines so anyone can re-run the audit and re-verify each finding.
@@ -335,10 +394,14 @@ Deliver in exactly this order:
       remediation, and effort estimate?
 - [ ] Borderline severities state the deciding assumption explicitly?
 - [ ] Uncertain findings marked "needs verification", not asserted?
+- [ ] **Decision ledger reviewed** — expensive-to-reverse decisions reconstructed
+      and classified JUSTIFIED / STALE / UNJUSTIFIED / UNVERIFIABLE, every number a
+      decision rests on **re-measured this session** (or the decision marked
+      unverifiable), and ledger-vs-code checked both directions (§6)?
 - [ ] **Every Critical/High refuted by an independent pass** — a separate agent
       or a fresh-context hostile read prompted to *kill* the finding, working
       from the code and not from your write-up, with survivors kept and
-      refutations recorded (§6)?
+      refutations recorded (§7)?
 - [ ] Every **absence claim** ("no X found", "enforced everywhere") backed by a
       widened search plus a second independent method, with the search stated?
 - [ ] Positive observations evidenced by **effect** (a rejection, a log, a test


### PR DESCRIPTION
The last of the four candidate ports from an external audit harness. The other three were assessed and **rejected**: report+roadmap deliverable duplicates §8; `ultracode`/loop-until-dry is harness-bound (the runtime-dependent class the v1.16.0 external-review batch already rejected); re-measure-the-claim is folded in here as one clause rather than a section.

## The gap

Code passes find defects in what was *built*. They cannot find the defect where the code faithfully implements a choice that **stopped being right** — a datastore picked for scale that never arrived, a rewrite justified by a benchmark that no longer reproduces, an expired constraint still shaping the design.

Gap re-verified on current `main`: `grep -rniE "ADR|decision record|stale justification"` under `skills/sota/` → **zero hits**. `sota-architecture` rules/01 §4 owns *writing* ADRs and is cross-referenced, not duplicated — this is the audit side.

## The change

`rules/01-audit-methodology.md` **§6**, router **AUDIT step 5**:

- **Reconstruct** the ledger from ADRs, design docs, CHANGELOG, and the PRs that introduced each major component. Where no record exists, infer from code and label it *reconstructed, unconfirmed* — a major component with no discoverable rationale is itself a finding.
- **Classify**: JUSTIFIED / **STALE** (sound when made, inputs since expired) / **UNJUSTIFIED** (the reasoning never supported it) / UNVERIFIABLE. STALE vs UNJUSTIFIED is kept explicitly distinct — one is a decision that outlived its inputs, the other a judgment about the decision as made.
- **Re-measure anything a decision rests on, this session.** A benchmark in a two-year-old ADR is a historical claim, not a current fact. Can't re-run it? Mark UNVERIFIABLE and say what would confirm it.
- **Check ledger-vs-code both directions** — recorded-but-never-implemented is as much a finding as implemented-but-never-recorded.
- Verdicts carry severity and feed the roadmap; report structure gains a **Decision ledger** section.
- Scoped to expensive-to-reverse decisions only — explicitly *not* every merged PR.

## Regression — no salience cost

`rules/01` grew 365 → 428 lines and the router 433 → 443. Both are pasted whole by an eval, so both were re-run:

| Eval | Before | After | Verdict |
|---|---|---|---|
| Routing (20, 3×@0.7) | with 1.00 / lift +0.10 | **1.00** / +0.11 | held |
| Audit precision (30, 3×@0.7) | 1.00 / 1.00 / 1.00 | **1.00 / 1.00 / 1.00** | held |

Completeness and silent-control were **proven input-identical rather than re-run** (completeness loads 17 skill files, none touched; `principle5()` extract sha `2a36f20d8e51` unchanged; silent-control's code-security corpus unchanged since #119). Running them would have been a vacuous green.

## The ablation caught its own breakage

The first regression run **aborted**:

```
§6 markers not found — ablation would silently no-op
```

Adding this section renumbered *Adversarial verification* §6 → §7, and `run-adjudication.py` hardcoded `"## 6. Adversarial verification"`. Without the guard, the ablation would have removed nothing, silently returned the **full** corpus as the "ablated" arm, and reported a fake +0.00 indistinguishable from the real one.

That is precisely the failure class this week's work is about — a control that appears to run and does nothing — caught only because the runner was written to abort rather than proceed. Markers now match on section **title**, and the ablation additionally asserts it removed a non-trivial block and that the section is genuinely gone. Both guards watched to fire.

## Unmeasured, and this is the last one

Four audit instruments now saturate at +0.00 (recall, cross-file, silent-control, precision), so **no current eval can score an audit-process change**. No efficacy claim is made. Per [AUDIT-PROCESS.md](evals/results/2026-07-20/AUDIT-PROCESS.md), this is the **last planned audit-path addition** until an agentic instrument exists.

## Checks

```
./scripts/check-invariants.sh   → PASS (all 7)
pre-commit run --all-files      → Passed
rules/01: 428/500 lines
```
