### PR TITLE
docs(readme): lead the hero with the measured lift + the loop, not the volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plus one real self-audit — **not by a measured lift**. The measured lift lives
   entirely in BUILD (completeness +0.39, freshness +0.53).
 
+### Changed
+
+- **README hero re-led with the measured lift and the *loop*, not the volume.** The
+  opening had led with "41 skills (296 files, ~60k lines)" — which reads as exactly
+  the prompt-dump this library outperforms. It now opens with the proven result
+  (best-practice coverage **~59% → ~98%, +0.39**, from a bare "build X" prompt, linked
+  to the scoreboard) and the one-line mechanism that differentiates it — *a loop, not a
+  prompt dump: route lean, re-state every turn, re-check last*. The volume figure moves
+  to a supporting "under the hood" line (kept intact for invariant 6). A distribution
+  move, not a content one: ~500 unique cloners/14 days were converting to 7 stars, and
+  the hero was selling the wrong thing.
+
 ## [1.18.0] - 2026-07-21
 
 The **learning-from-use** release. Ships the library's first path for hearing from its

--- a/README.md
+++ b/README.md
@@ -14,11 +14,21 @@
 
 **Make your AI coding assistant build and audit like your most senior engineer.**
 
-Your assistant is brilliant — it just doesn't know your standards. SOTA-skills teaches
-it: 41 skills (296 files, ~60k lines) encoding state-of-the-art 2026 practices for
-building **and** auditing software, fast-moving claims web-verified against primary
-sources. Native on Claude Code; works with Gemini CLI, Codex, and any agent that reads
-`AGENTS.md`. Every file stays under 500 lines, so the right rules load when needed.
+Your assistant is brilliant — it just doesn't know your standards, and it forgets the
+ones it does know as the task grows long. SOTA-skills fixes both, and the fix is
+**measured**: from a bare "build X" prompt, best-practice coverage climbs from **~59%
+to ~98% (+0.39)** — the model stops silently dropping tests, rate limiting, structured
+logging, and TLS ([see every number →](evals/results/RESULTS.md)).
+
+It works by being a **loop, not a prompt dump**: route in only the rules a task needs,
+re-state them every turn, and re-check them *last* before shipping — so the guidance
+survives a long context instead of fading into it. That's why it beats a bigger prompt
+instead of becoming one. Native on Claude Code; works with Gemini CLI, Codex, and any
+agent that reads `AGENTS.md`.
+
+Under the hood: **41 skills (296 files, ~60k lines)** of state-of-the-art 2026
+practice, each file under 500 lines so only the matching rules load, every fast-moving
+claim web-verified against a primary source.
 
 Two commands to install:
 


### PR DESCRIPTION
**Item 1 of the distribution push.** The bottleneck isn't the content — it's that ~500 unique cloners in 14 days convert to **7 stars**, and the README hero was selling the wrong thing.

## Before

Opened with *"41 skills (296 files, ~60k lines) encoding state-of-the-art 2026 practices…"* — which reads as **exactly the prompt-dump this library outperforms**. Volume-first framing invites the "another giant rules file" dismissal.

## After

Leads with the **proven result** and the **mechanism**:

- Best-practice coverage **~59% → ~98% (+0.39)** from a bare "build X" prompt, linked to the scoreboard.
- One-line differentiator: *a **loop**, not a prompt dump — route lean, re-state every turn, re-check last, so guidance survives a long context instead of fading into it.*
- Volume ("41 skills…") demoted to a supporting "under the hood" line.

## Validation

- **Invariant 6** (count-bearing surfaces) — the exact phrase `41 skills (296 files, ~60k lines)` is preserved verbatim, just relocated; check runs green.
- The `~59% → ~98% / +0.39` numbers **match `RESULTS.md` (0.59 → 0.98)** exactly, and the README's own "Measured" section (line 101) already carries the same figures — no internal contradiction.

```
./scripts/check-invariants.sh   → PASS (all 7)
pre-commit run --all-files      → Passed
```

Paired with the architecture infographic (separate deliverable) as the distribution set. Content unchanged; this is positioning only.
