### PR TITLE
feat(router): gap-reporting loop — the library's first path for learning from use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Gap-reporting loop — the library's first path for learning from use.** The
+  project has no telemetry by design, which also means a wrong rule, a stale
+  version claim, or a missing skill stays in the library for everyone until a human
+  reports it. Measured reality at v1.17.0: **~24 organic clones/day against 7 stars
+  and one issue ever filed** (GitHub traffic API; the three days with zero CI runs
+  show clones exactly equal to unique cloners). Hundreds of installs, no signal.
+  The fix uses the one channel this project uniquely has — the user is talking to an
+  agent that **already read the skills**. A new short router section tells that agent
+  to surface a **one-line** note when the library actually let the user down (a rule
+  contradicted by a primary source it just checked; a rule that doesn't fit and
+  states no exception; real surface area with no owning skill; guidance that would
+  have shipped a defect), with the issue-template link — and explicitly *not* for
+  personal preference, unneeded rules, or mid-task. Deliberately placed **outside**
+  the always-apply operating principles so it does not dilute the measured
+  principle-5/6 salience. README gains a matching section (issue templates already
+  existed; nothing pointed users at them). Regression-checked — the router grew
+  443 → 467 lines and the routing eval pastes it whole: with-arm **held at 1.00**
+  (3×@0.7, no misses), lift +0.11. Artifact:
+  `evals/results/2026-07-20/routing-3sample-postfeedback.json`.
+
 ## [1.17.0] - 2026-07-20
 
 The **silent-failure release**, and an unusually honest one. New coverage for the

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ More install options: [Installation](#installation) · more prompts: [Using it](
 - [Using it](#using-it)
 - [Optional setup & integrations](#optional-setup--integrations) — [badge](#badge), [gates](#enforcing-the-gates), [other agents](#other-ai-agents-codex-copilot-gemini-), [status line](#status-line-optional), [plugin extras](#optional-extras-for-plugin-users)
 - [Structure](#structure) · [How it works](#how-it-works) · [Conventions](#conventions)
-- [Contributing](#contributing) · [License](#license)
+- [Found a gap? Tell us](#found-a-gap-tell-us--its-the-only-signal-we-get) · [Contributing](#contributing) · [License](#license)
 
 **Deeper docs:** [Find it fast (docs index)](docs/INDEX.md) · [Does it work? (measured results)](evals/results/RESULTS.md) · [Why it works](docs/WHY-IT-WORKS.md) · [Keeping rules applied as context fills](docs/CONTEXT-MANAGEMENT.md) · [Roadmap](docs/ROADMAP.md)
 
@@ -506,6 +506,22 @@ Naming one (or the `sota` router) just makes the routing explicit. From there:
   unconditionally; load detailed rules files only as the task demands.
 - Borderline severities state the deciding assumption; unconfirmed findings
   are marked "needs verification", never asserted.
+
+## Found a gap? Tell us — it's the only signal we get
+
+This library has **no telemetry**. Nothing reports back, by design. That also
+means a wrong rule, a stale version claim, or a task with no owning skill stays
+in the library for everyone until a human says so.
+
+If a skill was wrong, outdated, or missing when you needed it:
+[**open an issue**](https://github.com/martinholovsky/SOTA-skills/issues/new/choose)
+(bad-guidance / skill-request templates — both take about a minute). Dangerous or
+security-sensitive guidance goes to a [private advisory](SECURITY.md) instead.
+
+The assistant will usually flag these itself: the router tells it to surface a
+one-line note when the library lets you down, rather than papering over it.
+
+If it saved you time, a ⭐ helps other engineers find it.
 
 ## Contributing
 

--- a/evals/results/2026-07-20/routing-3sample-postfeedback.json
+++ b/evals/results/2026-07-20/routing-3sample-postfeedback.json
@@ -1,0 +1,244 @@
+{
+ "_meta": {
+  "model": "anthropic/claude-sonnet-4.6",
+  "kind": "routing",
+  "cases": 20,
+  "samples": 3,
+  "temp": 0.7,
+  "ablate": false
+ },
+ "without-library": {
+  "recall": 0.8916666666666666,
+  "recalls": [
+   0.8833333333333332,
+   0.8833333333333332,
+   0.9083333333333332
+  ],
+  "misses": {
+   "r01": [
+    "sota-testing"
+   ],
+   "r02": [
+    "sota-sandboxing"
+   ],
+   "r07": [
+    "sota-code-security"
+   ],
+   "r09": [
+    "sota-web-frameworks"
+   ]
+  },
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-web-frameworks",
+    "sota-code-security"
+   ],
+   "r02": [
+    "sota-kubernetes",
+    "sota-devsecops",
+    "sota-code-security"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-identity-access"
+   ],
+   "r04": [
+    "sota-network-security",
+    "sota-security-compliance"
+   ],
+   "r05": [
+    "sota-shell-scripting",
+    "sota-cli-ux"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-identity-access",
+    "sota-secrets-management",
+    "sota-code-security"
+   ],
+   "r07": [
+    "sota-llm-engineering",
+    "sota-api-design",
+    "sota-data-engineering"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-code-security",
+    "sota-network-security"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-javascript-typescript",
+    "sota-ux-writing"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-cloud-infrastructure",
+    "sota-identity-access"
+   ],
+   "r11": [
+    "sota-ux-writing",
+    "sota-copywriting"
+   ],
+   "r12": [
+    "sota-performance",
+    "sota-observability",
+    "sota-databases"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases",
+    "sota-performance"
+   ],
+   "r15": [
+    "sota-llm-engineering",
+    "sota-sandboxing",
+    "sota-code-security",
+    "sota-threat-modeling"
+   ],
+   "r16": [
+    "sota-mobile",
+    "sota-async-concurrency",
+    "sota-databases"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-security-compliance"
+   ],
+   "r18": [
+    "sota-observability",
+    "sota-cloud-infrastructure"
+   ],
+   "r19": [
+    "sota-threat-modeling",
+    "sota-security-compliance",
+    "sota-identity-access"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-identity-access",
+    "sota-secrets-management",
+    "sota-devsecops"
+   ]
+  }
+ },
+ "with-library": {
+  "recall": 1.0,
+  "recalls": [
+   1.0,
+   1.0,
+   1.0
+  ],
+  "misses": {},
+  "predictions": {
+   "r01": [
+    "sota-api-design",
+    "sota-code-security",
+    "sota-testing",
+    "sota-async-concurrency"
+   ],
+   "r02": [
+    "sota-kubernetes",
+    "sota-sandboxing",
+    "sota-devsecops",
+    "sota-shell-scripting"
+   ],
+   "r03": [
+    "sota-architecture",
+    "sota-api-design",
+    "sota-databases",
+    "sota-code-security",
+    "sota-identity-access",
+    "sota-threat-modeling",
+    "sota-testing"
+   ],
+   "r04": [
+    "sota-network-security"
+   ],
+   "r05": [
+    "sota-shell-scripting"
+   ],
+   "r06": [
+    "sota-devsecops",
+    "sota-secrets-management",
+    "sota-code-security"
+   ],
+   "r07": [
+    "sota-llm-engineering",
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-databases",
+    "sota-privacy-compliance"
+   ],
+   "r08": [
+    "sota-golang",
+    "sota-code-security",
+    "sota-api-design",
+    "sota-threat-modeling",
+    "sota-secrets-management"
+   ],
+   "r09": [
+    "sota-frontend-design",
+    "sota-web-frameworks",
+    "sota-javascript-typescript",
+    "sota-testing"
+   ],
+   "r10": [
+    "sota-confidential-computing",
+    "sota-secrets-management",
+    "sota-cloud-infrastructure"
+   ],
+   "r11": [
+    "sota-ux-writing"
+   ],
+   "r12": [
+    "sota-databases",
+    "sota-performance",
+    "sota-observability"
+   ],
+   "r13": [
+    "sota-testing",
+    "sota-api-design"
+   ],
+   "r14": [
+    "sota-databases"
+   ],
+   "r15": [
+    "sota-code-security",
+    "sota-sandboxing",
+    "sota-llm-engineering"
+   ],
+   "r16": [
+    "sota-mobile",
+    "sota-async-concurrency",
+    "sota-testing"
+   ],
+   "r17": [
+    "sota-privacy-compliance",
+    "sota-code-security",
+    "sota-api-design"
+   ],
+   "r18": [
+    "sota-observability",
+    "sota-architecture"
+   ],
+   "r19": [
+    "sota-threat-modeling",
+    "sota-code-security",
+    "sota-api-design"
+   ],
+   "r20": [
+    "sota-cloud-infrastructure",
+    "sota-identity-access",
+    "sota-devsecops",
+    "sota-secrets-management"
+   ]
+  }
+ }
+}

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -441,3 +441,27 @@ Each rules file is 200–310 lines. A typical focused task needs 2–5 rules fil
 a full audit pass should load one skill at a time, finish its findings, then
 move on. If context is tight, prefer the skill's top-10 non-negotiables plus
 the single most relevant rules file.
+
+## When this library is wrong or missing something
+
+These rules are maintained and measured, and they are still incomplete — the
+library has no telemetry and learns nothing from use unless someone says so.
+You are the only observer of the gap at the moment it appears.
+
+If, while applying a skill, you hit one of these, **say so in one line at the end
+of your answer** and point the user at the report path — then carry on with the
+task:
+
+- a rule contradicted by a primary source you just checked (version, spec, API,
+  advisory) — freshness rot;
+- a rule that does not fit the situation and states no exception for it;
+- real surface area in the task with **no owning skill** — a routing gap;
+- guidance that, followed literally, would have shipped a defect.
+
+Report: `https://github.com/martinholovsky/SOTA-skills/issues/new/choose`
+(bad-guidance / skill-request templates). Anything dangerous or
+security-sensitive goes to a **private advisory** instead — see `SECURITY.md`.
+
+Do not fire this for personal preference, for a rule you simply did not need, or
+mid-task. One line, at the end, only when the library actually let the user down.
+An unreported gap stays in the library for everyone.


### PR DESCRIPTION
## The problem, measured

This library has **no telemetry** — by design. That also means a wrong rule, a stale version claim, or a task with no owning skill stays in the library for everyone until a human says so.

Reality at v1.17.0, from the GitHub traffic API:

| Signal | Value |
|---|---|
| Organic clones | **~24/day** (Jul 17–19 had *zero* CI runs and show clones exactly equal to unique cloners) |
| Stars | **7** (repo created 2026-06-17) |
| Issues ever filed | **1** |
| Watchers | 0 |

Hundreds of installs; essentially zero signal back. Every efficacy fact this project has, it produced by running evals on itself.

Worth noting where that bites hardest: the frontier where **all four** audit instruments saturate (large repos, real tasks, agentic, unprompted) is exactly what those users hit daily and the harness cannot simulate.

## The fix uses a channel this project uniquely has

The user is talking to an agent that **already read the skills**. So the agent is the one observer present at the moment a gap appears.

A new short router section tells it to surface a **one-line** note when the library actually let the user down:

- a rule contradicted by a primary source it just checked (version, spec, advisory) — freshness rot
- a rule that doesn't fit and states no exception for it
- real surface area with **no owning skill** — a routing gap
- guidance that, followed literally, would have shipped a defect

…with the issue-template link, and a private-advisory route for anything security-sensitive. Explicitly **not** for personal preference, a rule that simply wasn't needed, or mid-task interruptions.

**Placement is deliberate: outside the always-apply operating principles.** Our own [context-rot finding](docs/WHY-COMPLETENESS-RESIDUAL.md) shows added text lowers the salience of what's already there, and principles 5–6 carry the measured completeness lift. This is meta-guidance about the library, not about the user's task, so it sits at the end of the router instead of competing with them.

## What was already there vs. what was missing

The issue templates (`bad-guidance`, `skill-request`), Discussions, SECURITY.md, CONTRIBUTING.md and CODE_OF_CONDUCT.md **all already existed** — I checked before assuming a gap. The reporting surface was fine. **Nothing pointed users at it.** README now has a matching section and TOC entry.

## Regression

The router grew 443 → 467 lines and the routing eval pastes it whole:

| | Before | After |
|---|---|---|
| with-library | 1.00 | **1.00** (no misses) |
| lift | +0.11 | +0.11 |

3×@0.7. Artifact: `evals/results/2026-07-20/routing-3sample-postfeedback.json`.

## Checks

```
./scripts/check-invariants.sh   → PASS (all 7)
pre-commit run --all-files      → Passed
```

## Unmeasured

Whether this actually produces reports is unknowable until it ships. It costs ~25 router lines and one README section, and the routing regression shows no measured cost. If it yields nothing in a few weeks, it should be cut rather than kept on principle.
