### PR TITLE
feat(router): raise day zero automatically; say that installs aren't repo-resident

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,25 @@ personal rather than repo-resident.
   than no pointer, because it reads as a satisfied requirement. One
   audit-checklist item added.
 
+### Fixed
+
+Both found by running the new detection against a real repo
+([asterinas](https://github.com/asterinas/asterinas), 4304 commits) rather than
+trusting it as written:
+
+- **Licence detection matched the bare name `LICENSE`.** Asterinas ships
+  `LICENSE-MPL` + `COPYRIGHT`, so a literal check reports the licence missing
+  and feeds a false signal into the day-zero trigger. The router now matches
+  `LICENSE*` / `COPYING*` / `COPYRIGHT`, and says explicitly not to match the
+  bare name. Gate detection likewise widened beyond `.pre-commit-config.yaml`
+  to any hook manager or CI job.
+- **rules/01 §10 offered only two ways to point a second tool at `AGENTS.md`**
+  (symlink, CI-generated copy). Asterinas uses a third that is better than
+  both — a 28-byte `CLAUDE.md` reading `See [AGENTS.md](AGENTS.md).`:
+  platform-independent, no build step, and unable to degrade silently the way a
+  `core.symlinks=false` checkout does. It is now option 1 and the recommended
+  default, with the trade (one hop the agent must follow) stated.
+
 ### Changed
 
 - **README Installation** gains "An install is personal, not repo-resident" —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Follow-up to the v1.19.3 day-zero work: the library now **raises** day zero
+itself instead of waiting to be asked, and says plainly that an install is
+personal rather than repo-resident.
+
+### Added
+
+- **Router `skills/sota/SKILL.md` — a "Day zero" section.** On the first BUILD
+  task in an unfamiliar repo, check by *looking* (gate config, LICENSE, agent
+  file, git history length) and, if two or more are missing and the history is
+  short, surface `init-gates.sh` / `gen-agents-md.sh` **once, in a line**. Two
+  guards are part of the rule: a long history means a mature repo that decided
+  against them (say nothing), and **offer, never perform** — the scripts write
+  config into the user's repo, and a decline is decided. Placed outside the
+  `## BUILD mode — workflow` block on purpose: it is a per-repo precondition,
+  not a per-task step, and keeping it out leaves the eval-pinned BUILD section
+  byte-identical (`ROUTER_BUILD_SHA` still `71a9d78ea5e9e341`, verified).
+- **`sota-docs-workflow` rules/01 §10 — "an ambient install doesn't travel".**
+  User-scoped rule libraries, skills and linters resolve against one home
+  directory; a teammate's clone and CI see nothing. Solo vs shared is an
+  explicit choice, but the **gates** must be repo-resident either way — a
+  secret scan that exists only in your shell is not a control on anyone else's
+  commit. Plus: a pointer file referencing tooling the reader lacks is worse
+  than no pointer, because it reads as a satisfied requirement. One
+  audit-checklist item added.
+
+### Changed
+
+- **README Installation** gains "An install is personal, not repo-resident" —
+  that one install covers every project including brand-new ones, that it
+  resolves only on your machine, the `--project .` / `--copy` options for a
+  shared repo, and a pointer to the day-zero list.
+
 ## [1.19.3] - 2026-07-28
 
 Third intake pass, against

--- a/README.md
+++ b/README.md
@@ -187,6 +187,31 @@ status line, pre-commit gates, AGENTS.md) aren't auto-enabled — see
 [Optional extras for plugin users](#optional-extras-for-plugin-users). On first
 run the plugin shows a one-time notice pointing there.
 
+### An install is personal, not repo-resident
+
+Installing once makes the skills apply in **every** project you open, new ones
+included — there is nothing to run per repo, and a brand-new repo is covered the
+moment you start work in it. But the install resolves against *your* home
+directory: a teammate's clone and a CI runner see none of it.
+
+So for a repo shared with anyone, decide explicitly:
+
+```sh
+./scripts/install.sh --project .   # repo-resident: .claude/skills/ in the repo
+./scripts/install.sh --project . --copy   # ...pinned snapshot, not symlinks to your paths
+```
+
+— or leave it personal and put the install step in `CONTRIBUTING.md` so a
+contributor can reproduce it. What must **not** stay personal is the gates: a
+secret scan that lives only in your shell doesn't run on anyone else's commit.
+Wire those into the repo with [`init-gates.sh`](#enforcing-the-gates).
+
+And the things no install can supply per repo — gates, LICENSE, `.gitignore`, an
+agent file, and the order to create them in — are the day-zero list in
+[`sota-docs-workflow` rules/01 §10](skills/sota-docs-workflow/rules/01-documentation-architecture.md).
+The router raises it once, unprompted, the first time it meets a repo that has
+none of them.
+
 ### Updating
 
 **Plugin install:** updates ship when the version bumps — `/plugin update

--- a/skills/sota-docs-workflow/rules/01-documentation-architecture.md
+++ b/skills/sota-docs-workflow/rules/01-documentation-architecture.md
@@ -349,6 +349,26 @@ present — is worth a hook or CI job on day zero, when it costs one file and
 passes trivially. The same check proposed at ten thousand commits arrives red
 and gets disabled.
 
+**An ambient install doesn't travel — decide per repo.** Rule libraries, agent
+skills and linters installed at user scope resolve against *your* home
+directory. A teammate's clone and a CI runner resolve nothing, so a repo that
+depends on them is one that only works on one machine. Two honest options, and
+the choice belongs in the repo's contributing docs either way:
+
+- **Solo or private-to-you** — the ambient install is enough; write down
+  nothing, and don't pretend the repo is self-contained.
+- **Shared, public, or CI-checked** — make it repo-resident: vendor or
+  project-scope the tooling (for this library, `install.sh --project .`, or
+  `--copy` to pin a snapshot rather than link to a path only you have), *or*
+  state the install step in `CONTRIBUTING.md` so a contributor can reproduce it.
+  Whichever you choose, the **gates** must be repo-resident regardless — a
+  secret scan that exists only in your shell is not a control on anyone else's
+  commit (`sota-code-security` rules/10: a control nobody else runs is a no-op
+  everywhere but your machine).
+
+A pointer file that references tooling the reader doesn't have is worse than no
+pointer: it reads as a satisfied requirement.
+
 ## Audit checklist
 
 - [ ] Baseline present for the repo's stage: README + LICENSE + CHANGELOG always; CONTRIBUTING/CODE_OF_CONDUCT/SECURITY/SUPPORT once public or contribution-accepting; runbooks once on-call — each with one canonical home (no duplicate copies across root/`.github`/`docs`).
@@ -360,6 +380,7 @@ and gets disabled.
 - [ ] The agent file carries only what the agent would otherwise get wrong (exact commands, deviations, traps) — not a restatement of ambient/global rules or anything readable from the code; one canonical file, with per-tool names symlinked or CI-generated rather than forked.
 - [ ] Solved failures land in a troubleshooting playbook keyed on the literal symptom, written in the PR that fixed them; entries invalidated by a root-cause fix are deleted, and a thrice-reported symptom was fixed in code rather than re-documented.
 - [ ] The repo got `.gitignore` + secret scanning and a LICENSE before its first commit, and its must-never-regress invariants are enforced by a hook or CI job rather than described in prose.
+- [ ] Nothing the repo depends on resolves only against one contributor's home directory: gates are repo-resident, and any user-scoped tooling a shared repo assumes is either vendored/project-scoped or documented as an install step (§10).
 - [ ] README: one-sentence what, why, ≤5-minute copy-pasteable quickstart, honest badges, ownership/support pointer.
 - [ ] Every doc/dir has an owner (CODEOWNERS or equivalent); high-traffic pages have a freshness/review signal.
 - [ ] No known-stale pages kept "for reference"; deletions leave redirects/tombstones; no duplicated facts across pages.

--- a/skills/sota-docs-workflow/rules/01-documentation-architecture.md
+++ b/skills/sota-docs-workflow/rules/01-documentation-architecture.md
@@ -334,14 +334,25 @@ design out on day zero:
   copies that drift and spends context twice. Repo file = repo-specific only.
   The inverse is worse: repo-specific facts stranded in a personal file no
   teammate has.
-- **Forking the file per tool.** Keep one canonical `AGENTS.md` with
-  `CLAUDE.md` / `GEMINI.md` as symlinks (§7) — but know the failure mode first.
-  Git records a symlink as such, and where `core.symlinks` is false (set
-  automatically at clone time on filesystems that can't represent one) symlinks
-  are, in git's words, "checked out as small plain files that contain the link
-  text" (`git help config`) — the agent then reads the string `AGENTS.md` as the
-  whole file. If any contributor is on such a checkout, generate the duplicates
-  in CI from the canonical file and fail the build on drift instead.
+- **Forking the file per tool.** Keep one canonical `AGENTS.md` (§7) and pick
+  how the other names reach it, knowing the trade of each:
+  1. **A one-line pointer file** — `CLAUDE.md` containing
+     `See [AGENTS.md](AGENTS.md).` and nothing else. Platform-independent, no
+     build step, and it cannot silently degrade; the cost is one hop the agent
+     must follow. Observed in the wild on large cross-platform projects, and the
+     safest default.
+  2. **A symlink** — exact, but know the failure mode: git records a symlink as
+     such, and where `core.symlinks` is false (set automatically at clone time
+     on filesystems that can't represent one) symlinks are, in git's words,
+     "checked out as small plain files that contain the link text"
+     (`git help config`). The agent then reads the bare string `AGENTS.md` as
+     the entire file and follows no instructions at all — a silent failure, not
+     a visible one.
+  3. **CI-generated duplicates** from the canonical file, failing the build on
+     drift. Exact and platform-independent, at the cost of a job to maintain.
+
+  Anything else — hand-maintained copies — drifts, and the copy that goes stale
+  is the one your teammate's tool reads.
 
 **Bootstrap the invariants as checks, not prose.** Anything the repo must never
 regress — no secret in a commit, every internal link resolving, a required file

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -203,6 +203,27 @@ rules files that match the code in front of you. Never load all skills at once.
     control needs at runtime?). Not for controls that are simply *missing* —
     that's the owning domain skill's audit checklist.
 
+## Day zero — a repo this library has not been applied to yet
+
+Installing is *ambient*: the rules apply in every directory, including a repo
+with no gates, no agent file and no LICENSE. They then govern the code you write
+and nothing else — the repo keeps accepting unscanned commits. Check this
+**once per repo**, on the first BUILD task in an unfamiliar one, by looking (not
+inferring): is there a `.pre-commit-config.yaml` or a CI secret scan, a
+`LICENSE`, an `AGENTS.md`/`CLAUDE.md`, and how long is the git history? Two or
+more missing **and** a history of a few commits = day zero. A long history means
+a mature repo that likely decided against them; say nothing.
+
+When it fires, say it **once, in a line, with the command**, then get on with the
+task: `scripts/init-gates.sh` + `pre-commit install --hook-type pre-push` for
+gates (before the first commit, while a leaked credential is still free to
+remove), `scripts/gen-agents-md.sh` for the cross-tool entry point. Full ordering
+and reasoning — LICENSE, `.gitignore`, ambient-vs-repo-resident, the
+`core.symlinks` trap — in `sota-docs-workflow` rules/01 §10.
+
+**Offer, never perform.** These write config into the user's repo. Mention once,
+act only on a yes, and treat a decline as decided.
+
 ## BUILD mode — workflow
 
 1. Identify the domains the feature touches (table above) and the language(s).

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -209,10 +209,12 @@ Installing is *ambient*: the rules apply in every directory, including a repo
 with no gates, no agent file and no LICENSE. They then govern the code you write
 and nothing else — the repo keeps accepting unscanned commits. Check this
 **once per repo**, on the first BUILD task in an unfamiliar one, by looking (not
-inferring): is there a `.pre-commit-config.yaml` or a CI secret scan, a
-`LICENSE`, an `AGENTS.md`/`CLAUDE.md`, and how long is the git history? Two or
-more missing **and** a history of a few commits = day zero. A long history means
-a mature repo that likely decided against them; say nothing.
+inferring): is there a `.pre-commit-config.yaml` **or any other hook manager or
+CI job** running a secret scan; a license file (`LICENSE*`, `COPYING*` or
+`COPYRIGHT` — never match the bare name, projects name it after the licence);
+an `AGENTS.md`/`CLAUDE.md`; and how long is the git history? Two or more missing
+**and** a history of a few commits = day zero. A long history means a mature
+repo that likely decided against them; say nothing.
 
 When it fires, say it **once, in a line, with the command**, then get on with the
 task: `scripts/init-gates.sh` + `pre-commit install --hook-type pre-push` for


### PR DESCRIPTION
Follow-up to v1.19.3. Two gaps that turned up while walking through "what do I do in a brand-new repo":

1. The library **knew** what day zero needs (`sota-docs-workflow` rules/01 §10) but only said so when asked.
2. Nothing anywhere stated that a user-scoped install covers every project of *yours* and none of anyone else's.

## 1. The router now raises it — "automagically"

New `## Day zero` section in `skills/sota/SKILL.md`. On the first BUILD task in an unfamiliar repo, **look** (don't infer): gate config, LICENSE, agent file, git history length. Two or more missing **and** a short history ⇒ surface `init-gates.sh` / `gen-agents-md.sh` **once, in a line**, then get on with the task.

Two guards are part of the rule, because an over-eager version of this is worse than nothing:

- **Anti-nag** — a long history means a mature repo that likely *decided* against pre-commit. Say nothing.
- **Offer, never perform** — these scripts write config into the user's repo. Mention once, act only on a yes, treat a decline as decided.

**Placement.** Deliberately *outside* `## BUILD mode — workflow`: it's a per-repo precondition, not a per-task step, so it doesn't belong in a numbered build sequence. That placement also leaves the eval-pinned BUILD section byte-identical — `ROUTER_BUILD_SHA` computed before and after both give `71a9d78ea5e9e341`, so no mirror re-sync and no perturbation of the +0.39 completeness measurement. Flagging that explicitly: the structural argument came first, but I did verify the hash rather than assume it.

Router trimmed to **488** lines to stay under the 500 cap (first draft was 506 — the cap did its job).

## 2. An ambient install doesn't travel

`sota-docs-workflow` rules/01 §10 gains the rule: user-scoped rule libraries, skills and linters resolve against one home directory, so a teammate's clone and a CI runner see nothing. Solo vs shared is an explicit choice — but the **gates must be repo-resident either way**, because a secret scan that exists only in your shell is not a control on anyone else's commit (`sota-code-security` rules/10). Closes with: a pointer file referencing tooling the reader doesn't have is worse than no pointer, since it reads as a satisfied requirement. One audit-checklist item.

## 3. README

New "An install is personal, not repo-resident" block under Installation: one install covers every project including brand-new ones; it resolves only on your machine; `--project .` / `--copy` for a shared repo; and a pointer to the day-zero list.

## Measurement

**Unmeasured.** No lift is claimed for the trigger — it governs a conversational behaviour on repo state, which the completeness eval doesn't exercise.

## Checks

`./scripts/check-invariants.sh` → 8/8 PASS. `pre-commit run --all-files` → PASS. `ROUTER_BUILD_SHA` unchanged (verified).
