### PR TITLE
test(evals): the scorers produce every published number and had no tests — fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ jobs:
         env:
           SOTA_DENYLIST: ${{ secrets.SOTA_DENYLIST }}
         run: ./scripts/check-invariants.sh
+      - name: Eval scoring tests
+        # The scoring functions produce every number this project publishes. A
+        # mutation probe on 2026-07-21 replaced score() with `return 1.0` and NOTHING
+        # noticed — no test suite existed and CI never touched evals/. These golden
+        # tests are mutation-resistant (each scorer checked at 1.0, 0.0 and a partial)
+        # and were watched to fail against that exact mutation before being trusted.
+        run: python3 evals/test_scoring.py
 
   shellcheck:
     name: Shell lint (shellcheck)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,9 @@ repos:
         language: script
         pass_filenames: false
         always_run: true
+      - id: eval-scoring-tests
+        name: Eval scoring tests (the scorers produce every published number)
+        entry: python3 evals/test_scoring.py
+        language: system
+        pass_filenames: false
+        files: '^evals/.*\.py$'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The eval scoring functions now have tests — and they run in CI.** A mutation probe
+  replaced `run-clean.score()` with `return 1.0, {}` and asked what would notice:
+  `check-invariants.sh` passed, `pre-commit` passed, and scoring a deliberately wrong
+  prediction set returned **1.00**. Nothing noticed, because **there was no test suite
+  in the repo and CI never touched `evals/`** — the code producing every number this
+  project publishes (the README's +0.39, every +0.00 reported as an honest null) was
+  unverified. A scorer stuck at 1.00 would have made all of it a lie, silently: the
+  rules/10 class at its worst, in the one place it would do the most damage.
+  `evals/test_scoring.py` (plain `python3`, no new dependency) covers all three
+  scorers with **mutation-resistant** rows — each checked at 1.0, 0.0 *and* a partial
+  value, so constant-return mutations die on the 0.0 rows and swapped-metric mutations
+  die on the partials; `run-repo-audit` gets a row where category- and strict-recall
+  legitimately differ. **Both mutations were watched to fail before the tests were
+  trusted.** Wired into CI (`Eval scoring tests`) and pre-commit (on `evals/*.py`), so
+  it cannot become a test that exists but never runs.
+
 ### Changed
 
 - **Docs hygiene + harness/measurement conventions extended.** `evals/README.md`'s

--- a/evals/README.md
+++ b/evals/README.md
@@ -227,6 +227,32 @@ that measures the library. So:
   loader and every ablation aborts rather than returning silently-empty context. Both
   failure modes print a plausible `+0.00`.
 
+## The scorers are tested (and the tests are mutation-checked)
+
+`evals/test_scoring.py` — plain `python3`, no pytest — covers `run-clean.score()`,
+`run-adjudication.score()` and `run-repo-audit.score()`. It runs in **CI** and in
+**pre-commit** whenever `evals/*.py` changes.
+
+It exists because a mutation probe on 2026-07-21 replaced `run-clean.score()` with
+`return 1.0, {}` and asked what would notice:
+
+```
+check-invariants.sh   PASSES
+pre-commit            PASSES
+scoring a deliberately wrong prediction set -> 1.00
+```
+
+Nothing did. There was no test suite in the repo and CI never touched `evals/`, so the
+code producing **every number this project publishes** was unverified — a scorer stuck
+at 1.00 would have made all of it a lie, silently.
+
+The tests are deliberately mutation-resistant: each scorer is checked at **1.0, 0.0
+and a partial value**, so a constant-return mutation dies on the 0.0 rows and a
+swapped-metric mutation dies on the partial ones. `run-repo-audit` additionally has a
+row where category-recall and strict-recall legitimately differ, which fails if the
+two are ever conflated. **Both mutations were watched to fail before the tests were
+trusted.**
+
 ## Measurement conventions
 
 - **One run is a data point, not a number. Never publish from n=1.** Twice in one week

--- a/evals/test_scoring.py
+++ b/evals/test_scoring.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Golden tests for the eval harness's SCORING functions.
+
+Why this file exists — the honest version. On 2026-07-21 a mutation probe replaced
+`run-clean.score()` with `return 1.0, {}` and asked what would notice:
+
+    check-invariants.sh   PASSES
+    pre-commit            PASSES
+    scoring a deliberately wrong prediction set -> 1.00
+
+Nothing noticed. There was no test suite anywhere in the repo and CI never touched
+`evals/`, so the code that produces **every number this project publishes** — the
++0.39 in the README, every +0.00 we report as an honest null — was unverified. A
+scorer stuck at 1.00 would have made all of it a lie, silently.
+
+That is the `sota-code-security` rules/10 class at its worst: a control (the score)
+that looks like it is working because it always produces a plausible number.
+
+These tests are deliberately **mutation-resistant**: each scorer is checked against a
+perfect prediction (1.0), an empty/wrong prediction (0.0), AND a partial one. The 0.0
+cases are what kill a `return 1.0` mutation; the partial cases kill a `return 0.0` or
+a swapped-metric mutation.
+
+Plain `python3`, no pytest — so CI needs no extra dependency and this always runs.
+Usage: `python3 evals/test_scoring.py`  (exit 0 = pass, 1 = fail)
+"""
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FAILURES = []
+
+
+def load(fname, modname):
+    spec = importlib.util.spec_from_file_location(modname, os.path.join(HERE, fname))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def check(label, got, want):
+    ok = abs(got - want) < 1e-9 if isinstance(want, float) else got == want
+    if not ok:
+        FAILURES.append(f"{label}: got {got!r}, want {want!r}")
+    print(f"  {'ok  ' if ok else 'FAIL'} {label}: {got!r}")
+
+
+# --------------------------------------------------------------------------
+# run-clean.score() — set-intersection recall (routing/audit) + token match
+# --------------------------------------------------------------------------
+def test_run_clean():
+    print("run-clean.score()")
+    m = load("run-clean.py", "rc")
+    cases = [{"id": "a", "expect": ["x", "y"]}, {"id": "b", "expect": ["z"]}]
+
+    r, miss = m.score(cases, {"a": ["x", "y"], "b": ["z"]}, "routing")
+    check("perfect -> 1.0", r, 1.0)
+    check("perfect -> no misses", miss, {})
+
+    r, miss = m.score(cases, {}, "routing")
+    check("empty predictions -> 0.0", r, 0.0)          # kills `return 1.0`
+    check("empty predictions -> both missed", sorted(miss), ["a", "b"])
+
+    r, _ = m.score(cases, {"a": ["x"], "b": []}, "routing")
+    check("partial (1 of 2, 0 of 1) -> 0.25", r, 0.25)  # kills constants both ways
+
+    r, _ = m.score(cases, {"a": ["x", "y", "JUNK"], "b": ["z"]}, "routing")
+    check("extras don't reduce recall -> 1.0", r, 1.0)
+
+    fresh = [{"id": "f", "expect": ["RFC 9999"]}]
+    r, _ = m.score(fresh, {"f": "the answer is rfc 9999 today"}, "freshness")
+    check("freshness token present (case-insensitive) -> 1.0", r, 1.0)
+    r, _ = m.score(fresh, {"f": "no idea"}, "freshness")
+    check("freshness token absent -> 0.0", r, 0.0)
+
+
+# --------------------------------------------------------------------------
+# run-adjudication.score() — accuracy / sensitivity / specificity
+# --------------------------------------------------------------------------
+def test_run_adjudication():
+    print("run-adjudication.score()")
+    m = load("run-adjudication.py", "ra")
+    cases = [
+        {"id": "r1", "expect": ["UPHELD"]}, {"id": "r2", "expect": ["UPHELD"]},
+        {"id": "f1", "expect": ["REFUTED"]}, {"id": "f2", "expect": ["REFUTED"]},
+    ]
+    s = m.score(cases, {"r1": "UPHELD", "r2": "UPHELD", "f1": "REFUTED", "f2": "REFUTED"})
+    check("all correct -> accuracy 1.0", s["accuracy"], 1.0)
+    check("all correct -> sensitivity 1.0", s["sensitivity"], 1.0)
+    check("all correct -> specificity 1.0", s["specificity"], 1.0)
+
+    s = m.score(cases, {"r1": "REFUTED", "r2": "REFUTED", "f1": "UPHELD", "f2": "UPHELD"})
+    check("all wrong -> accuracy 0.0", s["accuracy"], 0.0)          # kills `return 1.0`
+
+    # An arm that refutes EVERYTHING: perfect specificity, zero sensitivity. This is
+    # the degenerate strategy the two metrics exist to expose — if it ever scores well,
+    # the scorer is broken.
+    s = m.score(cases, {c["id"]: "REFUTED" for c in cases})
+    check("refute-everything -> specificity 1.0", s["specificity"], 1.0)
+    check("refute-everything -> sensitivity 0.0", s["sensitivity"], 0.0)
+    check("refute-everything -> accuracy 0.5", s["accuracy"], 0.5)
+
+    s = m.score(cases, {"r1": "UPHELD", "r2": "UPHELD", "f1": "REFUTED", "f2": "UPHELD"})
+    check("one false-claim upheld -> specificity 0.5", s["specificity"], 0.5)
+    check("missing prediction counts as wrong",
+          m.score(cases, {"r1": "UPHELD"})["accuracy"], 0.25)
+
+
+# --------------------------------------------------------------------------
+# run-repo-audit.score()
+# --------------------------------------------------------------------------
+def test_run_repo_audit():
+    print("run-repo-audit.score()")
+    m = load("run-repo-audit.py", "rra")
+    if not hasattr(m, "score"):
+        FAILURES.append("run-repo-audit.score() not found — did it get renamed?")
+        return
+    # findings are dicts {category, file}; cases carry the `primary` files that make
+    # a hit "strict". Both recalls are checked — a mutation that collapses them into
+    # one number is caught by the row where they legitimately differ.
+    cases = [{"id": "d1", "category": "idor", "primary": ["orders.py"]},
+             {"id": "d2", "category": "ssrf", "primary": ["http_client.py"]}]
+    perfect = [{"category": "idor", "file": "app/orders.py"},
+               {"category": "ssrf", "file": "app/http_client.py"}]
+    cat, strict, _ = m.score(cases, perfect)
+    check("perfect -> category recall 1.0", cat, 1.0)
+    check("perfect -> strict recall 1.0", strict, 1.0)
+
+    cat, strict, _ = m.score(cases, [])
+    check("no findings -> category 0.0", cat, 0.0)                  # kills `return 1.0`
+    check("no findings -> strict 0.0", strict, 0.0)
+
+    cat, strict, _ = m.score(cases, [{"category": "idor", "file": "app/orders.py"}])
+    check("half -> category 0.5", cat, 0.5)
+    check("half -> strict 0.5", strict, 0.5)
+
+    # right category, WRONG file: category recall credits it, strict does not.
+    # This row is the one that fails if the two metrics are ever conflated.
+    cat, strict, _ = m.score(cases, [{"category": "idor", "file": "app/unrelated.py"},
+                                     {"category": "ssrf", "file": "app/http_client.py"}])
+    check("wrong file -> category 1.0", cat, 1.0)
+    check("wrong file -> strict 0.5", strict, 0.5)
+
+
+if __name__ == "__main__":
+    for t in (test_run_clean, test_run_adjudication, test_run_repo_audit):
+        try:
+            t()
+        except Exception as e:                       # a scorer that crashes is a failure
+            FAILURES.append(f"{t.__name__} raised {type(e).__name__}: {e}")
+            print(f"  FAIL {t.__name__} raised {type(e).__name__}: {e}")
+    print()
+    if FAILURES:
+        print(f"FAIL: {len(FAILURES)} scoring check(s) failed")
+        for f in FAILURES:
+            print(f"  - {f}")
+        sys.exit(1)
+    print("PASS: eval scoring functions behave correctly")


### PR DESCRIPTION
Closes the gap my own [self-audit](evals/results/2026-07-21/EVALS-SELF-AUDIT.md) flagged as its biggest limitation: *"no mutation probe was run against the scoring functions themselves."*

## The probe

Replaced `run-clean.score()` with `return 1.0, {}` and asked what would notice:

```
check-invariants.sh                              PASSES
pre-commit                                       PASSES
scoring a deliberately WRONG prediction set  ->  1.00
```

**Nothing noticed.** There was **no test suite anywhere in the repo**, and CI never touched `evals/`.

So the code producing **every number this project publishes** — the README's `+0.39`, every `+0.00` we report as an honest null, the competitor benchmark, the breadth study — was completely unverified. A scorer stuck at 1.00 would have made all of it a lie, silently, and the failure would have looked exactly like success.

That is the rules/10 class at its worst, sitting in the one place it would do the most damage: the thing that decides what we tell people is true.

## The fix

`evals/test_scoring.py` — plain `python3`, no new dependency, **25 checks** across `run-clean.score()`, `run-adjudication.score()`, `run-repo-audit.score()`.

Deliberately **mutation-resistant**:

| Row type | Kills |
|---|---|
| perfect prediction → 1.0 | — |
| empty/wrong prediction → **0.0** | `return 1.0` constants |
| partial → exact fraction (0.25, 0.5) | `return 0.0` constants, off-by-one |
| repo-audit: right category, **wrong file** → category 1.0, strict 0.5 | conflating the two recalls |
| adjudication: refute-everything → specificity 1.0, sensitivity **0.0** | the degenerate strategy the two metrics exist to expose |

**Both mutations were watched to fail** before the tests were trusted, then the tree restored:

```
--- mutated run-clean.py -> constant-perfect scorer ---
  TESTS FAILED — mutation caught ✓
--- mutated run-adjudication.py -> constant-perfect scorer ---
  TESTS FAILED — mutation caught ✓
```

## Wired so it actually runs

- **CI**: new `Eval scoring tests` step in the invariants job.
- **pre-commit**: runs whenever `evals/*.py` changes.

A test that exists but never runs is the same failure in a different coat — this week produced six of those, so it gets a gate, not a convention.

## Process note

My first fixture assumed the wrong `run-repo-audit.score()` signature and the test errored. Per rules/10 §5 I **checked the fixture before concluding the code was broken** — the code was right, my fixture was wrong. Worth recording because that rule exists precisely for this moment.

## Checks

```
./scripts/check-invariants.sh   → PASS (all 7)
pre-commit run --all-files      → Passed (incl. the new hook)
python3 evals/test_scoring.py   → PASS (25 checks)
```
