### PR TITLE
feat(docs-workflow): host-capability report + agent-facing hooks must not rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,39 @@ trusting it as written:
   resolves only on your machine, the `--project .` / `--copy` options for a
   shared repo, and a pointer to the day-zero list.
 
+## [Unreleased]
+
+Two rules taken from a *worked example* rather than a repo of ideas: a full
+agent session scaffolding a clone of
+[asterinas](https://github.com/asterinas/asterinas) (Rust OS kernel, 4304
+commits), where the canonical dev loop is a container the host didn't have.
+
+### Added
+
+- **`sota-docs-workflow` rules/01 §6 — the host-capability report.** Where a
+  repo's documented dev loop doesn't run on every supported host, ship a small
+  executable report that probes the machine and prints, per target, whether it
+  works here and **what each gap blocks**. Its three load-bearing properties:
+  probe capabilities rather than one implementation's name (a `docker` check
+  reports "no runtime" on a machine running podman), name the consequence of
+  each gap so nobody discovers it through a ten-minute failed build, and report
+  rather than gate. Verified absent — every `preflight` in the library was CORS
+  and `doctor` appeared nowhere.
+- **`sota-docs-workflow` rules/01 §7 — automation on an agent's edits must
+  check, not rewrite.** A format-on-write hook is right for a human editor and
+  wrong for an agent: rewriting the file *after* the agent wrote it stales the
+  agent's view, so its next edit fails or clobbers the reformat. Such hooks
+  report (non-zero, with file and fix) and let the agent apply it; rewriting
+  belongs at commit time or in CI, where nothing holds a live view. Zero prior
+  hits across the tree. Two audit-checklist items added.
+
+Both adopted on reasoning, **not measured** — no lift claimed. The same session
+independently rediscovered five rules we already had (silent control failure in
+an upstream script that exits 0 while checking nothing, agent-doc decay, proving
+a gate by making it fail, and two shell-safety rules); those are recorded in
+[docs/ADOPTION-LOG.md](docs/ADOPTION-LOG.md) as convergences, including one
+noted as a *routing* miss rather than a coverage gap.
+
 ## [1.19.3] - 2026-07-28
 
 Third intake pass, against

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -54,6 +54,10 @@ lessons-log — its own best structural idea, applied to ourselves.
 | 2026-07-28 | claude-project-scaffold README "Design Philosophy" + context-rot rationale | Include only what the agent would get wrong without it; short agent files beat bloated ones | **rejected: already ours** | — |
 | 2026-07-28 | claude-project-scaffold `templates/adr-template.md` | Full ADR template with alternatives and consequences | **rejected: already covered** | — |
 | 2026-07-28 | claude-project-scaffold `.claude/memory/`, `commands/`, `hooks/`, `presets/`, `scaffold.sh` | Generated slash commands, lint-on-edit hook, memory index, preset engine | **rejected: runtime-bound** | — |
