### PR TITLE
fix(python): carve the liveness probe out of the no-await async-def rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`sota-python` rules/07 §1 contradicted `sota-observability` rules/05 §1.**
+  rules/07:56 called an `async def` endpoint with zero `await` "a bug marker";
+  rules/05 specifies a liveness probe as process-internal-only, "usually just
+  return 200" — which *is* a no-`await` `async def`. A reader following rules/07
+  literally makes the handler `def`, it runs in the anyio threadpool, and
+  saturation by slow sync handlers delays the probe until the orchestrator
+  restarts a process whose event loop was fine: the restart storm rules/05
+  exists to prevent. rules/07 now carves the liveness case out explicitly, cross-
+  references rules/05 §1, tells the author to say so in the docstring (or the
+  next reader "fixes" it), and notes that readiness follows the normal rule. One
+  audit-checklist grep added.
+
+  Found by running the library, not reading it: a live BUILD session hit the
+  collision, resolved it correctly by judgment, and documented why — but only
+  because the model was thinking. The rule as written would have produced the
+  wrong code for a literal reader. Third gap this week surfaced by field use.
+
 ## [1.19.5] - 2026-07-28
 
 The **verify-what-you-set-up** release. The library could scaffold a repo and

--- a/skills/sota-python/rules/07-frameworks-testing.md
+++ b/skills/sota-python/rules/07-frameworks-testing.md
@@ -55,6 +55,14 @@ async def create_user(payload: UserIn, svc: UserService = Depends(get_user_servi
   SQLAlchemy async session / httpx.AsyncClient). Mixed stack? Make the endpoint `def` and
   stay sync, or fix the stack. An `async def` endpoint with zero `await` inside is a bug
   marker — it gains nothing and risks someone adding blocking calls later.
+- **Exception: the liveness probe.** A liveness endpoint is *supposed* to await nothing —
+  its job is "is the event loop responsive", so `sota-observability` rules/05 §1 specifies
+  process-internal-only, "usually just return 200". Written as `def` it runs in the anyio
+  threadpool, where saturation by slow sync handlers delays the probe and the orchestrator
+  restarts a process whose event loop was fine — the restart storm rules/05 exists to
+  prevent. So a no-`await` `async def` is **correct** here and the marker does not apply.
+  Say so in the docstring, or the next reader "fixes" it. Readiness (`/readyz`), which does
+  check dependencies, follows the normal rule.
 - Background work: `BackgroundTasks` for small post-response work; real job queue
   (arq/celery/temporal) for anything that must survive a process restart.
 
@@ -233,6 +241,7 @@ grep -rn "async def" $(grep -rln "APIRouter\|FastAPI" --include="*.py" src/) | h
 grep -rn "requests\.\|time.sleep\|session.query\|Session(" --include="*.py" src/ | grep -i route  # sync-in-async [HIGH]
 grep -rn "@\(app\|router\)\.\(get\|post\|put\|delete\)" --include="*.py" src/ -A3 | grep -L response_model | head  # ORM leak risk
 grep -rn "AsyncClient()" --include="*.py" src/ | grep -v lifespan              # per-request clients [MEDIUM]
+grep -rn -B2 "livez\|/health\|healthz" --include="*.py" src/ | grep "^.*def "  # liveness: `async def`, no deps (§1 exception)
 grep -rn "^[A-Z_]* = .*Session\|^engine = " --include="*.py" src/              # module-global state vs Depends
 
 # Django ORM


### PR DESCRIPTION
Two rules in the library contradicted each other. Both texts verified before writing this:

```
sota-python/rules/07:56
  An `async def` endpoint with zero `await` inside is a bug marker —
  it gains nothing and risks someone adding blocking calls later.

sota-observability/rules/05:13
  Liveness | Process-internal only: event loop responsive, no deadlock.
  Usually just "return 200".
```

A liveness probe written exactly as `sota-observability` prescribes **is** a no-`await` `async def` — which `sota-python` calls a bug marker. Neither rule cross-referenced the other.

## Why it matters, concretely

A reader following rules/07 literally makes the handler `def`. FastAPI then runs it in the anyio threadpool (~40 threads). When slow sync handlers saturate that pool, the probe is delayed, the orchestrator sees a failed liveness check, and it restarts a process whose event loop was perfectly healthy — **the restart storm rules/05 exists to prevent.** The rule as written produces the wrong code in exactly the case the other rule cares most about.

## The fix

rules/07 §1 now states the exception, cross-references rules/05 §1, explains the threadpool mechanism, tells the author to say so in the docstring (*or the next reader "fixes" it*), and notes that readiness — which does check dependencies — follows the normal rule. One audit-checklist grep added to spot liveness handlers.

## How it was found

By **running** the library, not reading it. A live BUILD session on a fresh repo hit the collision, chose the observability side, and justified it in the handler's docstring:

> `async def` with no `await` is intentional rather than an oversight: it keeps the handler on the event loop instead of the anyio threadpool, so a threadpool saturated by sync handlers cannot fail liveness and trigger that same restart storm.

That resolution is correct — but it only happened because the model was reasoning about both rules at once. A session that followed rules/07 literally would have shipped the bug. Converting a judgment call into a stated rule is the whole point.

Third gap this week surfaced by field use rather than review (after the asterinas agent-file claims and the all-skipped-workflow class).

## Measurement

Adopted on reasoning, **not measured** — no lift claimed.

## Checks

`./scripts/check-invariants.sh` → 9/9 PASS. `pre-commit run --all-files` → PASS. rules/07 at 266 lines (cap 500).
