### PR TITLE
docs: fix stale silent-failure counts; consolidate the audit-null result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shipped-artifact gaps) rather than padded. Report:
   [`evals/results/2026-07-21/EVALS-SELF-AUDIT.md`](evals/results/2026-07-21/EVALS-SELF-AUDIT.md).
 
+### Changed
+
+- **Doc hygiene: stale silent-failure counts corrected and the audit-null story
+  consolidated.** `evals/README.md` still said "41 positives + 8 negative controls"
+  (doubly stale — the set is 61 positives + 20 negatives at 81 cases); fixed, and the
+  +0.00 result annotated as reproduced at n=49/69/81. The `RESULTS.md` scoreboard row
+  moved 49 → 81 cases, and a new paragraph states the audit-family result plainly in
+  one place for the first time: **all four audit-ability rows are +0.00** (recall,
+  cross-file, silent-control, precision), every apparent subgroup exception dissolved
+  when its subgroup grew, and the library's audit half is justified by gap analysis
+  plus one real self-audit — **not by a measured lift**. The measured lift lives
+  entirely in BUILD (completeness +0.39, freshness +0.53).
+
 ## [1.18.0] - 2026-07-21
 
 The **learning-from-use** release. Ships the library's first path for hearing from its

--- a/evals/README.md
+++ b/evals/README.md
@@ -40,15 +40,15 @@ audit STRAT-HIGH-2).
 - `cases/silent-failure.jsonl` (81) — a control that **looks enabled and does
   nothing** (inert scanner, fail-open policy, ruleset that loads zero rules,
   truncation before inspection, a test that passes against a no-op'd body …) →
-  the mechanism by which it is inert. 41 positives + **8 negative controls** whose
-  correct answer is "not silent" (the control fails loudly), so an arm that cries
+  the mechanism by which it is inert. 61 positives (35 enumerated + **26 tagged
+  `novel`**, mechanisms `sota-code-security` rules/10 does *not* enumerate — which
+  separates "teaches the lens" from "recites its own list") + **20 negative controls**
+  whose correct answer is "not silent" (the control fails loudly), so an arm that cries
   no-op at everything cannot score 1.00 — each negative deliberately *resembles* a
-  positive class, so shape-matching trips; **26 positives are tagged `novel`** —
-  mechanisms `sota-code-security` rules/10 does *not* enumerate, which separates
-  "teaches the lens" from "recites its own list". Two designs: `run-clean.py`
+  positive class, so shape-matching trips. Two designs: `run-clean.py`
   (vocabulary given — classification) and `run-silent-open.py` (free-form, blind
   opus judge — discovery), both with an `--ablate` arm that removes rules/10.
-  Result: **+0.00 — no measurable lift**, reproduced at n=49 and again at n=69.
+  Result: **+0.00 — no measurable lift**, reproduced at n=49, n=69 and n=81.
   An earlier **+0.07 from a 15-case version did not replicate and is retracted**.
   The `novel` subgroup was grown 6 → 26 to test whether the enumerated catalogue
   *anchors* the model onto its own list: **it does not** (0.96 unguided vs 0.92

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -15,7 +15,7 @@ Same model, same task, library loaded vs. nothing.
 | **Completeness** (7 build tasks) | 0.59 | **0.98** | **+0.39** | 2 runs × 3, temp 0.7 | [MIRROR-VERIFICATION](2026-07-20/MIRROR-VERIFICATION.md) |
 | **Freshness** (32 current-2026 facts) | 0.44 | **0.97** | **+0.53** | 3×, temp 0.7 | [MULTI-SAMPLE](2026-07-13/MULTI-SAMPLE.md) |
 | Routing (20 tasks) | 0.90 | **1.00** | **+0.10** | 3×, temp 0.7 | [MULTI-SAMPLE](2026-07-13/MULTI-SAMPLE.md) |
-| Silent-control detection (49 inert-control cases) | 0.94 | 0.93 | +0.00 | 5×, temp 1.0 | [SILENT-FAILURE](2026-07-20/SILENT-FAILURE.md) |
+| Silent-control detection (81 inert-control cases) | 0.91 | 0.93 | +0.00 | 3×, temp 0.7 | [SILENT-FAILURE](2026-07-20/SILENT-FAILURE.md) |
 | Audit **precision** (30 claims, 15 false) | 1.00 | 1.00 | +0.00 | 3×, temp 0.7 | [AUDIT-PROCESS](2026-07-20/AUDIT-PROCESS.md) |
 | Audit (14 hard snippets) | 1.00 | 1.00 | +0.00 | 1× | [BASELINE](2026-07-10/BASELINE.md) |
 | Cross-file audit (8-defect repo) | 1.00 | 1.00 | +0.00 | 2 models | [REPO-AUDIT](2026-07-13/REPO-AUDIT.md) |
@@ -43,6 +43,21 @@ is all in the unguided arm. Audit is +0.00 and reported, not hidden — a capabl
 model already recognizes vulnerabilities, even cross-file when the repo fits in
 context. The real remaining audit frontier is an **agentic large-repo** audit
 (too big to hold at once); logged in the [roadmap](../../docs/ROADMAP.md).
+
+**The audit-family result, stated plainly (2026-07-21).** All four rows above that
+score audit ability sit at **+0.00**: audit-hard recall, cross-file repo audit,
+silent-control detection (n=81), and audit precision. Across *recall and precision*,
+a frontier model handed the code and the question does not need the library — and
+**every subgroup signal that looked like an exception dissolved when its subgroup
+grew** (taxonomy-anchoring 6→26, over-flagging of loud controls 8→20). This is not
+"the audit content is worthless": it is "no single-prompt eval can distinguish
+audit-*process* guidance, because when the code and the question both fit one prompt
+the model is already at ceiling." The library's audit half is currently justified by
+gap analysis and one real-world self-audit that found two genuine defects in the
+harness ([EVALS-SELF-AUDIT](2026-07-21/EVALS-SELF-AUDIT.md)) — **not by a measured
+lift**, and that is stated rather than implied. The only design that could move it is
+the agentic large-repo audit. The measured lift lives entirely in **BUILD**
+(completeness +0.39, freshness +0.53).
 
 **Retraction (2026-07-20).** This row first shipped as **0.92 → 0.99 (+0.07)**
 from a 15-case set. Growing the set to **49** — adding harder cases that broke the


### PR DESCRIPTION
Doc hygiene from the current session.

- `evals/README.md` said **"41 positives + 8 negative controls"** — doubly stale (the set is 61 positives + 20 negatives at 81 cases). Fixed; +0.00 annotated as reproduced at n=49/69/81.
- `RESULTS.md` scoreboard silent-control row: 49 → **81** cases.
- **New `RESULTS.md` paragraph** stating the audit-family result plainly for the first time: all four audit-ability rows are **+0.00** (recall, cross-file, silent-control, precision); every apparent subgroup exception dissolved when grown (anchoring 6→26, over-flagging 8→20); the audit half is justified by gap analysis + one real self-audit, **not a measured lift**. The measured lift lives entirely in BUILD.

```
./scripts/check-invariants.sh   → PASS
pre-commit run --all-files      → Passed
```