+| 2026-07-28 | Live agent session scaffolding [asterinas](https://github.com/asterinas/asterinas) (`aster-env.sh`) | A host-capability report: probe the machine, print per target what works and what each gap blocks | **adopted** | `sota-docs-workflow/rules/01` §6 · unreleased |
+| 2026-07-28 | Same session (`rust-post-edit.sh`, check-only by design) | Automation firing on an agent's edits must report, not rewrite — a rewrite stales the agent's own view of the file | **adopted** | `sota-docs-workflow/rules/01` §7 · unreleased |
+| 2026-07-28 | Same session — `docker`-only probe missed a running podman | Detect by capability, not by one implementation's name | **rejected: already ours** | — |
+| 2026-07-28 | Same session — `tools/format_all.sh` exits 0 while checking nothing; `AGENTS.md` pins a stale toolchain; gate proven by making it fail; bash 3.2 empty-array and `set -e` in command substitution | Four rules of ours, independently rediscovered in the wild | **rejected: already ours** | — |
 
 ## Entries
 
@@ -261,3 +265,54 @@ was already the router's BUILD step 4 and is now restated for day zero in §10.
 **Measurement status:** all four are content refinements adopted on reasoning,
 **not measured**. Do not cite a lift. None is a plausible completeness-eval
 candidate — they govern repo artifacts, not generated code.
+
+### 2026-07-28 — a live agent session on asterinas, two adoptions
+
+Source: a full Claude Code transcript of "scaffold this repo for development"
+run against a clone of <https://github.com/asterinas/asterinas> (a Rust OS
+kernel, 4304 commits), 2026-07-28. Not a repo of ideas — a *worked example*,
+which makes it a different kind of source: what it produced under real
+constraints is the observation, and the question is which parts generalise.
+
+**Adopted (2).** The session's `aster-env.sh` is a **host-capability report** —
+it probes the machine and prints, per `make` target, whether it works here and
+what each gap blocks. It exists because the repo's canonical loop is a container
+the host didn't have, so the agent repeatedly proposed `make kernel` and
+repeatedly failed. That generalises to any repo whose documented dev loop
+doesn't run on every supported host, and it is genuinely absent here: every
+`preflight` in this library is CORS, `doctor` appears nowhere, and §6 covered
+joiners rather than host deltas. Landed in `rules/01` §6 with the three
+properties that make it work — probe capabilities rather than one
+implementation's name, name what each gap blocks, and report rather than gate.
+
+The second is smaller and less obvious: the session's post-edit hook is
+**deliberately check-only**, and its header says why — a hook that reformats a
+file *after* the agent wrote it invalidates the agent's view, so the next edit
+fails or clobbers. Automation aimed at agents therefore reports and lets the
+agent apply the fix; rewriting belongs at commit time or in CI, where nothing
+holds a live view. Zero hits across the tree; landed in `rules/01` §7.
+
+**Rejected: already ours (two clusters, both worth recording).** The session
+self-corrected mid-run — it had probed for `docker` only and missed a running
+podman. That is the same class as two defects fixed in the router the same day
+(a bare `LICENSE` match missing `LICENSE-MPL`, a hardcoded
+`.pre-commit-config.yaml` missing other hook managers), but the principle is
+already stated at `sota/rules/01-audit-methodology.md` §"negative claims need
+more proof": *a narrow search and a true absence produce identical output*. Three
+instances in one day argue for **applying** it at each probe site, not for a new
+rule — so it is recorded here as a convergence, with the router fix as the
+application.
+
+Separately, the run independently rediscovered four rules of ours: an upstream
+`format_all.sh` that exits 0 while its BSD-sed extraction silently checks nothing
+(`sota-code-security` rules/10, silent control failure, found in the wild); an
+`AGENTS.md` pinning a toolchain three versions stale (`rules/01` §7, "a wrong
+command silently corrupts every agent run"); proving the new gate by injecting
+faults and watching it fail (our watch-a-guard-fail convention); and both bash
+3.2 empty-array-under-`set -u` and `set -e` not firing inside command
+substitution (`sota-shell-scripting` rules/01:126 and :48). All four are
+validation, not change — but the last is worth noting as a *routing* miss rather
+than a coverage one: the rules existed and were rediscovered by debugging.
+
+**Measurement status:** both adoptions are content refinements taken on
+reasoning, **not measured**. Do not cite a lift.

--- a/skills/sota-docs-workflow/rules/01-documentation-architecture.md
+++ b/skills/sota-docs-workflow/rules/01-documentation-architecture.md
@@ -182,6 +182,28 @@ Impact: payouts delayed; no data loss (queue is durable).
 - Keep an entry-point index per repo/team (`docs/README.md`): what docs exist,
   one line each, by Diátaxis mode. Indexes decay too — keep them short.
 
+**Where the canonical dev loop doesn't run everywhere, ship a capability
+report.** Plenty of repos have one documented path — a container, a specific
+OS, a licensed toolchain — and a reality where a given machine runs only part of
+it. Prose ("requires Docker") doesn't help someone who *has* a runtime that
+isn't the named one, or who can't tell which of twenty `make` targets are
+reachable. A small executable report does: it probes the host and prints, per
+target, **works here / doesn't, and what each gap blocks**.
+
+- **Probe capabilities, not one implementation's name.** A check for `docker`
+  reports "no container runtime" on a machine running podman; a check for
+  `LICENSE` misses `LICENSE-MPL`. A single-name probe returns a false absence
+  that then gets acted on — the audit-side statement of the same rule is
+  `sota/rules/01-audit-methodology.md` ("a narrow search and a true absence
+  produce identical output").
+- **Every "unavailable" line names what it blocks**, so the reader learns the
+  consequence without discovering it through a ten-minute failed build.
+- **Report, never gate.** It exits 0 by design; it describes the host, it
+  doesn't judge it. Keep the gate a separate command.
+- Its audience is now agents as much as humans: without one, an agent proposes
+  the documented command, fails, and retries it — the failure mode this artifact
+  exists to prevent.
+
 ## §7 AI-era documentation
 
 Docs are now read by agents as well as humans. Same content, two consumers.
@@ -216,6 +238,14 @@ Docs are now read by agents as well as humans. Same content, two consumers.
   runner that isn't the framework's, the port that isn't the documented one.
 - **Agent docs decay like all docs** — review them when commands change; a wrong
   test command in AGENTS.md silently corrupts every agent run.
+- **Automation that fires on an agent's edits must check, not rewrite.** A
+  format-on-write hook is fine for a human editor and wrong for an agent: it
+  changes the file *after* the agent wrote it, so the agent's view of that file
+  is now stale and its next edit either fails or clobbers the reformatting. Have
+  such hooks **report** the problem (non-zero, with the file and the fix) and let
+  the agent apply it — the same content, in the one order that keeps both sides
+  consistent. Reserve rewriting for hooks that run at commit or in CI, where no
+  agent holds a live view.
 - **llms.txt** (llmstxt.org): root-level Markdown index of a site's docs for LLM
   consumption. Status as of mid-2026: community convention, ~10% site adoption,
   not an IETF standard, major crawlers don't commit to fetching it — but coding
@@ -397,6 +427,8 @@ pointer: it reads as a satisfied requirement.
 - [ ] No known-stale pages kept "for reference"; deletions leave redirects/tombstones; no duplicated facts across pages.
 - [ ] Every page-able alert links to a runbook; runbooks are command-exact, decision-tree ordered, flag destructive steps, and were updated after the last incident that used them.
 - [ ] Onboarding guide exists, and the newest joiner actually filed fixes against it.
+- [ ] Where the canonical dev loop doesn't run on every supported host, a capability report says per target what works here and what each gap blocks — probing capabilities rather than one implementation's name, and reporting rather than gating (§6).
+- [ ] No automation rewrites files in response to an agent's edits (format-on-write hooks report instead); rewriting is confined to commit-time or CI, where nothing holds a live view of the file (§7).
 - [ ] One search surface covers internal docs; error messages/alerts/code link into docs.
 - [ ] AGENTS.md/CLAUDE.md exists, is short and human-curated, has exact build/test commands, and matches current reality; no forked divergent copies.
 - [ ] Public docs site: llms.txt generated (not hand-written) if published; pages are self-contained with stable headings.


### PR DESCRIPTION
Two rules taken from a **worked example** rather than a repo of ideas: a full agent session scaffolding a clone of [asterinas](https://github.com/asterinas/asterinas) (Rust OS kernel, 4304 commits) on a host that lacked the container the canonical dev loop assumes.

Different kind of source, so a different standard: what the session *produced under real constraints* is the observation, and the question is which parts generalise. Both were verified absent against the tree before landing.

## 1. `rules/01` §6 — the host-capability report

The session wrote a script that probes the machine and prints, per `make` target, whether it works here and **what each gap blocks**. It exists because the agent kept proposing `make kernel` and kept failing.

Three properties are what make it work, and all three came from watching it be got wrong:

- **Probe capabilities, not one implementation's name.** The session's own first version checked for `docker` and reported "no container runtime" on a machine with a running podman — it self-corrected mid-run.
- **Every "unavailable" line names what it blocks**, so nobody learns the consequence through a ten-minute failed build.
- **Report, never gate** — exit 0 by design; the gate is a separate command.

**Verified absent:** every `preflight` hit in the library is CORS, `doctor` appears nowhere, and §6 covered new joiners rather than host deltas.

## 2. `rules/01` §7 — automation on an agent's edits must check, not rewrite

The session's post-edit hook is deliberately check-only, and its header says why: a hook that reformats the file *after* the agent wrote it invalidates the agent's view, so the next edit fails or clobbers the reformat. Right for a human editor, wrong for an agent. Such hooks report (non-zero, with file and fix) and let the agent apply it; rewriting belongs at commit time or in CI, where nothing holds a live view.

**Verified absent:** zero hits across the tree.

Two audit-checklist items added.

## Recorded as convergences, not adopted

The session independently rediscovered five rules we already have, logged in `docs/ADOPTION-LOG.md` with citations rather than manufactured into diffs:

| Rediscovered | Ours |
|---|---|
| `tools/format_all.sh` exits 0 while its BSD-sed extraction silently checks nothing — 6 crates unchecked | `sota-code-security` rules/10, silent control failure, **in the wild** |
| `AGENTS.md` pins a toolchain three versions stale | `rules/01` §7 — "a wrong command silently corrupts every agent run" |
| Gate proven by injecting faults and watching it fail | our watch-a-guard-fail convention |
| bash 3.2 empty array under `set -u`; `set -e` not firing in command substitution | `sota-shell-scripting` rules/01:126 and :48 |
| `docker`-only probe missing podman | `sota/rules/01-audit-methodology.md` — "a narrow search and a true absence produce identical output" |

The last row deserves a note: that's the same class as two router defects fixed earlier today (bare `LICENSE` missing `LICENSE-MPL`; hardcoded `.pre-commit-config.yaml`). Three instances in one day argues for **applying** the existing principle at every probe site — which #142 did — not for a new rule.

And the shell-safety row is logged as a **routing miss, not a coverage gap**: the rules existed and were re-derived by debugging instead.

## Measurement

Both adoptions are content refinements taken on reasoning, **not measured**. No lift claimed.

## Checks

`./scripts/check-invariants.sh` → 8/8 PASS. `pre-commit run --all-files` → PASS. rules/01 at 434 lines (cap 500).
