### PR TITLE
feat(skills): adopt 3 claude-project-scaffold ideas + the day-zero gap it exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Third intake pass, against
+[claude-project-scaffold](https://github.com/martinholovsky/claude-project-scaffold)
+— an agent-context scaffolder, not a repo scaffolder. Most of its content turned
+out to be ours already (the minimal-agent-file principle, the context-rot
+rationale, the ADR format), recorded as convergences. Three ideas were genuinely
+absent and landed; the gap the source *didn't* cover — that a fresh repo
+inherits nothing from an ambient/global agent setup — became the fourth and
+largest addition. No skill added (41 unchanged).
+
+### Added
+
+- **`sota-docs-workflow` rules/01 §9 — the troubleshooting playbook.** The
+  dev-facing counterpart to §5's on-call runbooks: a symptom-keyed index of
+  failures already solved once, in Symptom → Diagnosis → Fix form, written in
+  the PR that fixed the bug. Includes the two rules the source didn't have —
+  delete entries a root-cause fix invalidated, and treat a thrice-reported
+  symptom as a signal to fix the code instead of documenting it again. Verified
+  absent: "symptom" appeared across the library only in the alerting/on-call
+  sense.
+- **`sota-docs-workflow` rules/01 §10 — day zero in a new repo.** An installed
+  skills library, a personal `CLAUDE.md`, and a house style guide are *ambient*;
+  a fresh repo, a teammate's clone, and a CI runner inherit none of them.
+  Covers the only two artifacts that must precede the first commit (`.gitignore`
+  + secret scanning, LICENSE) and why; the ambient-vs-repo split for agent files
+  in both directions; and the `core.symlinks=false` failure mode that turns a
+  symlinked `CLAUDE.md` into a one-line text file (verified against
+  `git help config`), with CI generation as the fallback.
+- **`sota-docs-workflow` rules/01 §7 — the minimal agent-file shape.** §7 said
+  what content earns its place but gave no skeleton; it now carries a four-block
+  one, with the rule that the row which earns its place is the one contradicting
+  the default.
+- **`sota-architecture` rules/01 §4 — ADR directory discipline.** Sequential
+  kebab-case filenames plus an `index.md` status table, and committing the ADR
+  in the PR that implements the decision. The format and the
+  consequences-with-a-downside rule were already there; the directory-level
+  practice that makes a stalled process visible was not.
+
+### Changed
+
+- `sota-docs-workflow/SKILL.md` BUILD mode now routes new-repo bootstrap and the
+  troubleshooting playbook (steps 7–8), and rules/01 gains three audit-checklist
+  items.
+
 ## [1.19.2] - 2026-07-24
 
 The **second intake** release: three ideas mined from

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ survives a long context instead of fading into it. That's why it beats a bigger 
 instead of becoming one. Native on Claude Code; works with Gemini CLI, Codex, and any
 agent that reads `AGENTS.md`.
 
-Under the hood: **41 skills (296 files, ~60k lines)** of state-of-the-art 2026
+Under the hood: **41 skills (296 files, ~61k lines)** of state-of-the-art 2026
 practice, each file under 500 lines so only the matching rules load, every fast-moving
 claim web-verified against a primary source.
 

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -47,6 +47,13 @@ lessons-log — its own best structural idea, applied to ourselves.
 | 2026-07-24 | swarm-forge `crap4go`/`crap4clj` tools | Complexity × coverage composite to rank where the next test belongs | **adopted** | `sota-testing/rules/07` §7.2 · v1.19.2 |
 | 2026-07-24 | swarm-forge (convergent) | Scoped/diff mutation; mutation as a control probe; read survivors don't average; reviewer must not modify audited code; heartbeat on long runs; verify the other role ran the tool | **rejected: already ours** | — |
 | 2026-07-24 | swarm-forge `engineering.prompt` Startup Tools | Resolve every tool at latest upstream each run; never reuse cached/vendored copies | **rejected: contrary** | — |
+| 2026-07-28 | [claude-project-scaffold](https://github.com/martinholovsky/claude-project-scaffold) `templates/troubleshooting.md.tmpl` | A repo-resident Symptom → Diagnosis → Fix playbook where solved dev failures accrue | **adopted** | `sota-docs-workflow/rules/01` §9 · unreleased |
+| 2026-07-28 | claude-project-scaffold `templates/CLAUDE.md.tmpl` | A minimal four-block skeleton for the agent file (stack / commands / conventions / traps) | **adopted** | `sota-docs-workflow/rules/01` §7 · unreleased |
+| 2026-07-28 | claude-project-scaffold `templates/adr-index.md.tmpl` | An ADR `index.md` status table + sequential kebab-case numbering, committed with the code | **adopted** | `sota-architecture/rules/01` §4 · unreleased |
+| 2026-07-28 | claude-project-scaffold (gap it exposed, not content it had) | A fresh repo inherits nothing from an ambient/global agent setup — bootstrap order and canonical-file mechanics | **adopted** | `sota-docs-workflow/rules/01` §10 · unreleased |
+| 2026-07-28 | claude-project-scaffold README "Design Philosophy" + context-rot rationale | Include only what the agent would get wrong without it; short agent files beat bloated ones | **rejected: already ours** | — |
+| 2026-07-28 | claude-project-scaffold `templates/adr-template.md` | Full ADR template with alternatives and consequences | **rejected: already covered** | — |
+| 2026-07-28 | claude-project-scaffold `.claude/memory/`, `commands/`, `hooks/`, `presets/`, `scaffold.sh` | Generated slash commands, lint-on-edit hook, memory index, preset engine | **rejected: runtime-bound** | — |
 
 ## Entries
 
@@ -197,3 +204,60 @@ is precisely the axis this library covers; it implies no change here.
 **not measured**. Do not cite a lift for them. The testability-boundary rule is
 the only one with a plausible claim to changing generated code; if a future
 eval round has spare budget, it is the one worth a completeness case.
+
+### 2026-07-28 — claude-project-scaffold (martinholovsky), three adoptions + one exposed gap
+
+Source: <https://github.com/martinholovsky/claude-project-scaffold>, MIT, read at
+full depth (2157 lines, last pushed 2026-04-14), 2026-07-28. It is an
+**agent-context scaffolder**, not a repo scaffolder: it generates `CLAUDE.md`,
+`.claude/{rules,memory,commands,hooks}`, an ADR directory, and preset-specific
+smoke scripts, and touches none of LICENSE, `.gitignore`, CI, or branch
+protection. That framing matters for what could be taken — most of its *stated*
+philosophy is ground this library already held, and the largest thing we took is
+something it does not contain.
+
+**Adopted (3).** The **troubleshooting playbook** (`rules/01` §9) was the clean
+gap: a `grep` for `Symptom|playbook|troubleshooting` across `sota-docs-workflow`
+and `sota-observability` returned only the on-call/alerting sense — §5 runbooks
+(`rules/01:130`), symptom-based paging (`sota-observability/rules/04:108`) —
+never the dev-loop artifact where a solved local failure is written down so the
+second encounter is a lookup. Our version adds the two disciplines the template
+lacks: delete an entry once a root-cause fix makes it a false lead, and treat a
+symptom reported three times as a signal to fix the code rather than document it
+again. The **minimal agent-file skeleton** (`rules/01` §7) filled a smaller hole
+— §7:196 said what content earns its place but gave no shape to hang it on. The
+**ADR index and numbering** (`sota-architecture/rules/01` §4) likewise: we had
+the format and the "an ADR without a downside is marketing" rule (`rules/01:93`)
+but nothing on the directory, and a status column that is all `proposed` is the
+cheapest possible read on a stalled decision process.
+
+**The gap it exposed (the largest addition).** The scaffold exists because a new
+repo has no agent context — but it treats that as a file-generation problem. The
+underlying rule is broader and belongs in the library: an installed skills
+library, a personal `~/.claude/CLAUDE.md`, and a house style guide are all
+*ambient*, and a fresh repo, a teammate's clone, and a CI runner inherit none of
+them. `rules/01` §10 states that, orders the two artifacts that must precede the
+first commit (`.gitignore` + secret scanning, LICENSE) with the reason each is
+expensive later, splits ambient-vs-repo content in both directions, and records
+the `core.symlinks=false` failure mode — symlinks "checked out as small plain
+files that contain the link text" (verified against `git help config`), which
+silently reduces a symlinked `CLAUDE.md` to the string `AGENTS.md`.
+
+**Rejected: already ours.** The README's "only include what Claude would get
+wrong without it" and its context-rot rationale restate `rules/01` §7:196-202
+almost phrase for phrase, and this library additionally *measures* the effect
+(`docs/CONTEXT-MANAGEMENT.md`, the decay eval). Its ADR template is a longer
+form of one we already carry, without the downside-required rule. Convergence,
+not a change.
+
+**Rejected: runtime-bound.** The 975-line `scaffold.sh`, the preset variable API,
+the `PostToolUse` lint hook, the generated slash commands, and the
+`.claude/memory/` index are executable harness machinery, and this library is
+Markdown-only by construction — the same disposition the memory-bank and
+worktree-lock ideas got in the dev-aid pass (PRs #112-114). The one idea inside
+them that generalises, pushing critical invariants into deterministic gates,
+was already the router's BUILD step 4 and is now restated for day zero in §10.
+
+**Measurement status:** all four are content refinements adopted on reasoning,
+**not measured**. Do not cite a lift. None is a plausible completeness-eval
+candidate — they govern repo artifacts, not generated code.

--- a/skills/sota-architecture/rules/01-architecture-styles-and-decisions.md
+++ b/skills/sota-architecture/rules/01-architecture-styles-and-decisions.md
@@ -93,6 +93,14 @@ this?" must have a greppable answer.
 **Rule:** An ADR without a *Consequences* section listing at least one downside
 is marketing, not a decision record. Reject it in review.
 
+**Directory discipline.** Sequential kebab-case filenames
+(`0012-use-outbox-for-order-events.md`) plus an `index.md` holding one row per
+ADR — number, title, status, date. The index is what makes the practice
+auditable at a glance: a status column that is all `proposed` is a stalled
+process, and a superseded chain is legible without opening a file. Commit the
+ADR **in the PR that implements the decision** where one exists, so rationale
+and code land together; a pre-implementation decision lands on its own.
+
 ## 5. Practice evolutionary architecture with fitness functions
 
 **Rule:** Encode architectural qualities as automated, continuously-run checks

--- a/skills/sota-docs-workflow/SKILL.md
+++ b/skills/sota-docs-workflow/SKILL.md
@@ -58,9 +58,13 @@ When creating docs or setting up workflow:
    commits with imperative ≤72-char subjects; conventional commits only if
    automation consumes them (`rules/04` §1–3).
 7. **Agent docs**: one short, human-curated AGENTS.md/CLAUDE.md with exact
-   commands and repo-specific traps — never auto-generated bloat
-   (`rules/01` §7).
-8. Before declaring done, self-review against the relevant files' **Audit
+   commands and repo-specific traps — never auto-generated bloat, never a
+   restatement of ambient/global rules (`rules/01` §7, §10). On a **new repo**,
+   `.gitignore` + secret scanning and LICENSE land before the first commit
+   (`rules/01` §10).
+8. **Solved failures accrue** in a symptom-keyed troubleshooting playbook,
+   written in the PR that fixed them (`rules/01` §9).
+9. Before declaring done, self-review against the relevant files' **Audit
    checklists**.
 
 ## AUDIT mode

--- a/skills/sota-docs-workflow/rules/01-documentation-architecture.md
+++ b/skills/sota-docs-workflow/rules/01-documentation-architecture.md
@@ -200,6 +200,20 @@ Docs are now read by agents as well as humans. Same content, two consumers.
   from language defaults, files/dirs the agent must not touch, commit/PR
   conventions, known traps. Content that doesn't: anything the agent can read
   from code, generic best practices, restated style guides.
+- **The minimal shape.** Four blocks is enough for most repos; anything past
+  them has to earn its line against the test above.
+
+  ```text
+  # <repo> — one line: what it is, who runs it
+  ## Tech stack     table, only where a wrong guess sends the agent down a wrong path
+  ## Dev commands   the exact build / test / lint / run lines, with the flags you use
+  ## Conventions    2–5 repo rules that cannot be inferred from the code
+  ## Traps          the things that look fine and aren't
+  ```
+
+  A stack table an agent could rebuild by opening `package.json` is padding. The
+  row that earns its place is the one **contradicting** the default: the test
+  runner that isn't the framework's, the port that isn't the documented one.
 - **Agent docs decay like all docs** — review them when commands change; a wrong
   test command in AGENTS.md silently corrupts every agent run.
 - **llms.txt** (llmstxt.org): root-level Markdown index of a site's docs for LLM
@@ -251,6 +265,90 @@ exactly one canonical copy — per repo or via the org default, not both. README
 LICENSE live at the repo root (GitHub surfaces them in the repo header) and are
 **not** inheritable community-health files.
 
+## §9 The troubleshooting playbook — where solved failures accrue
+
+§5's runbooks serve the on-call reader mid-incident. A **troubleshooting
+playbook** serves a different reader: a contributor or an agent who just hit an
+error on their own machine, in a test run, or in CI. It is not alert-linked and
+not severity-ranked — it is a growing index of **failures already solved once**,
+so the second encounter costs a lookup instead of a re-debug.
+
+One entry per failure, three parts, nothing else:
+
+```text
+### Symptom: <the literal error text or observable behaviour>
+**Diagnosis:** <the actual cause, stated as a fact about this repo>
+**Fix:** <exact commands, or the file to change>
+```
+
+- **Key on what the reader sees, not on what you now know.** The heading is the
+  string they will paste into a search box — the exception name, the status
+  code, the log line. "Environment misconfiguration" is unfindable by someone
+  staring at `ModuleNotFoundError`.
+- **Write it in the PR that fixes the bug**, while the cause is still known. A
+  playbook backfilled later doesn't get written.
+- **The diagnosis must be repo-specific.** "Check your dependencies" is not a
+  diagnosis; "the dev server resolves imports from `src/` only, so a module
+  added outside it resolves after a reinstall and not before" is.
+- **Delete entries the fix made impossible.** Once a class of failure is closed
+  at the root — a validation, a default, a guard — its entry is a false lead
+  and goes (§4).
+- **It is a repo artifact, not a chat log**: in-repo, linked from both the
+  README's contributing path and the agent file (§7), or neither audience finds
+  it.
+
+A symptom reported a third time is a signal to **stop writing entries** — that
+fix belongs in the code or the setup script, not the playbook.
+
+## §10 Day zero — a new repo inherits no context, however good your tooling
+
+An installed agent skills library, a personal `~/.claude/CLAUDE.md`, a house
+style guide: all of it is **ambient** — attached to a machine or an account. A
+freshly initialised repo inherits none of it, and neither does the teammate, the
+CI runner, or the agent that clones it tomorrow. Whatever the repo's correctness
+depends on has to live **in the repo**. Two questions, in this order.
+
+**1. What must exist before the first commit?** Only two things, because both
+are expensive to add later:
+
+- **`.gitignore` + secret scanning.** A credential committed in commit 1 is not
+  fixed by deleting it in commit 2 — it is in the history, and removing it costs
+  a rewrite *plus* rotating the credential (`sota-secrets-management` rules/04).
+  The pre-commit hook is cheapest while the history is one commit long.
+- **`LICENSE`.** Its absence is not neutral (§8): all rights reserved, and not
+  inheritable from an org default. Adding one later needs sign-off from everyone
+  who has contributed by then.
+
+Everything else in the §8 baseline still follows §8's rule — created when its
+trigger fires, not pre-seeded. An empty `CONTRIBUTING.md` on day zero is the
+decay problem (§4) with a head start.
+
+**2. What can only the repo tell an agent?** A general skills library knows how
+to write a Go service; it cannot know that *this* one is tested behind a flag,
+deploys from a branch that isn't the default one, or has a directory nothing may
+touch. That gap is the agent file (§7), held to §7's test. Two failure modes to
+design out on day zero:
+
+- **Restating ambient rules in the repo file.** If a personal or org-level agent
+  file already says "use conventional commits", repeating it in-repo creates two
+  copies that drift and spends context twice. Repo file = repo-specific only.
+  The inverse is worse: repo-specific facts stranded in a personal file no
+  teammate has.
+- **Forking the file per tool.** Keep one canonical `AGENTS.md` with
+  `CLAUDE.md` / `GEMINI.md` as symlinks (§7) — but know the failure mode first.
+  Git records a symlink as such, and where `core.symlinks` is false (set
+  automatically at clone time on filesystems that can't represent one) symlinks
+  are, in git's words, "checked out as small plain files that contain the link
+  text" (`git help config`) — the agent then reads the string `AGENTS.md` as the
+  whole file. If any contributor is on such a checkout, generate the duplicates
+  in CI from the canonical file and fail the build on drift instead.
+
+**Bootstrap the invariants as checks, not prose.** Anything the repo must never
+regress — no secret in a commit, every internal link resolving, a required file
+present — is worth a hook or CI job on day zero, when it costs one file and
+passes trivially. The same check proposed at ten thousand commits arrives red
+and gets disabled.
+
 ## Audit checklist
 
 - [ ] Baseline present for the repo's stage: README + LICENSE + CHANGELOG always; CONTRIBUTING/CODE_OF_CONDUCT/SECURITY/SUPPORT once public or contribution-accepting; runbooks once on-call — each with one canonical home (no duplicate copies across root/`.github`/`docs`).
@@ -259,6 +357,9 @@ LICENSE live at the repo root (GitHub surfaces them in the repo header) and are
 - [ ] Tutorials run end-to-end on a clean environment (verified recently, versions pinned).
 - [ ] Docs live in-repo, change via reviewed PRs, and behavior-changing code PRs touch docs.
 - [ ] CI checks links (lychee or equivalent) and lints docs; internal links gate PRs.
+- [ ] The agent file carries only what the agent would otherwise get wrong (exact commands, deviations, traps) — not a restatement of ambient/global rules or anything readable from the code; one canonical file, with per-tool names symlinked or CI-generated rather than forked.
+- [ ] Solved failures land in a troubleshooting playbook keyed on the literal symptom, written in the PR that fixed them; entries invalidated by a root-cause fix are deleted, and a thrice-reported symptom was fixed in code rather than re-documented.
+- [ ] The repo got `.gitignore` + secret scanning and a LICENSE before its first commit, and its must-never-regress invariants are enforced by a hook or CI job rather than described in prose.
 - [ ] README: one-sentence what, why, ≤5-minute copy-pasteable quickstart, honest badges, ownership/support pointer.
 - [ ] Every doc/dir has an owner (CODEOWNERS or equivalent); high-traffic pages have a freshness/review signal.
 - [ ] No known-stale pages kept "for reference"; deletions leave redirects/tombstones; no duplicated facts across pages.


### PR DESCRIPTION
Third intake pass, against [claude-project-scaffold](https://github.com/martinholovsky/claude-project-scaffold) (MIT, 2157 lines, read at full depth).

## Framing

It is an **agent-context scaffolder**, not a repo scaffolder — it generates `CLAUDE.md`, `.claude/{rules,memory,commands,hooks}`, an ADR directory and smoke scripts, and touches none of LICENSE, `.gitignore`, CI, or branch protection. Most of its *stated* philosophy is ground this library already holds; the largest thing taken here is something it does not contain.

## Adopted (4)

| Where | What | Verified absent by |
|---|---|---|
| `sota-docs-workflow/rules/01` §9 | **Troubleshooting playbook** — the dev-facing counterpart to §5's on-call runbooks: symptom-keyed, Symptom → Diagnosis → Fix, written in the PR that fixed the bug | `grep -i "symptom\|playbook"` over `sota-docs-workflow` + `sota-observability` returned only the alerting/on-call sense (`rules/01:130`, `observability/rules/04:108`) |
| `sota-docs-workflow/rules/01` §10 | **Day zero** — a fresh repo inherits nothing from an ambient/global agent setup | not present anywhere; the gap the source exposes but doesn't cover |
| `sota-docs-workflow/rules/01` §7 | **Minimal agent-file skeleton** (4 blocks) | §7:196 said what content earns its place, gave no shape |
| `sota-architecture/rules/01` §4 | **ADR directory discipline** — `index.md` status table, sequential kebab-case, committed with the implementing PR | format + downside rule existed (`rules/01:78,93`); directory practice did not |

Two rules in §9 are **ours, not the source's**: delete an entry once a root-cause fix makes it a false lead, and treat a thrice-reported symptom as a signal to fix the code rather than document it again.

§10 answers the case where the library is already installed globally but the repo is new — it orders the only two artifacts that must precede the first commit (`.gitignore` + secret scanning, LICENSE) with the reason each is expensive later, splits ambient-vs-repo agent content in both directions, and records the `core.symlinks=false` failure mode that silently reduces a symlinked `CLAUDE.md` to the one-line string `AGENTS.md` — verified against `git help config`, quoted verbatim.

## Rejected (3), with reasons in the log

- **already ours** — the README's "only include what Claude would get wrong without it" and its context-rot rationale restate §7:196-202 nearly phrase for phrase (and we additionally *measure* the effect).
- **already covered** — its ADR template, minus our downside-required rule.
- **runtime-bound** — `scaffold.sh` (975 lines), the preset variable API, the `PostToolUse` lint hook, generated slash commands, and `.claude/memory/`. Markdown-only library; same disposition the memory-bank/worktree-lock ideas got in PRs #112-114.

## Measurement

All four are content refinements **adopted on reasoning, not measured**. No lift is claimed anywhere in the diff. None is a plausible completeness-eval candidate — they govern repo artifacts, not generated code.

## Checks

`./scripts/check-invariants.sh` → PASS (8/8; README `~60k` → `~61k` recount included). `pre-commit run --all-files` → PASS.
