### PR TITLE
feat(ci): invariant 9 — at most one [Unreleased], and it must be the top entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,13 @@ symlinks to it — edit only this file, never the symlinks.
    prose/code and false-positive); needs `python3`, skipped-with-warning if
    absent locally, enforced in CI. Adopted 2026-07-24 from the
    training-knowledge-vault vault-doctor — see [docs/ADOPTION-LOG.md](docs/ADOPTION-LOG.md).
+9. **duplicate `[Unreleased]`** — `CHANGELOG.md` carries at most one
+   `## [Unreleased]` heading and it must be the topmost entry; the archives
+   carry none. Invariant 5 reads only the *first* `## [` heading, so a second
+   `[Unreleased]` further down was invisible to CI: on 2026-07-28 two feature
+   PRs each opened one above `[1.19.3]` and `main` carried both until a human
+   noticed during the release cut. Fence-aware, so a heading quoted inside a
+   code block doesn't count.
 
 Separately, `scripts/check-freshness.sh` (run monthly by
 `.github/workflows/freshness.yml`) tracks the root `LAST-VERIFIED` stamp —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Invariant 9 — at most one `## [Unreleased]`, and it must be the top entry**
+  (`scripts/check-invariants.sh`), with archives allowed none. Invariant 5 reads
+  only the *first* `## [` heading, so a second `[Unreleased]` further down was
+  invisible to CI; on 2026-07-28 PRs #142 and #143 each opened one above
+  `[1.19.3]` and `main` carried both until the v1.19.4 cut caught it by hand.
+  Fence-aware (a heading quoted inside a code block doesn't count), portable to
+  bash 3.2, no `python3` needed. Documented in AGENTS.md and CONTRIBUTING.md,
+  where the contributor-facing rule is: if `[Unreleased]` exists, add to it.
+
+  Watched to fail before being trusted, on all four cases — duplicate headings,
+  a single one buried below a release, one in an archive, and one quoted inside
+  a fence (must pass). The second case exposed a defect **in the check itself**:
+  `grep -m 1` on a pipe closes it early, the upstream `printf` dies of SIGPIPE,
+  and `pipefail` + `set -e` then killed the script mid-check — it printed its
+  heading and nothing else. Fixed by reading the first heading without an
+  early-exit consumer. (Invariant 5's `grep -m 1` is safe because it reads a
+  file, not a pipe.) A guard that dies silently is the failure this repo keeps
+  writing rules about; only running it against a real break surfaced it.
+
 ## [1.19.4] - 2026-07-28
 
 The **field-testing** release. v1.19.3 wrote down what a new repo needs; this one

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,12 @@ are marked "needs verification", never asserted.
    `[text](x)`-shaped prose/code; needs `python3` (skipped-with-warning if
    absent locally, enforced in CI). Adopted from the training-knowledge-vault
    vault-doctor (see [docs/ADOPTION-LOG.md](docs/ADOPTION-LOG.md)).
+9. **duplicate `[Unreleased]`**: `CHANGELOG.md` may carry at most one
+   `## [Unreleased]` heading, and it must be the topmost entry; the archive
+   files carry none. Practical effect for contributors: if `[Unreleased]`
+   already exists, **add to it** — don't open a second one. Invariant 5 only
+   inspects the first `## [` heading, so duplicates below it used to pass CI
+   (two PRs did exactly that on 2026-07-28).
 
 Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`);
 CI scans the full git history, the pre-commit hook scans each commit.

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -26,6 +26,11 @@
 #      match the [text](x) shape (e.g. type annotations) and false-positive.
 #      (Idea adopted from the training-knowledge-vault vault-doctor, 2026-07-24;
 #      see docs/ADOPTION-LOG.md.)
+#   9. CHANGELOG has at most one "## [Unreleased]" heading, it is the topmost
+#      entry, and the archives have none. Check 5 only compares the TOP entry
+#      to VERSION, so a second [Unreleased] lower down passed CI silently — on
+#      2026-07-28 two feature PRs each added one above [1.19.3] and main
+#      carried both until the release cut noticed by hand.
 #
 # Portable to macOS bash 3.2 (no mapfile/associative arrays). Checks 4 and 8 need
 # python3 (Unicode char counting; link parsing); they are skipped with a warning
@@ -48,7 +53,7 @@ note() { printf '    %s\n' "$1"; }
 # CHANGELOG, docs/) is human/agent-facing prose, not loaded as a skill, so it is
 # intentionally uncapped (decided 2026-07-15) — navigability there comes from a
 # table of contents and docs/INDEX.md, not a line ceiling.
-echo "[1/8] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
+echo "[1/9] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
 over=0
 while IFS= read -r f; do
   [ -f "$f" ] || { note "SKIPPED (tracked but missing from worktree): $f"; continue; }
@@ -62,7 +67,7 @@ done < <(git ls-files 'skills/*/*.md' 'skills/*/rules/*.md')
 if [ "$over" -eq 0 ]; then echo "    ok"; else fail=1; fi
 
 # --- 2. Audit checklist ends every rules file ------------------------------
-echo "[2/8] Every skills/*/rules/*.md ends with an '## Audit checklist'"
+echo "[2/9] Every skills/*/rules/*.md ends with an '## Audit checklist'"
 missing=0
 while IFS= read -r f; do
   [ -f "$f" ] || { note "SKIPPED (tracked but missing from worktree): $f"; continue; }
@@ -90,7 +95,7 @@ if [ "$missing" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # .denylist.local (git-ignored, one ERE per line, '#' comments). When neither
 # exists (e.g. an external fork's PR), only the generic phrases are checked —
 # the maintainer's pre-commit hook and this repo's CI carry the full list.
-echo "[3/8] No internal-name leaks"
+echo "[3/9] No internal-name leaks"
 DENY='the user runs|the user operates'
 if [ -n "${SOTA_DENYLIST:-}" ]; then
   DENY="$DENY|$SOTA_DENYLIST"
@@ -126,7 +131,7 @@ fi
 # Code, Codex, ...) skip any skill that exceeds it. Count Unicode characters
 # (descriptions use em-dashes: 1 char, 3 bytes) via python3, parsing both
 # folded block scalars (`>-`) and plain single-line descriptions.
-echo "[4/8] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
+echo "[4/9] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
 if command -v python3 >/dev/null 2>&1; then
   if desc_out=$(python3 - "$MAX_DESC" <<'PY'
 import sys, glob, re
@@ -180,7 +185,7 @@ fi
 # One version, four places: VERSION, plugin.json, the CHANGELOG's top entry,
 # and (after the release lands) the newest v* tag. Drift here shipped a main
 # briefly claiming 1.8.0 with 1.9.0 content (2026-07-03) — hence a hard check.
-echo "[5/8] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
+echo "[5/9] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
 v5=0
 ver=$(tr -d '[:space:]' < VERSION)
 # Strict X.Y.Z: rejects interior malformations (1..2, 1.2, 1.2.3.4) the old
@@ -214,7 +219,7 @@ if [ "$v5" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # rot on surfaces nobody recounts (the social preview said "30 skills" for
 # three releases). Recount from the tree and compare every tracked surface;
 # RELEASING.md lists the same surfaces for manual release edits.
-echo "[6/8] Count-bearing surfaces match the tree"
+echo "[6/9] Count-bearing surfaces match the tree"
 v6=0
 ck() { # ck <found> <expected> <surface>
   [ "$1" = "$2" ] || { note "$3: says '${1:-<not found>}', tree says '$2'"; v6=1; }
@@ -260,7 +265,7 @@ if [ "$v6" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # library-map entry must name a real skill dir. Catches the drift the
 # 2026-07-10 audit found: sota-confidential-computing was added to the table
 # but missing from the map for a full release.
-echo "[7/8] Router lists every skill (routing table + library map)"
+echo "[7/9] Router lists every skill (routing table + library map)"
 v7=0
 router=skills/sota/SKILL.md
 bt='`'
@@ -285,7 +290,7 @@ if [ "$v7" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # with no rot-catching upside. Fenced AND inline code are stripped so link-shaped
 # examples (in ``` fences or `backticks`) are not scanned. Idea from vault-doctor
 # (training-knowledge-vault); see docs/ADOPTION-LOG.md.
-echo "[8/8] Internal Markdown links resolve (*.md targets)"
+echo "[8/9] Internal Markdown links resolve (*.md targets)"
 if command -v python3 >/dev/null 2>&1; then
   if link_out=$(python3 - <<'PY'
 import os, re, sys
@@ -324,6 +329,47 @@ PY
 else
   note "SKIPPED: python3 not found (CI enforces this check)"
 fi
+
+# --- 9. One [Unreleased] section, at the top ---------------------------------
+# Check 5 reads only the FIRST '## [' heading, so a duplicate [Unreleased]
+# further down is invisible to it. Two feature PRs each opened one above the
+# previous release (2026-07-28) and both sat on main until a human noticed
+# during the release cut. Fence-aware, like check 2: a CHANGELOG entry may
+# legitimately quote '## [Unreleased]' inside a code fence.
+echo "[9/9] CHANGELOG has at most one [Unreleased], and it is the top entry"
+v9=0
+changelogs="CHANGELOG.md $(git ls-files 'docs/CHANGELOG-archive*.md' | tr '\n' ' ')"
+for cl in $changelogs; do
+  [ -f "$cl" ] || continue
+  # strip fenced blocks so quoted headings inside ``` are not counted
+  body=$(awk '/^(```|~~~)/ { fence = !fence; next } !fence' "$cl")
+  n=$(printf '%s\n' "$body" | grep -cE '^## \[Unreleased\]' || true)
+  case "$cl" in
+    CHANGELOG.md)
+      if [ "$n" -gt 1 ]; then
+        note "CHANGELOG.md has $n '## [Unreleased]' headings — merge them into one"
+        v9=1
+      elif [ "$n" -eq 1 ]; then
+        # No `grep -m 1` / `head` here: they close the pipe early, the upstream
+        # printf dies of SIGPIPE, and `set -o pipefail` + `set -e` then kill the
+        # script mid-check — it printed the heading and nothing else. (Check 5's
+        # `grep -m 1` is safe only because it reads a FILE, not a pipe.)
+        first=$(printf '%s\n' "$body" | grep -E '^## \[' | sed -n '1s/^## \[\([^]]*\)\].*/\1/p')
+        if [ "$first" != "Unreleased" ]; then
+          note "CHANGELOG.md has an [Unreleased] section below [$first] — it must be the top entry"
+          v9=1
+        fi
+      fi
+      ;;
+    *)
+      if [ "$n" -gt 0 ]; then
+        note "$cl has an '## [Unreleased]' heading — archives hold released versions only"
+        v9=1
+      fi
+      ;;
+  esac
+done
+if [ "$v9" -eq 0 ]; then echo "    ok"; else fail=1; fi
 
 # --- Result ---------------------------------------------------------------
 echo


### PR DESCRIPTION
Closes the gap the v1.19.4 cut found by hand.

## The hole

Invariant 5 reads only the **first** `## [` heading in `CHANGELOG.md`, so a second `[Unreleased]` further down is invisible to it. On 2026-07-28 PRs #142 and #143 each opened one above `[1.19.3]` — `main` carried both, CI stayed green, and it was only caught while cutting v1.19.4.

## The check

`CHANGELOG.md` may have at most one `## [Unreleased]`, and if present it must be the topmost entry; `docs/CHANGELOG-archive*.md` may have none. Fence-aware (same awk fence-toggle shape as check 2, so a heading quoted inside a code block doesn't count), portable to bash 3.2, no `python3` dependency.

## Watched to fail before being trusted

Per this repo's own convention — a guard nobody has seen reject something is an assumption:

| Case | Expected | Result |
|---|---|---|
| A — two `[Unreleased]` headings (the real bug) | caught | ✅ `has 2 '## [Unreleased]' headings` |
| B — one buried below a release entry | caught | ✅ `has an [Unreleased] section below [1.19.4]` |
| C — one in an archive file | caught | ✅ `archives hold released versions only` |
| D — one quoted inside a ```` ``` ```` fence | **ignored** | ✅ passes |

## Case B found a defect in the check itself

First run of case B printed the `[9/9]` heading **and nothing else** — no `ok`, no finding. Cause: `grep -m 1` on a pipe closes it after the first match, the upstream `printf` dies of SIGPIPE, and `set -o pipefail` + `set -e` then killed the script mid-check.

Fixed by extracting the first heading without an early-exit consumer (`grep` all matches, then `sed -n '1s/…/…/p'`). Invariant 5's own `grep -m 1` is safe **only** because it reads a file rather than a pipe — that's now stated in a comment so nobody "fixes" it into a bug later.

Worth stating plainly: the check written to catch a silent CI failure had a silent failure of its own, and nothing except running it against a real break would have shown it. Case A passed on the first try and would have shipped the bug.

## Docs updated in the same change

- `AGENTS.md` — invariant list now 9, with the why
- `CONTRIBUTING.md` — same, plus the contributor-facing rule: **if `[Unreleased]` exists, add to it, don't open a second one**
- `CHANGELOG.md` — a single `[Unreleased]` (which the new check now enforces on this very PR)

## Checks

`./scripts/check-invariants.sh` → 9/9 PASS. `pre-commit run --all-files` → PASS.
