### PR TITLE
feat(router): state how to resolve two rules that contradict each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Router — how to resolve two loaded rules that contradict each other.** The
+  library has 41 skills that can disagree and, until now, said nothing about
+  what to do when they do: a `grep` for `conflict|precedence|disagree|override`
+  across `skills/sota/SKILL.md` returned only an unrelated table row. Six lines
+  in "When this library is wrong": a contradiction is usually a **scope
+  collision** (a general default vs a requirement inside a narrower domain), the
+  narrower wins *in its domain*, pick by which failure mode is worse here, and
+  **never resolve it silently** — name the rule you followed and why in a comment
+  beside the code, or the next reader reverts it. Then report it, because a
+  contradiction needing judgment is itself a defect. Placed next to the report
+  path, outside the eval-pinned BUILD block (`ROUTER_BUILD_SHA` unchanged).
+
 ### Fixed
 
 - **`sota-python` rules/07 §1 contradicted `sota-observability` rules/05 §1.**
@@ -25,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collision, resolved it correctly by judgment, and documented why — but only
   because the model was thinking. The rule as written would have produced the
   wrong code for a literal reader. Third gap this week surfaced by field use.
+
+  **Scoped deliberately to Python**, verified rather than assumed: no other
+  language skill carries an analogous "async without await" rule (checked all
+  eight), and the trap is FastAPI-specific — a `def` handler is dispatched to
+  the anyio threadpool. `sota-javascript-typescript` rules/04 shows a *sync*
+  `/healthz` handler, which is correct for Node, where nothing dispatches
+  request handlers to a threadpool. No equivalent carve-out is needed elsewhere.
 
 ## [1.19.5] - 2026-07-28
 

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -481,6 +481,13 @@ task:
 - real surface area in the task with **no owning skill** — a routing gap;
 - guidance that, followed literally, would have shipped a defect.
 
+**Two loaded rules that contradict each other** are usually a scope collision:
+one is a general default, the other a requirement inside a narrower domain. The
+narrower wins *in its domain* — pick by which failure mode is worse here (a
+needless idiom vs an outage), never silently: name the rule you followed and why
+in a comment beside the code, or the next reader reverts it. Then report it —
+the fix is an explicit exception in whichever rule was too broad.
+
 Report: `https://github.com/martinholovsky/SOTA-skills/issues/new/choose`
 (bad-guidance / skill-request templates). Anything dangerous or
 security-sensitive goes to a **private advisory** instead — see `SECURITY.md`.


### PR DESCRIPTION
Answers a question #148 raised but didn't settle: is that collision Python-specific, and what about conflicts between cross-cutting and language skills generally?

## Is it Python-specific? Yes — verified, not assumed

| Check | Result |
|---|---|
| Analogous "async without await is a bug marker" rule in the other 8 language skills | **none** |
| `sota-javascript-typescript` rules/04 `/healthz` | a **sync** handler — correct for Node, where nothing dispatches request handlers to a threadpool |
| Other language skills mentioning liveness/readiness | Go: 1 file, JVM/.NET/Rust/PHP/Ruby/C++: 0 |

The trap is FastAPI-specific: a `def` handler gets dispatched to the anyio threadpool, so threadpool saturation delays the probe. No other language skill needs the carve-out. #148 was correctly scoped; that's now recorded in the CHANGELOG with the evidence.

## The bigger gap it exposed

The library ships **41 skills that can disagree**, and said nothing about what to do when they do. `grep -iE "conflict|precedence|disagree|overrid"` over `skills/sota/SKILL.md` returns a single unrelated table row. No resolution rule anywhere.

The liveness case is proof this matters: a live session hit the collision and resolved it correctly *by reasoning*, with no rule to lean on. The next session might not.

## The rule

Six lines, in "When this library is wrong" — next to the report path, because the two belong together:

- a contradiction is usually a **scope collision**: a general default vs a requirement inside a narrower domain
- the **narrower wins in its domain**
- pick by **which failure mode is worse here** (a needless idiom vs an outage)
- **never resolve it silently** — name the rule you followed and why in a comment beside the code, or the next reader reverts it
- **then report it**, because a contradiction that needed judgment is itself a defect, and the fix is an explicit exception in whichever rule was too broad

That last point closes the loop: this PR's own rule (#148) is exactly what "report it" should produce.

## Constraints respected

- Router **490 → 497** lines (cap 500). Tight — worth knowing the next router addition needs a trim first.
- `ROUTER_BUILD_SHA` unchanged at `71a9d78ea5e9e341` — the addition sits outside the eval-pinned BUILD block, so the completeness measurement is untouched.

## Measurement

Adopted on reasoning, **not measured** — no lift claimed.

## Checks

`./scripts/check-invariants.sh` → 9/9 PASS.
