### PR TITLE
feat(skills): adopt 3 swarm-forge ideas — testability boundary, mutation baseline, complexity-ranked coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`sota-architecture` rules/02 §14 — the testability boundary (humble
+  object).** Every system has a shell automated tests cannot drive (GUI,
+  devices, real clocks/networks, process spawn); draw that boundary explicitly
+  in the build, keep it thin, allow it no business branching, and measure
+  coverage/mutation/complexity against the core only. Includes the corollary
+  that a *growing* shell is an architecture finding, not a testing one. Two
+  checklist items added. The library had hexagonal ports/adapters (§4) and the
+  generated/vendored coverage exclusion, but nothing connecting them — a
+  `grep` for `humble object|near IO|adapter shell|untestable` across
+  `sota-architecture` and `sota-testing` returned zero hits.
+- **`sota-testing` rules/06 §6.3 — mutation survivor baselines.** Persist the
+  survivor set and gate CI on *new* survivors (the mutation analogue of the
+  coverage ratchet) instead of an absolute score, under two conditions: the
+  mutation engine version is pinned beside the baseline (engines change
+  operator sets between releases, so an unpinned diff attributes tool churn to
+  your code), and only the tool writes the file (a hand-edited baseline is a
+  live survivor marked dead). Checklist item added.
+- **`sota-testing` rules/07 §7.2 — rank coverage gaps by complexity.** Cross
+  coverage with branch density to aim the next test and the next mutation run;
+  a branch-dense thinly-covered module outranks a 3-line getter at 0%. Stated
+  as a pointer, never a gate, so it does not become the Goodhart target that
+  §7.2 already warns coverage thresholds are. Two checklist items added, one
+  of them tying the measured scope back to the rules/02 §14 boundary.
+
+### Changed
+
+- **`docs/ADOPTION-LOG.md`** — second entry: three ideas adopted from
+  [swarm-forge](https://github.com/unclebob/swarm-forge) (read at source level
+  on `main`, `six-pack`, and `adversaries`), one recorded as `rejected:
+  contrary` (its resolve-at-latest tool policy, which also breaks its own
+  mutation baseline — none of the seven tool repos carries a tag, verified via
+  the GitHub API), and **six convergences** recorded as `rejected: already
+  ours` with the file:line that covers each. All three adoptions are reasoned,
+  **not measured** — the entry says so explicitly and forbids citing a lift.
+
 ## [1.19.1] - 2026-07-24
 
 The **adopt-what-we-verified** release: five ideas mined from an external repo

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -40,6 +40,11 @@ lessons-log — its own best structural idea, applied to ourselves.
 | 2026-07-24 | training-knowledge-vault lessons-log loop | A locked, triaged, commit-tracked ledger for turning observations into curated changes | **adopted (as this file)** | `docs/ADOPTION-LOG.md` · v1.19.1 |
 | 2026-07-24 | training-knowledge-vault (structure) | Per-file `volatility`, stable `id`s, personas, prompts, sessions, model-map | **rejected: non-fit** | — |
 | 2026-07-24 | training-knowledge-vault (convergent) | `AGENTS.md` + tool adapters; nav-parity CI check; "encode the lesson as a check"; system-prompt token budgeting | **rejected: already ours** | — |
+| 2026-07-24 | [swarm-forge](https://github.com/unclebob/swarm-forge) `engineering.prompt` | Separate the testable core from the environment-bound shell; only the core participates in coverage/mutation/complexity tooling | **adopted** | `sota-architecture/rules/02` §14 · unreleased |
+| 2026-07-24 | swarm-forge `hardender.prompt` | Differential mutation against a persisted manifest — gate on new survivors, not an absolute score | **adopted** | `sota-testing/rules/06` §6.3 · unreleased |
+| 2026-07-24 | swarm-forge `crap4go`/`crap4clj` tools | Complexity × coverage composite to rank where the next test belongs | **adopted** | `sota-testing/rules/07` §7.2 · unreleased |
+| 2026-07-24 | swarm-forge (convergent) | Scoped/diff mutation; mutation as a control probe; read survivors don't average; reviewer must not modify audited code; heartbeat on long runs; verify the other role ran the tool | **rejected: already ours** | — |
+| 2026-07-24 | swarm-forge `engineering.prompt` Startup Tools | Resolve every tool at latest upstream each run; never reuse cached/vendored copies | **rejected: contrary** | — |
 
 ## Entries
 
@@ -101,3 +106,92 @@ symlinks), the nav-parity check (≈ our invariant 7 router-drift), "encode the
 lesson as a new check" (≈ our per-audit new-invariant practice), and treating the
 always-loaded context file as a token budget (≈ our incremental-loading thesis in
 [CONTEXT-MANAGEMENT.md](CONTEXT-MANAGEMENT.md)).
