### PR TITLE
docs(releasing): stamp ADOPTION-LOG "Landed in" versions at release cut

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,6 +11,7 @@ lands through a PR — `main` is protected for everyone, including admins (see
 |---|---|
 | `VERSION` | the new semver, single line |
 | `.claude-plugin/plugin.json` | `"version"`; also the skill/domain counts in `"description"` if they changed |
+| `docs/ADOPTION-LOG.md` | any `adopted` row whose **Landed in** cell still says `unreleased` gets the shipping version — `grep -n '· unreleased' docs/ADOPTION-LOG.md`, replace each with `vX.Y.Z`. Adoptions land in ordinary PRs between releases, so the version isn't knowable when the entry is written; nothing in CI catches a stale marker (it's prose), which is exactly why it's on this list |
 | `CHANGELOG.md` | new `## [X.Y.Z] - YYYY-MM-DD` section at the top **and** a `[X.Y.Z]: …/releases/tag/vX.Y.Z` link ref at the bottom (top entry = current version — no `[Unreleased]` left behind). CHANGELOG is **no longer line-capped** (the 500-line invariant is skill-files-only since 2026-07-15), so archiving old releases is now **optional hygiene** for navigability, not forced: when the root gets long, you *may* move the oldest sections **and their link refs** into the newest `docs/CHANGELOG-archive*.md` (headings and `[X.Y.Z]:` refs must stay in the same file) |
 
 ## 2. Count-bearing surfaces (when the skill count changes)
@@ -72,6 +73,9 @@ skills.
 - [ ] `./scripts/check-invariants.sh` passes
 - [ ] `VERSION` == `plugin.json` version == the tag you're about to push
 - [ ] CHANGELOG top entry is the new version, dated, with its link ref
+- [ ] `grep -n '· unreleased' docs/ADOPTION-LOG.md` returns nothing — every
+      adopted row carries the version it shipped in (match the `· ` separator,
+      not the bare word: the file's own conventions section says "unreleased")
 - [ ] If the skill count changed: README badge/hero, router body +
       description, plugin/marketplace.json show the recounted numbers
       (the social-preview pill + README alt are "N+" floors — touch them

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -24,7 +24,9 @@ lessons-log — its own best structural idea, applied to ourselves.
 - **Landed-in pointer, not a promise.** An `adopted` entry names the concrete
   change (rule file + section, or script + check) and the release it shipped in.
   This is the commit-hash-on-apply idea from the source vault, expressed as our
-  version + PR rather than a bare hash.
+  version + PR rather than a bare hash. Adoptions land between releases, so write
+  `unreleased` when the version isn't known yet — the release cut greps for that
+  word and stamps it ([RELEASING.md](../RELEASING.md) §1).
 - **Convergent ≠ adopted.** When an external repo independently arrives at
   something we already do, record it as `rejected: already ours` — it is
   validation, not a change. Do not manufacture a diff to "adopt" it.


### PR DESCRIPTION
Follow-up to #137. The three adopted rows in `docs/ADOPTION-LOG.md` say `unreleased` in their **Landed in** cell, because adoptions land in ordinary PRs and the shipping version isn't knowable at write time. Nothing in CI catches a stale marker — invariant 8 resolves links, and the cell is prose — so this goes on the release runbook instead.

## Changes

- **`RELEASING.md` §1** — new row in the version-bearing files table, with the reason it's there rather than in CI.
- **`RELEASING.md` pre-tag checklist** — a grep that must return nothing before tagging.
- **`docs/ADOPTION-LOG.md` conventions** — documents `unreleased` as the placeholder the release cut looks for, linking back to `RELEASING.md` so the convention is discoverable from either end.

## One detail worth noting

The grep matches the `· unreleased` table-cell marker, not the bare word. The obvious version (`grep -n unreleased`) would match the conventions sentence that *names* the placeholder, so the check would never pass — a self-defeating checklist item. Verified the tightened pattern returns exactly 3 matches, the 3 rows from #137.

`./scripts/check-invariants.sh` and `pre-commit run` pass.
