### PR TITLE
feat: read-only setup check + two rules its own runs exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`docs/VERIFY-SETUP.md` — the read-only setup check.** `init-gates.sh` sets a
+  repo up; nothing checked the result, and "configured" and "working" render
+  identically. A paste-in prompt that reports whether the library reaches the
+  directory, whether the repo's agent file is *true*, and whether its gates are
+  real — changing nothing, and marking anything unobservable as UNVERIFIED
+  rather than passing it. Linked from README → Enforcing the gates and
+  docs/INDEX.md. Derived from two live runs against a 4300-commit repository:
+  the first run's own limitations produced four of its checks (claims-vs-commands,
+  the three-state hook distinction, execute-vs-reject, and can-you-land-the-fix),
+  each a gap the run exposed rather than something reasoned in advance.
+- **`sota-code-security` rules/10 §2.13 — a control that never executes.** One
+  step earlier than "runs but does nothing": a gate whose trigger never fires —
+  an `issue_comment` job nobody comments on, a path filter matching nothing, a
+  branch filter naming a renamed branch. Its whole run history is *skipped*, and
+  **all-skipped is not all-green, but every dashboard renders it the same way**.
+  Verify on two axes (ever executed / ever rejected) and state the sample.
+  Found in the wild: a review workflow with 5/5 skipped runs. One checklist item.
+- **`sota-docs-workflow` rules/01 §7 — check an agent file's *claims*, not just
+  that its commands exist.** The two rot at different rates and only the first
+  gets noticed. Observed on that same repo: all seven `make` targets resolved,
+  while the stated toolchain was seven months stale and the stated contents of
+  `make check` were wrong. Verify in two passes, and prefer linking the file that
+  owns a fact over asserting it. One checklist item.
+
 - **Invariant 9 — at most one `## [Unreleased]`, and it must be the top entry**
   (`scripts/check-invariants.sh`), with archives allowed none. Invariant 5 reads
   only the *first* `## [` heading, so a second `[Unreleased]` further down was