+
+### 2026-07-24 — swarm-forge (unclebob), three adoptions
+
+Source: <https://github.com/unclebob/swarm-forge>, read at the source level on
+2026-07-24 — `main` (documentary branch: shared constitution articles plus the
+tmux/worktree orchestration scripts) and the runnable `six-pack` and
+`adversaries` branches (role prompts). It is a **harness**: tmux session and git
+worktree per role, a handoff daemon between agent inboxes, and a layered
+"constitution" of `.prompt` files that agents are instructed to obey. Its
+engineering content is thin by design — `engineering.prompt` is 45 lines and
+`local-engineering.prompt` on `six-pack` is 5 — so the overlap with this library
+is narrow but sharp where it exists.
+
+1. **The testability boundary** *(adopted → `sota-architecture/rules/02` §14)*.
+   `engineering.prompt:22-23` separates testable modules from ones that are
+   "environmentally unsuitable" (GUI, external devices, hangs under automation),
+   directs that the unsuitable region be minimized, and lets **only** testable
+   modules participate in coverage, mutation, and complexity tooling.
+   **Verified gap:** `grep -rni "humble object|near IO|adapter shell|untestable"`
+   over `skills/sota-architecture/rules/*` and `skills/sota-testing/` returned
+   **zero hits**. We had hexagonal ports/adapters (rules/02 §4) and the
+   generated/vendored coverage exclusion (`sota-testing/rules/07:81`) but not the
+   humble-object pattern that connects them — the design rule that makes every
+   test metric interpretable. Landed as an explicit, machine-readable core/shell
+   split with a shell-growth-is-an-architecture-finding clause, cross-referenced
+   from both testing rules.
+
+2. **Differential mutation against a manifest** *(adopted →
+   `sota-testing/rules/06` §6.3)*. `hardender.prompt` always runs mutation
+   differentially against a persisted manifest rather than scoring from scratch.
+   **Verified partial gap:** rules/06:153 already had "scoped, not global — run
+   on the diff", and the survivors-are-findings triage; the *baseline* mechanism
+   that turns those into a CI gate on **new survivors only** (the mutation
+   analogue of our coverage ratchet) was absent. Adopted with two conditions the
+   source repo itself demonstrates the need for: pin the mutation engine beside
+   the baseline, and never hand-edit it.
+
+   The pinning condition is a live defect in the source. `engineering.prompt:4-6`
+   instructs every role to resolve each tool at "latest available upstream" at
+   its own startup and explicitly **not** to reuse cached or vendored copies, and
+   none of the seven tool repos (`mutate4go`, `crap4go`, `dry4go`, `clj-mutate`,
+   `crap4clj`, `dry4clj`, `Acceptance-Pipeline-Specification`) carries a single
+   tag — verified via the GitHub API on 2026-07-24 — so "latest" is whatever HEAD
+   is at that moment. Roles that start hours apart in one swarm can therefore diff
+   a manifest across engine versions. Our rule states the invariant his prompt
+   omits; his install policy is recorded below as `rejected: contrary`.
+
+3. **Complexity × coverage composite** *(adopted → `sota-testing/rules/07`
+   §7.2)*. His `crap4*` tools compute the CRAP-style composite (complexity
+   weighted by how little of it is verified). **Verified gap:** cyclomatic
+   complexity appeared once in the tree, at `sota-testing/rules/01:124`, as one
+   input to a risk heuristic — nothing crossed it with coverage to *rank* where
+   the next test belongs, which is the question rules/06 previously answered as
+   "highest-risk modules". Adopted as a pointer for aiming mutation and review
+   effort, explicitly not as a gate (it would Goodhart exactly like a coverage
+   threshold).
+
+**Rejected: contrary.** The Startup Tools policy — resolve every tool at latest
+upstream on each run, never reuse cached, vendored, or preinstalled copies — is
+the inverse of `sota-devsecops` pinning and provenance guidance, and it is what
+breaks the differential baseline in item 2. Recorded so the idea is not
+re-litigated from the same source.
+
+**Rejected: already ours (six convergences).** Scoped/diff mutation
+(`sota-testing/rules/06:153`); mutation as a control probe (`rules/06:158` plus
+`sota-code-security/rules/10` §3, where ours additionally names the two traps
+that make a green run lie); read survivors rather than average them
+(`rules/06:180`); the reviewer must not modify the code under review
+(`sota/rules/01-audit-methodology.md:342` §9, "read-only by default", which also
+covers secret redaction and the re-audit loop his `reviewer.prompt` has no
+equivalent of); a heartbeat on long-running verification so a hang is
+distinguishable from work (`sota-shell-scripting/rules/04:147`); and checking
+that the upstream role actually ran the tool or justified skipping it
+(principle 6, evidence completion). Independent arrival at six of our rules from
+a completely different starting point is validation — no diff manufactured.
+
+**Not surfaced as candidates:** the role topology and file-based handoff protocol
+(orchestration, not rules), the Gherkin/APS acceptance pipeline (specific to the
+author's own tool repos), and the per-role commit byline. Also noted, not
+adopted: the constitution's dimensions are entirely internal-quality — mutation,
+complexity, duplication, coverage, dependency direction — with no security,
+privacy, or operability content anywhere in the articles or role prompts. That is
+a scope choice for a harness whose users supply their own project rules, and it
+is precisely the axis this library covers; it implies no change here.
+
+**Measurement status:** all three are content refinements adopted on reasoning,
+**not measured**. Do not cite a lift for them. The testability-boundary rule is
+the only one with a plausible claim to changing generated code; if a future
+eval round has spare budget, it is the one worth a completeness case.

--- a/skills/sota-architecture/rules/02-domain-modeling-and-boundaries.md
+++ b/skills/sota-architecture/rules/02-domain-modeling-and-boundaries.md
@@ -221,6 +221,48 @@ responsibility and its key invariants. If the sentence needs "and", consider
 splitting; if two contexts' sentences keep mentioning each other, consider
 merging or formalizing the seam (customer/supplier with a contract).
 
+## 14. The testability boundary (humble object)
+
+**Rule:** Every system has a shell that automated tests cannot meaningfully
+drive — GUI and rendering, external devices, real clocks and networks, process
+spawning, anything that opens a window, needs a display, or hangs without one.
+Draw that boundary **explicitly** and keep the shell **thin**: all decisions
+move inward to the testable core, and the shell degenerates into a translator
+with no branches worth asserting (the "humble object"). This is §4's adapter
+rule stated as a testability constraint rather than a dependency one.
+
+**Rule:** No business `if` in the shell. A conditional, loop, or calculation in
+a UI callback, device driver wrapper, or CLI entrypoint is logic that has
+escaped the core — move it in and leave a call behind.
+
+**Rule:** Make the boundary **machine-readable** — a package/module split the
+build understands, not a convention in someone's head. Coverage, mutation, and
+complexity tooling then measure the core only. Measuring the untestable shell
+distorts every number in both directions and buries the signal (see
+`sota-testing` rules/07 §7.2 and rules/06 §6.3).
+
+**Rationale:** this is the precondition for any test metric meaning anything.
+"62% coverage" over a codebase where a third is an untestable UI shell is not
+a number, it's noise; the same 62% over an explicitly bounded core is a signal
+you can act on. Teams that skip this step end up either gaming the metric or
+disbelieving it — and disbelieving it is the more expensive outcome.
+
+```text
+BAD:  render_invoice_row(inv):          # in the view layer
+        if inv.total > credit_limit and not inv.customer.is_exempt:
+          badge = "OVER LIMIT"          # a business rule, untestable without a UI
+
+GOOD: core:  invoice.limit_status(customer) -> OverLimit | Ok   # unit-tested
+      shell: render_invoice_row(inv) -> badge_for(inv.limit_status(cust))
+             # no branch of its own; one smoke test proves it is wired
+```
+
+**Rule:** The shell still needs *some* verification — a small number of
+end-to-end or smoke tests that prove it is wired up (`sota-testing` rules/05),
+not unit metrics. And treat shell growth as an **architecture** finding: if the
+untestable region keeps expanding, logic is leaking outward, and no amount of
+test discipline will reach it.
+
 ## Audit checklist
 
 - Can the team produce a context map? Are seam relationship types (ACL, conformist, published language) explicit?
@@ -240,3 +282,5 @@ merging or formalizing the seam (customer/supplier with a contract).
 - Do list/dashboard reads go through dedicated read models, or do they load aggregates in bulk?
 - Do any write decisions consume read-model/projection data instead of loading the aggregate?
 - Are services/modules named after capabilities or after entities (noun-services)?
+- Is the boundary between the testable core and the environment-bound shell (GUI, device, IO, process spawn) explicit in the build, or only in convention? Does business branching live in that shell?
+- Does the shell keep growing release over release (logic leaking outward), and do coverage/mutation/complexity tools measure the core or the whole tree?

--- a/skills/sota-testing/rules/06-property-fuzzing-mutation.md
+++ b/skills/sota-testing/rules/06-property-fuzzing-mutation.md
@@ -181,6 +181,17 @@ calculate_interest.py:41  mutated `<` -> `<=`   SURVIVED
   `calculate_interest` is a finding; ten in a logging shim are noise. Triage
   like bug reports: kill (add the missing assertion), suppress-with-reason
   (equivalent/dont-care), or accept (documented untested zone).
+- **Baseline the survivors so runs are diffable.** An absolute score is a bad
+  gate for the same reason a global coverage target is (rules/07 §7.2). Persist
+  the current survivor set as a checked-in baseline and fail CI only on *new*
+  survivors — the mutation analogue of a coverage ratchet, and what makes a
+  minutes-long scoped run gate-worthy. Two conditions keep the diff honest:
+  **pin the mutation engine version** next to the baseline (engines change their
+  operator sets between releases; a baseline compared across versions attributes
+  tool churn to your code, and re-baselining is then a deliberate step in the
+  upgrade), and **let only the tool write it** — a hand-edited baseline is a live
+  survivor marked dead, the same manufactured safety as an assertion-free test
+  (rules/02 §2.7).
 - Trend per-module mutation score on risk-critical code; a *drop* is the
   signal (new code arriving with weaker tests), the absolute number less so.
 
@@ -240,6 +251,10 @@ into the CI test suite.
 - [ ] Mutation score gamed? Tests asserting incidental internals near
       mutation-config thresholds, blanket mutant suppressions without reasons
       → High.
+- [ ] If a survivor baseline/manifest gates CI: is the mutation engine version
+      pinned beside it, and is the file tool-generated? Unpinned engine → Low
+      (diff attributes tool churn to code); hand-edited entries (check
+      `git log -p` for manual edits) → High (live survivors marked dead).
 - [ ] Approval/golden suites: do they have an owner and a retirement plan, or
       are 3-year-old approvals still the only tests on refactored code →
       Medium (frozen bugs).

--- a/skills/sota-testing/rules/07-suite-health-and-ci.md
+++ b/skills/sota-testing/rules/07-suite-health-and-ci.md
@@ -79,7 +79,18 @@ GOOD: diff-coverage: changed lines >= 85% branch coverage   AND
       (stored number auto-raises; lowering it requires a reviewed commit)
 ```
 - Exclude generated/vendored code from measurement; measuring it inflates
-  the number and buries the signal.
+  the number and buries the signal. Same for the environment-bound shell that
+  unit tests cannot drive (GUI, device, process-spawn adapters) — but the fix
+  there is architectural: make that boundary explicit and keep it thin
+  (`sota-architecture` rules/02 §14), then measure the core.
+- **Rank the gaps by risk, not by size of deficit.** Coverage alone cannot say
+  where the next test belongs. Cross it with complexity: a module that is both
+  **branch-dense and thinly covered** is the highest-value target, and the
+  composite (complexity weighted by how little of it is verified) ranks work
+  better than either number alone. A 200-branch payment router at 50% is a
+  finding; a 3-line getter at 0% is not. Use the ranking to aim mutation runs
+  (`rules/06` §6.3) and review attention — as a *pointer*, never as a gate,
+  or it becomes the same Goodhart target as a coverage threshold.
 - Reporting coverage in PRs: show the uncovered lines, not just the delta
   percentage — reviewers act on lines, not numbers.
 
@@ -187,6 +198,15 @@ A red main/merge-queue is a site incident for the team's delivery:
       trivial code) → Medium; ratchet/diff-coverage instead → good.
 - [ ] Is generated/vendored code excluded from coverage? Check coverage
       config excludes vs `*_pb2.py|.pb.go|generated|vendor` → Low.
+- [ ] Does the measured scope match the testable core, or does an
+      environment-bound shell (UI, device, process-spawn adapters) sit in the
+      denominator? Whole-tree measurement with an untestable region →
+      Low–Medium (the number is noise; fix the boundary, `sota-architecture`
+      rules/02 §14).
+- [ ] Are coverage gaps prioritized against complexity (branch-dense +
+      thinly-covered first), or is the backlog being worked by whatever moves
+      the percentage fastest (trivial modules) → Medium (effort aimed at the
+      metric, not the risk).
 - [ ] Pipeline timing: PR wall-clock now vs 6 months ago (CI history). >15
       min and growing with no sharding/selection plan → Medium.
 - [ ] Slowest tests known? Runner timing reports enabled and reviewed? No


### PR DESCRIPTION
Mined [unclebob/swarm-forge](https://github.com/unclebob/swarm-forge) for ideas worth taking, using the `docs/ADOPTION-LOG.md` discipline: read the candidate home file and confirm the idea is genuinely absent before adopting, and cite the covering `file:line` for anything rejected as already-covered.

Sources read at source level on 2026-07-24: `main` (shared constitution articles + tmux/worktree orchestration), plus the runnable `six-pack` and `adversaries` branches (role prompts). It is a harness with a deliberately thin content layer — `engineering.prompt` is 45 lines — so the overlap is narrow but sharp where it exists.

## Adopted (3)

**1. `sota-architecture` rules/02 §14 — the testability boundary (humble object).**
Separate the testable core from the environment-bound shell (GUI, devices, real clocks/networks, process spawn); make the split machine-readable in the build, allow the shell no business branching, and measure coverage/mutation/complexity against the core only. Includes the corollary that a *growing* shell is an architecture finding, not a testing one.

Verified gap: `grep -rni "humble object|near IO|adapter shell|untestable"` across `skills/sota-architecture/rules/*` and `skills/sota-testing/` returned **zero hits**. We had hexagonal ports/adapters (§4) and the generated/vendored coverage exclusion (`rules/07:81`), but nothing connecting them — the design rule that makes every test metric interpretable.

**2. `sota-testing` rules/06 §6.3 — mutation survivor baselines.**
Persist the survivor set and gate CI on *new* survivors (the mutation analogue of our coverage ratchet) instead of an absolute score, under two conditions: pin the mutation engine beside the baseline, and let only the tool write the file.

The pinning condition is a live defect in the source repo, which is what makes it worth stating as a rule: its `engineering.prompt` directs every role to resolve each tool at "latest available upstream" at its own startup and to refuse cached copies, while **none of its seven tool repos carries a single tag** (verified via the GitHub API). Roles starting hours apart in one swarm can diff a manifest across engine versions.

**3. `sota-testing` rules/07 §7.2 — rank coverage gaps by complexity.**
Cross coverage with branch density to aim the next test and the next mutation run. A 200-branch payment router at 50% is a finding; a 3-line getter at 0% is not. Stated as a pointer, never a gate — as a gate it Goodharts exactly like the coverage threshold the same section already warns against. Previously cyclomatic complexity appeared once in the whole tree (`rules/01:124`) and was never crossed with coverage.

## Rejected: contrary (1)

The Startup Tools policy — resolve every tool at latest upstream each run, never reuse cached/vendored copies — is the inverse of `sota-devsecops` pinning and provenance guidance, and it is what breaks its own differential baseline. Recorded so it is not re-litigated from the same source.

## Rejected: already ours (6 convergences)

Scoped/diff mutation (`rules/06:153`) · mutation as a control probe (`rules/06:158` + `sota-code-security/rules/10` §3, where ours also names the two traps that make a green run lie) · read survivors don't average them (`rules/06:180`) · reviewer must not modify the audited code (`sota/rules/01-audit-methodology.md:342` §9) · heartbeat on long runs (`sota-shell-scripting/rules/04:147`) · verify the upstream role actually ran the tool (principle 6). Independent arrival at six of our rules from a different starting point is validation; no diff manufactured.

## Measurement status

All three adoptions are reasoned, **not measured**. The log entry says so and forbids citing a lift. The testability-boundary rule is the only one with a plausible claim to changing generated code — flagged in the log as the candidate if a future eval round has budget.

## Checks

- `./scripts/check-invariants.sh` — all 8 pass
- `pre-commit run --all-files` — gitleaks, invariants, eval scoring tests all pass
- No skill added (41 unchanged); no router or count surface touched