--- a/README.md
+++ b/README.md
@@ -413,6 +413,14 @@ yourself in place. The hooks call your project's own toolchain, so install the
 per-language tools it lists on exit (and `pre-commit install` if the script
 couldn't).
 
+**Then check it actually took.** `init-gates.sh` sets things up; nothing
+verifies the result, and "configured" and "working" render identically — a
+config file with no installed hook is not a control, and a CI job whose every
+run is *skipped* is a gate on paper. [docs/VERIFY-SETUP.md](docs/VERIFY-SETUP.md)
+is a read-only prompt you paste into an agent: it reports whether the library,
+this repo's context, and its gates are in place, changes nothing, and marks
+anything it could not observe as UNVERIFIED rather than passing it.
+
 Add `--docs-gate` to also install a pre-commit hook that **blocks a commit which
 changes code but updates no docs** (README/CHANGELOG/`docs/`/`*.md`) — so docs
 stay current without you having to ask. It writes a small helper to

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -58,6 +58,9 @@ lessons-log — its own best structural idea, applied to ourselves.
 | 2026-07-28 | Same session (`rust-post-edit.sh`, check-only by design) | Automation firing on an agent's edits must report, not rewrite — a rewrite stales the agent's own view of the file | **adopted** | `sota-docs-workflow/rules/01` §7 · v1.19.4 |
 | 2026-07-28 | Same session — `docker`-only probe missed a running podman | Detect by capability, not by one implementation's name | **rejected: already ours** | — |
 | 2026-07-28 | Same session — `tools/format_all.sh` exits 0 while checking nothing; `AGENTS.md` pins a stale toolchain; gate proven by making it fail; bash 3.2 empty-array and `set -e` in command substitution | Four rules of ours, independently rediscovered in the wild | **rejected: already ours** | — |
+| 2026-07-28 | Two live verification runs on an [asterinas](https://github.com/asterinas/asterinas) clone | A read-only setup check: is the library reaching this repo, is its agent file true, are its gates real | **adopted** | `docs/VERIFY-SETUP.md` · unreleased |
+| 2026-07-28 | Same runs — a review workflow with 5/5 *skipped* runs | A control whose trigger never fires: all-skipped is not all-green | **adopted** | `sota-code-security/rules/10` §2.13 · unreleased |
+| 2026-07-28 | Same runs — 7/7 `make` targets resolved while the stated toolchain was 7 months stale | Verify an agent file's claims, not just that its commands exist | **adopted** | `sota-docs-workflow/rules/01` §7 · unreleased |
 
 ## Entries
 
@@ -316,3 +319,49 @@ than a coverage one: the rules existed and were rediscovered by debugging.
 
 **Measurement status:** both adoptions are content refinements taken on
 reasoning, **not measured**. Do not cite a lift.
+
+### 2026-07-28 — the verification prompt, and what running it twice taught
+
+Source: two live read-only verification runs against a clone of
+<https://github.com/asterinas/asterinas>, 2026-07-28 — the second run using a
+prompt revised from the first run's own shortcomings. Neither run is an external
+repo of ideas; the *artifact under test was our own instruction*, which makes
+this the first entry where the observation is a measurement of our own output.
+
+**Adopted (3).** `docs/VERIFY-SETUP.md` fills a hole the library created for
+itself: `init-gates.sh` and `gen-agents-md.sh` set a repo up, and nothing ever
+checked the result. The distinction it exists to enforce is that **"configured"
+and "working" render identically** — a `.pre-commit-config.yaml` with no
+installed hook, a scanner nobody has watched reject anything, a CI job whose
+every run is skipped.
+
+Four of its checks were **not** designed; they are the first run's limitations,
+promoted:
+
+1. *Claims, not just commands.* The first prompt asked only whether named
+   commands exist. All seven `make` targets resolved — and the run found, on its
+   own initiative, that the file's stated toolchain was seven months stale and
+   its description of `make check` was wrong. That extension is now the
+   instruction, and the underlying rule landed in `rules/01` §7.
+2. *Three states for a hook*, not two: installed / configured-but-not-installed /
+   nothing configured at all. The run had to invent `N/A — nothing to install`
+   because the prompt offered no verdict that fit; an absent gate is a different
+   finding from an inert one.
+3. *Executed vs rejected.* Asked only "has it rejected anything", the run
+   surfaced something better — a review workflow whose five most recent runs were
+   all **skipped**, i.e. a trigger that never fires. That is a genuinely earlier
+   failure than the inert-control class we already had, and landed as
+   `sota-code-security` rules/10 §2.13.
+4. *Can you land the fix?* The run volunteered that the repo was upstream, not
+   the operator's — so every finding was an upstream PR, not local config. A fix
+   list you cannot land is a different deliverable.
+
+**Not adopted, worth recording.** The run's routing dry-run named 16 specific
+rules files; all 16 were verified to exist. That is the check working, not a
+change — but it is the reason the dry-run stays in the prompt: a routing
+verification that accepted plausible-looking filenames would be the most
+dangerous possible false pass.
+
+**Measurement status:** all three are content refinements adopted on reasoning,
+**not measured**. Do not cite a lift. `VERIFY-SETUP.md` is prose, not an
+enforced invariant — nothing in CI checks that a downstream repo ran it.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,6 +12,7 @@ trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issu
 | Understand how a prompt gets routed to skills | [README → How it works](../README.md#how-it-works); [`skills/sota/SKILL.md`](../skills/sota/SKILL.md) |
 | See example prompts (build & audit) | [README → Using it](../README.md#using-it) |
 | Enforce the rules as git hooks | [README → Enforcing the gates](../README.md#enforcing-the-gates) |
+| **Verify a repo is actually set up** (read-only check: library reaching it, agent file true, gates real not just configured) | [**VERIFY-SETUP.md**](VERIFY-SETUP.md) |
 | Use it with Codex / Gemini / other AGENTS.md agents | [README → Other AI agents](../README.md#other-ai-agents-codex-copilot-gemini-) |
 
 ## Keep the model applying the rules (context / "forgetting")

--- a/docs/VERIFY-SETUP.md
+++ b/docs/VERIFY-SETUP.md
@@ -1,0 +1,145 @@
+# Verifying a repo's setup — the read-only check
+
+`scripts/init-gates.sh` and `scripts/gen-agents-md.sh` **set things up**.
+Nothing checks the result. This is that check: a prompt you paste into a coding
+agent that reports whether the library, this repo's own context, and its gates
+are actually in place — and changes nothing.
+
+It exists because "configured" and "working" are different states that render
+identically. A `.pre-commit-config.yaml` with no installed hook is a file, not a
+control. A CI workflow whose every run is *skipped* is a gate on paper. An
+`AGENTS.md` whose commands all resolve can still assert a toolchain seven months
+stale. Each of those passes an existence check and fails the job.
+
+## When to run it
+
+- On a repo you just scaffolded, before trusting the scaffolding.
+- On a repo you inherited, before assuming its green CI means anything.
+- Periodically on your own, because agent files decay
+  ([`sota-docs-workflow` rules/01](../skills/sota-docs-workflow/rules/01-documentation-architecture.md) §7).
+
+## The prompt
+
+Paste this verbatim.
+
+```text
+SOTA setup verification — READ-ONLY. Do not build, scaffold, install, or fix
+anything. Do not create, modify, or delete a single file. If a check fails, say
+so and move on; the output is a report, not a repair.
+
+Verify by OBSERVATION, never inference. Run the command, read the file. Any
+check you cannot actually run gets reported as UNVERIFIED with the reason —
+never as a pass. Probe for capabilities, not for one implementation's name: a
+check for `docker` misses podman, `LICENSE` misses `LICENSE-MPL`,
+`.pre-commit-config.yaml` misses husky/lefthook/a CI job.
+
+## A. Is the library reaching this directory?
+
+1. List the sota-* skills you can actually load right now, and count them.
+   Compare against `ls -d ~/.claude/skills/sota*/ | wc -l` (or the plugin's
+   skills dir). PASS = the counts agree and the `sota` router is among them.
+2. Always-on routing: does `~/.claude/CLAUDE.md` contain a sota routing
+   directive, and does `~/.claude/settings.json` define a `UserPromptSubmit`
+   hook whose command mentions sota? PASS = both. If only the CLAUDE.md
+   directive exists, say so — routing then depends on the model reading it
+   rather than on a per-prompt injection.
+3. Stack profile: does `~/.claude/profiles/*.md` exist and resolve (not a
+   dangling symlink)? Report the filename only, not its contents.
+
+## B. Is this repo's own context in place?
+
+4. Agent file: `AGENTS.md` and/or `CLAUDE.md`. PASS is not existence — it is
+   CONTENT. Read it and state whether it carries (a) exact build/test/lint
+   commands, (b) deviations from the language default, (c) traps. A file that
+   only restates generic best practice, or that points at tooling a fresh
+   contributor would not have, is a FAIL with the reason.
+   If `CLAUDE.md` is a symlink, check it resolves; if it is a one-line pointer
+   to `AGENTS.md`, that is fine and preferred.
+5. Verify the agent file is TRUE, in two passes:
+   5a. Every build/test/lint command it names exists (Makefile target, script in
+       package.json, task in pyproject/justfile). Name the file:line of each.
+   5b. Every factual CLAIM it makes is still accurate — pinned versions,
+       toolchains, image tags, what a given target actually does. Open the file
+       it describes and compare. This is where agent files rot: the command
+       still exists, the claim about it went stale months ago, and nothing
+       checks it.
+6. Day-zero artifacts: a licence file (`LICENSE*`/`COPYING*`/`COPYRIGHT`),
+   `.gitignore`, README. Report each present/absent.
+
+## C. Are the gates real, or just configured?
+
+7. Find every gate mechanism, not just one: `.pre-commit-config.yaml`, husky,
+   lefthook, `.git/hooks/*` (non-sample), and CI workflows. For each, list what
+   it actually runs.
+8. Secret scanning specifically: is any gate running gitleaks/trufflehog/
+   detect-secrets, at commit time or in CI? Confirm with a repo-wide search, not
+   by assuming from a filename.
+9. Are the gates INSTALLED, not merely configured? Check `.git/hooks/` for
+   non-sample hooks and `core.hooksPath`. Distinguish three states: installed /
+   configured-but-not-installed (a file, not a control) / nothing configured at
+   all (N/A, not a failure).
+10. For each gate, establish TWO things from observable history — use
+    `gh run list --limit 60` (or the CI provider's equivalent) and read real
+    conclusions:
+    (a) Has it ever EXECUTED? A workflow whose runs are all "skipped" has a
+        trigger condition that never fires — that is a control on paper only.
+    (b) Has it ever REJECTED anything? A gate with only successes has never
+        been observed doing its job.
+    Mark each UNVERIFIED where history doesn't show it, and state your sample
+    size — "not in the last 60 runs" is not "never".
+
+## D. Routing dry-run (no code)
+
+11. Without writing any code, state which sota-* skills and which specific
+    rules files you WOULD load for: "add an authenticated file-upload endpoint
+    backed by Postgres". List them, then stop. This tests that routing resolves;
+    it is not permission to implement anything.
+
+## E. Can the findings be acted on?
+
+12. Report `git remote -v` and whether this repo is yours, a fork, or an
+    upstream clone. A fix list you cannot land is a different deliverable from
+    one you can.
+
+## Output
+
+A table: check | PASS / FAIL / PARTIAL / UNVERIFIED / N/A | evidence observed.
+PARTIAL and N/A each require a one-line reason. UNVERIFIED must state what
+prevented verification and your sample size where relevant.
+Then a short ordered list of what to fix — described, not done — each marked
+[local] or [upstream] per check 12.
+Do not apply any fix. Do not offer to start building. End after the report.
+```
+
+## The one check it cannot do read-only
+
+Proving the secret gate *rejects* something needs a real commit attempt. Run it
+yourself — three lines, reversible:
+
+```sh
+printf 'aws_secret_access_key = "AKIAIOSFODNN7EXAMPLE"\n' > leak-test.txt
+git add leak-test.txt && git commit -m "gate test"   # MUST be rejected
+git reset -q && rm -f leak-test.txt
+```
+
+If that commit succeeds, check 8 was a false pass — you have a scanner in the
+config and no control on the commit path.
+
+## Reading the report
+
+- **FAIL on check 5b with PASS on 5a** is the common and dangerous shape: the
+  commands work, the claims lie. Fix by replacing the assertion with a link to
+  the file that owns the fact.
+- **All-skipped run history** is
+  [`sota-code-security` rules/10](../skills/sota-code-security/rules/10-silent-control-failure.md)
+  §2.13 — the trigger is the finding, not the gate's logic.
+- **UNVERIFIED is not a soft PASS.** It means nobody has watched the thing work.
+  Treat it as unknown, and say so when reporting upward.
+
+## Provenance
+
+Derived from two live runs against a real 4300-commit repository (2026-07-28).
+The first run's own limitations produced checks 5b, 9's three-state
+distinction, 10's execute/reject split, and 12 — each was a gap the run exposed
+rather than something reasoned in advance. See
+[ADOPTION-LOG.md](ADOPTION-LOG.md).

--- a/skills/sota-code-security/rules/10-silent-control-failure.md
+++ b/skills/sota-code-security/rules/10-silent-control-failure.md
@@ -273,6 +273,34 @@ in-context data and the output, that is the finding — regardless of how
 carefully the instruction is worded. (Class added 2026-07-24 from the
 training-knowledge-vault lesson on attention leakage; see docs/ADOPTION-LOG.md.)
 
+### 2.13 A control that never executes
+
+One step earlier than "runs but does nothing": a gate whose **trigger condition
+never fires**. It is configured, committed, listed in the docs and visible in
+the UI — and its entire run history is *skipped*. Nothing errors, because
+nothing ran.
+
+Where it shows up: a CI job gated on an event that never occurs (an
+`issue_comment` trigger for a review workflow nobody comments on; a path filter
+that matches no real path; a branch filter naming a branch since renamed), a
+scheduled job on a disabled schedule, a hook registered under a lifecycle event
+the tool no longer emits, a policy scoped to a label nothing carries.
+
+The tell is in the run history, not the config: **all-skipped is not all-green,
+but every dashboard renders it the same way.** So verify a gate on two axes,
+not one:
+
+- **Has it ever executed?** Read real run history (`gh run list`, the pipeline's
+  own log) and count non-skipped runs. Zero means the trigger is unreachable —
+  the finding is the trigger, not the gate's logic.
+- **Has it ever rejected anything?** A gate with executions but no failures has
+  still never been observed doing its job (§1's falsification question, and
+  `sota-testing` rules/09 — watch a security test fail before trusting it).
+
+State the sample when reporting either: "no non-skipped run in the last N" is a
+bounded observation, not "never". A single-name search compounds this — see
+`sota/rules/01-audit-methodology.md` on absence claims.
+
 ## 3. Vacuous tests — the meta-case
 
 A test that passes against broken code is worse than no test: it manufactures
@@ -380,6 +408,10 @@ Design:
       below", authz-in-prompt) standing in for an enforced boundary over data or
       permissions that live in the same context? Enforce structurally/in code
       (rules/08 §1–2), not by instruction — §2.12.
+- [ ] For each gate, does run history show it has ever **executed** (not
+      all-skipped: an unreachable trigger, path/branch filter, or dead
+      lifecycle event) and ever **rejected** anything? State the sample size —
+      "not in the last N runs" is not "never" — §2.13.
 - [ ] Early-return guards on empty/oversized/unparseable input that an attacker
       can deliberately trigger to skip inspection?
 - [ ] Any truncation (`[:N]`, byte caps, `LIMIT`) on the path *into* a scan,

--- a/skills/sota-docs-workflow/rules/01-documentation-architecture.md
+++ b/skills/sota-docs-workflow/rules/01-documentation-architecture.md
@@ -238,6 +238,17 @@ Docs are now read by agents as well as humans. Same content, two consumers.
   runner that isn't the framework's, the port that isn't the documented one.
 - **Agent docs decay like all docs** — review them when commands change; a wrong
   test command in AGENTS.md silently corrupts every agent run.
+- **Check the file's *claims*, not just that its commands exist.** The two rot
+  at different rates and only the first is ever noticed. A verification that
+  confirms every named target resolves passes happily while the file asserts a
+  pinned toolchain seven months stale, an image tag long superseded, or that a
+  given target runs a check it doesn't. Observed exactly that on a 4300-commit
+  project: all seven `make` targets existed; the stated toolchain and the stated
+  contents of `make check` were both wrong. So verify in two passes — every
+  command resolves to a real target, **and** every factual assertion still
+  matches the file it describes. Better still, delete the assertion and link the
+  source of truth: a sentence naming the pin will drift, a pointer to
+  `rust-toolchain.toml` cannot.
 - **Automation that fires on an agent's edits must check, not rewrite.** A
   format-on-write hook is fine for a human editor and wrong for an agent: it
   changes the file *after* the agent wrote it, so the agent's view of that file
@@ -428,6 +439,7 @@ pointer: it reads as a satisfied requirement.
 - [ ] Every page-able alert links to a runbook; runbooks are command-exact, decision-tree ordered, flag destructive steps, and were updated after the last incident that used them.
 - [ ] Onboarding guide exists, and the newest joiner actually filed fixes against it.
 - [ ] Where the canonical dev loop doesn't run on every supported host, a capability report says per target what works here and what each gap blocks — probing capabilities rather than one implementation's name, and reporting rather than gating (§6).
+- [ ] Agent-file verification covers claims as well as commands: every named target resolves **and** every factual assertion (pins, tags, what a target does) still matches its source — with drift-prone assertions replaced by a link to the file that owns the fact (§7).
 - [ ] No automation rewrites files in response to an agent's edits (format-on-write hooks report instead); rewriting is confined to commit-time or CI, where nothing holds a live view of the file (§7).
 - [ ] One search surface covers internal docs; error messages/alerts/code link into docs.
 - [ ] AGENTS.md/CLAUDE.md exists, is short and human-curated, has exact build/test commands, and matches current reality; no forked divergent copies.


### PR DESCRIPTION
`init-gates.sh` and `gen-agents-md.sh` set a repo up. **Nothing checked the result.** This adds that check, plus the two library rules that the act of running it exposed.

The distinction it exists to enforce: **"configured" and "working" render identically.** A `.pre-commit-config.yaml` with no installed hook is a file. A scanner nobody has watched reject anything is an assumption. A CI job whose every run is *skipped* is a gate on paper.

## 1. `docs/VERIFY-SETUP.md`

A paste-in, read-only prompt: does the library reach this directory, is the repo's agent file *true*, are its gates real. Changes nothing; marks anything unobservable UNVERIFIED rather than passing it. Linked from README → Enforcing the gates and `docs/INDEX.md`.

Includes the one check it *cannot* do read-only — proving the secret gate rejects a real commit — as three reversible lines for the operator to run themselves.

## 2. `sota-code-security` rules/10 §2.13 — a control that never executes

One step earlier than the inert-control class we already had. A gate whose **trigger never fires**: an `issue_comment` job nobody comments on, a path filter matching nothing, a branch filter naming a since-renamed branch, a hook on a dead lifecycle event. Its whole run history is `skipped`, and **all-skipped is not all-green — but every dashboard renders it the same way.**

Verify on two axes, not one: has it ever *executed*, and has it ever *rejected*. State the sample — "not in the last 60 runs" is not "never".

Found in the wild: a review workflow with 5/5 skipped runs. One checklist item.

## 3. `sota-docs-workflow` rules/01 §7 — check the agent file's claims

Commands and claims rot at different rates, and only the first gets noticed. Observed on a 4300-commit project: **all seven `make` targets resolved** while the file's stated toolchain was seven months stale and its description of `make check` was wrong. Verify in two passes, and prefer linking the file that owns a fact over asserting it. One checklist item.

## Where the checks came from

Four of the prompt's checks were **not designed** — they are the first run's own limitations, promoted:

| Check | Origin |
|---|---|
| 5b claims-vs-commands | The run extended check 5 unprompted, and that extension found both real defects |
| 9's three states | The run had to invent `N/A — nothing to install`; no offered verdict fit an absent gate |
| 10's execute-vs-reject | Asked only about rejection, the run surfaced something better: 5/5 skipped |
| 12 can-you-land-the-fix | The run volunteered that the repo was upstream, so every finding was a PR, not local config |

`ADOPTION-LOG.md` records this as the first entry where the artifact under test is **our own instruction** rather than an external repo.

Also worth noting: the routing dry-run named 16 specific rules files and **all 16 were verified to exist** — no fabricated paths. That's the check working, and the reason it stays in the prompt: a routing verification that accepted plausible-looking filenames would be the most dangerous false pass available.

## Measurement

All three adopted on reasoning, **not measured** — no lift claimed. `VERIFY-SETUP.md` is prose, not an enforced invariant; nothing in CI checks that a downstream repo ran it.

## Checks

`./scripts/check-invariants.sh` → 9/9 PASS. `pre-commit run --all-files` → PASS. rules/10 at 437, rules/01 at 446 (cap 500).
