### PR TITLE
docs: fix the stale 500-line cap in CONTRIBUTING, add the front-door release gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`CONTRIBUTING.md` carried the same wrong cap the README did.** Rule 3 said
+  "Every Markdown file is ≤ 500 lines" and the PR checklist said "All touched files
+  are ≤ 500 lines". The cap has been **skill-files-only since PR #100**
+  (2026-07-15) — README/CHANGELOG/`docs/` are deliberately uncapped. Both fixed,
+  with the reason (incremental rule loading) and where navigability comes from
+  instead. `AGENTS.md` was checked and needed no change: its wording already scopes
+  the cap correctly ("the cap is load-bearing only there").
+- **`RELEASING.md` gained the step that would have caught the invisible-audit-half
+  problem** — a new §2b "Front-door surfaces", because **no invariant catches a
+  capability that never got a sentence anywhere a reader looks**. Invariant 6 fails
+  on a wrong *number* in the README; nothing fails on a missing *feature*, which is
+  how five audit capabilities went undocumented across v1.17.0–v1.19.7. The pre-tag
+  checklist now carries a matching item. Also documented there: avoid dots in release
+  branch names — the assistant's `Bash(git checkout *.*)` deny rule matches a branch
+  name containing dots, so `release/v1.19.7` is refused while
+  `chore/release-v1-19-7` works. It bit again at this cut.
+- **`docs/MAINTENANCE.md` now names its high-rot targets** instead of treating every
+  claim as equally durable. First on the list is §3.9.2's eight-project tool table,
+  which demonstrated its own failure mode the day it landed: two of the eight had
+  been renamed under the URLs a manifest still carries. The runbook now says to
+  re-verify with `gh api` **and read `full_name` back**, and flags that the Ruby row
+  asserts a *negative* ("no established tool") that needs re-checking rather than
+  assuming.
+- **`docs/ROADMAP.md` re-stamped to 2026-07-30 / post-v1.19.7**, recording a third
+  discovery mode (a user-authored prompt aimed at the library's own coverage, with
+  CVEs ruled out), four new open items, and live re-checked adoption signals: **8
+  stars, 0 watchers, 2 forks, exactly one true issue ever** (#4, closed — filtering
+  `has("pull_request")` out of the issues endpoint, which otherwise counts every PR
+  as an issue), and **0 external gap reports in 8 days**. `ROUTER_BUILD_SHA` was
+  **re-computed and matched** (`71a9d78ea5e9e341`), confirming v1.19.7's router edits
+  landed outside the eval-pinned BUILD block, so historical completeness runs stay
+  comparable. Router headroom re-counted at 497/500.
+- **`docs/INDEX.md`** points at the README's new audit section, so the capability is
+  reachable from the find-it-fast index rather than only from the README itself.
+
 ## [1.19.7] - 2026-07-30
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,13 @@ By contributing you agree your contribution is licensed under
    numbers are for semantic boundaries only ("GA since", "fixed in", CVE fix
    versions, spec editions). Recommend maintained tools; when one goes EOL,
    point at its maintained successor and keep a one-line EOL note.
-3. **Stay lean.** Every Markdown file is **≤ 500 lines** so skills load
-   incrementally without blowing the context window. If a topic outgrows that,
-   split it into another `rules/NN-topic.md`.
+3. **Stay lean.** Every **skill** file (`skills/*/SKILL.md`, `skills/*/rules/*.md`)
+   is **≤ 500 lines** so skills load incrementally without blowing the context
+   window. If a topic outgrows that, split it into another `rules/NN-topic.md`.
+   The cap is load-bearing *only* there: README, CHANGELOG and `docs/` are read
+   by humans and agents rather than loaded as skills, so they are deliberately
+   **uncapped** (decided 2026-07-15, PR #100) — navigability there comes from a
+   table of contents and [docs/INDEX.md](docs/INDEX.md).
 
 ## Repository layout
 
@@ -165,7 +169,7 @@ Run the invariant checks any time:
 - [ ] Stays generic — no personal/company stack, project names, or "you run X".
 - [ ] New fast-moving claims cite a primary source.
 - [ ] Every touched `rules/*.md` still ends with `## Audit checklist`.
-- [ ] All touched files are ≤ 500 lines.
+- [ ] All touched **skill** files (`skills/**`) are ≤ 500 lines (README/CHANGELOG/`docs/` are uncapped).
 - [ ] No secrets in examples (masked/placeholder only).
 - [ ] `pre-commit` / `scripts/check-invariants.sh` passes.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,6 +46,27 @@ Then update every surface that carries a count:
   is typically blocked), commit both files, and re-upload the PNG at GitHub
   **Settings → Social preview** (the repo file does not refresh it).
 
+## 2b. Front-door surfaces (every release) — no gate catches these
+
+Invariant 6 fails the build on a wrong **number** in the README. **Nothing** fails
+on a capability that never got a sentence anywhere a reader looks. That gap is not
+hypothetical: at the v1.19.7 cut, grepping `main` returned **0 hits** in `README.md`
+for `adversarial`, `refut`, `decision ledger`, `inert`, `no-op`, and `ADOPTION-LOG` —
+five capabilities shipped across v1.17.0–v1.19.7 with no front-door mention, and
+"How it works" still described an audit chain that predated three of its own passes.
+
+So before tagging, for each capability this release (and the last few) added:
+
+```sh
+grep -ic '<distinctive term>' README.md docs/INDEX.md
+```
+
+Zero hits is a **documentation finding**, not a polish item — fix it in the release
+PR. Two habits that go with it: say where a capability is *not* backed by a measured
+number rather than letting the reader assume, and re-read the long-lived prose while
+you are there (that cut found "keep every file ≤ 500 lines" in both README and
+CONTRIBUTING, a cap that has been skill-files-only since PR #100).
+
 ## 3. Land the PR
 
 ```sh
@@ -53,6 +74,11 @@ Then update every surface that carries a count:
 git checkout -b <branch> && git commit && git push
 # open the PR; both required checks green → squash-merge
 ```
+
+**Branch naming:** avoid dots. The assistant's permission rule `Bash(git checkout *.*)`
+— meant to block file-discarding checkouts — also matches a *branch* name containing
+dots, so `release/v1.19.7` is denied while `chore/release-v1-19-7` works. This bites
+at almost every cut (it did again at v1.19.7); a human shell is unaffected.
 
 ## 4. Tag and publish (after the squash-merge)
 
@@ -83,4 +109,7 @@ skills.
       re-rendering the PNG)
 - [ ] New skills appear in the README table and the router's routing table +
       library map
+- [ ] **Front-door grep done (§2b)** — every capability this release added has a
+      mention in README/`docs/INDEX.md`, and anything unbacked by a measured number
+      says so
 - [ ] GitHub Settings social-preview re-upload — only if the PNG changed

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@ trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issu
 | See the SOTA-vs-competitor benchmark | [COMPETITOR-BENCHMARK.md](../evals/results/2026-07-13/COMPETITOR-BENCHMARK.md) |
 | Read a shareable write-up of the key finding | [writeups/completeness-blind-spot.md](writeups/completeness-blind-spot.md) |
 | See what the library does **not** lift (the honest +0.00s) | [AUDIT-PROCESS.md](../evals/results/2026-07-20/AUDIT-PROCESS.md) |
+| Know what the audit hunts that a scanner can't (inert controls, unreached dependencies, stale decisions, refutation, absence claims) | [README → What the audit hunts](../README.md#what-the-audit-hunts-that-a-scanner-cant) |
 | Read the retraction + the retired anchoring hypothesis | [SILENT-FAILURE.md](../evals/results/2026-07-20/SILENT-FAILURE.md) |
 
 ## Contribute / operate the repo
@@ -44,7 +45,7 @@ trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issu
 | Know the invariants CI enforces | [AGENTS.md → Invariants](../AGENTS.md#invariants-enforced-in-pre-commit-and-ci) |
 | Full contribution conventions | [CONTRIBUTING.md](../CONTRIBUTING.md) |
 | Cut a release | [RELEASING.md](../RELEASING.md) |
-| Keep fast-moving claims accurate (sweep runbook) | [MAINTENANCE.md](MAINTENANCE.md) |
+| Keep fast-moving claims accurate (sweep runbook + named high-rot targets) | [MAINTENANCE.md](MAINTENANCE.md) |
 | See which external ideas were adopted/rejected and why | [ADOPTION-LOG.md](ADOPTION-LOG.md) |
 | See what's planned / open | [ROADMAP.md](ROADMAP.md) |
 | Report bad guidance or a leaked secret | [SECURITY.md](../SECURITY.md) |

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -53,6 +53,23 @@ fix what has drifted. Do it as a **rolling** pass (a few skills a month) or a
    caught (e.g. the 2026-07 sweeps caught "BIMI = RFC 8910" and a stale
    DMARC RFC this way).
 
+**Named high-rot targets** (check these even in a rolling pass):
+
+- **`sota-devsecops` rules/03 §3.9.2 — the dependency-reachability tool table.**
+  Eight third-party projects, each row asserting that tool's *documented* blind
+  spot; all verified live 2026-07-30. Highest-rot item in the library by
+  construction, and it demonstrated its own failure mode on the day it landed: two
+  of the eight had been **renamed** under the URLs a manifest still carries
+  (`fpgmaas/deptry` → `osprey-oss/deptry`, `icanhazstring/composer-unused` →
+  `composer-unused/composer-unused`). Re-verify each with
+  `gh api repos/<o>/<r> --jq '{full_name, archived, pushed_at}'` and **read
+  `full_name` back** — `gh api` follows renames silently, so a 200 under the old
+  name is not evidence the project is where the row says it is. The Ruby row
+  asserts a *negative* ("no established tool"); re-check that a maintained option
+  has not appeared rather than assuming it still holds.
+- **Tool names generally** — the §3 tool matrix in `sota/rules/01`: renames, forks
+  and license splits (Semgrep → Opengrep) are the common drift, not version bumps.
+
 **At scale**, this is a natural multi-agent job: one research+fix agent per
 skill in parallel, then an independent adversarial verify pass, then land the
 fixes via PR. The 2026-07-08 sweep (65 fixes) and 2026-07-10 audit followed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,9 +4,38 @@ Priorities set by the **2026-07-10 audit**
 ([AUDIT-2026-07-10.md](AUDIT-2026-07-10.md)). Ordered; revisit after each
 release. The 2026-07-01 cycle is fully executed and kept below as history.
 
-## Open tasks — next-session pick-up *(as of 2026-07-28)*
+## Open tasks — next-session pick-up *(as of 2026-07-30)*
 
-**Current state (2026-07-28, after v1.19.6).** Six patch releases landed
+**This cycle (2026-07-30, v1.19.7 — "inert dependency").** One release, from a
+**third** discovery mode: not an external repo (v1.19.1–2) and not us running the
+library (v1.19.3–6), but a **user-authored audit prompt aimed at the library's
+coverage**, with CVEs and versions explicitly ruled out of scope. Under that
+exclusion, 5 of its 6 requirements had no home — `rules/03-dependencies.md`
+answered "is what we ship vulnerable" from end to end and never "is this
+dependency reached at all" (all eight `reachab*` mentions in the file were
+CVE-triage reachability). Landed: `sota-devsecops` rules/03 **§3.9
+declared-but-not-reached** (entrypoint tracing incl. the impossible-path trap,
+per-ecosystem tools each with its documented blind spot, **deletion-as-proof**,
+leverage ratio, `gh api` upstream health, A–D taxonomy), cross-refs into the four
+language skills with partial or zero coverage, and 8 rows + an entry in
+[ADOPTION-LOG.md](ADOPTION-LOG.md). **Not measured — do not cite a lift.**
+
+Two rules came out of *validating* that section rather than writing it: `gh api`
+follows repo renames silently (so a 200 under a manifest's URL is not evidence the
+project is still there), and where an ecosystem has no established tool (Ruby;
+.NET is thin) the honest instruction is to skip the tool and go straight to the
+deletion proof. Four first-draft claims were wrong and were corrected against
+primary sources; one (`pushed_at` "moves on any branch push") could not be
+confirmed and was **dropped** rather than shipped.
+
+**Also this cycle: the README's audit half was invisible.** Grep on `main` before
+the cut returned **0 hits** for `adversarial`, `refut`, `decision ledger`, `inert`,
+`no-op`, and `ADOPTION-LOG` — five capabilities shipped across v1.17.0–v1.19.7 that
+no reader could find from the front door, and "How it works" still described a
+five-step audit chain that predated three of its own passes. Fixed with a new
+README section carrying its own +0.00 caveat. The generalisable finding is below.
+
+**Prior cycle (2026-07-28, after v1.19.6).** Six patch releases landed
 2026-07-24…28 (**v1.19.1 → v1.19.6**), and the notable shift is *how* they were
 found: v1.19.1–2 came from reading external repos, v1.19.3–6 from **running the
 library and watching it fail**. Landed: three external intakes recorded in
@@ -30,7 +59,36 @@ a vague three-word prompt routed to clarifying questions instead and skipped it.
 Silence is therefore not evidence the rule is broken — check the router loaded
 first.
 
-**New open items from this cycle:**
+**New open items from the 2026-07-30 cycle:**
+
+- **No gate notices a capability that never reached a front-door surface.**
+  Invariant 6 fails the build on a wrong *number* in the README; nothing fails on a
+  missing *feature*. That is why five audit capabilities went undocumented for three
+  releases — the same silent-surface shape `sota-code-security` rules/10 describes
+  for controls. Interim fix landed in [RELEASING.md](../RELEASING.md): the pre-tag
+  checklist now says to grep the README and `docs/INDEX.md` for a distinctive term
+  from each capability the release added. A real gate would need a machine-readable
+  list of capabilities per release — worth considering, not obviously worth the
+  ceremony.
+- **§3.9 may be the one audit instrument that could move off +0.00.** Every audit
+  eval saturates because a frontier model handed the code *and* the question is
+  already at ceiling — but §3.9 grades a **procedure** (copy the tree, delete the
+  dependency, run the real build, report exit codes) rather than a recognition. An
+  eval that scores whether the model *actually ran the deletion* instead of asserting
+  "appears unused" would test something the saturated instruments cannot reach. Needs
+  a tool-using harness, so it shares the blocker with the agentic large-repo audit
+  (item 2 below) — cheaper, though: a small fixture repo with two genuinely inert
+  dependencies and one reached only from a test.
+- **The §3.9 tool table will rot.** It names eight third-party projects, each with
+  its documented blind spot, all verified live 2026-07-30. Two had already been
+  **renamed** under the URLs a manifest would carry. It is now a named target in
+  [MAINTENANCE.md](MAINTENANCE.md); the section itself tells readers to re-verify
+  before trusting a row, which is the only maintainable posture.
+- **Ruby and .NET have no dependency-reachability tool worth naming.** Recorded as a
+  deliberate gap, not an oversight (candidates: 5 stars, one contributor each, one
+  with no push since 2025-01-03). Revisit if a maintained option appears.
+
+**Open items from the 2026-07-28 cycle (still open):**
 
 - **No update-notification path for clone installs.** Symlinked skills update the
   moment you `git pull`, but nothing ever tells you to pull. The plugin's
@@ -58,10 +116,12 @@ first.
   materialise either: gh's update notice fires **on invocation**, and nobody
   invokes a CLI for a library used inside an agent session. Revisit only if
   one-command install becomes the bottleneck.
-- **Router headroom: 497/500 lines.** The next router addition needs a trim
-  first. `ROUTER_BUILD_SHA` is still `71a9d78ea5e9e341` — every router edit this
-  cycle landed outside the eval-pinned BUILD block, so historical completeness
-  runs stay comparable.
+- **Router headroom: 497/500 lines** (re-counted 2026-07-30 — v1.19.7's routing-table
+  and library-map edits were made net-zero on purpose, by recombining a wrapped line).
+  The next router addition needs a trim first. `ROUTER_BUILD_SHA` is still
+  `71a9d78ea5e9e341`, **re-computed and matched 2026-07-30**, so every router edit
+  across v1.19.x landed outside the eval-pinned BUILD block and historical
+  completeness runs stay comparable.
 - **Unverified claim in the README** — that git-hosted plugin marketplaces
   re-check at session start. Documented, not checked against a primary source.
   `rules/01` §7 now tells readers to verify claims like this; we should take our
@@ -81,14 +141,16 @@ infographic, and — the headline — **cross-model replication: the +0.39 compl
 lift is not sonnet-specific** (`openai/gpt-5.1` shows **+0.44**).
 
 **Genuinely open, ordered by value:**
-1. **Distribution / adoption** — the real bottleneck. Re-checked 2026-07-28 via
-   `gh`: **8 stars, 0 watchers, 2 forks, 1 issue ever** (closed, 2026-06-29). The
-   gap-reporting loop has now produced **0 reports in 6 days** — still short of a
-   verdict, but the "cut it if nil in a few weeks" clock is running. Note the
-   asymmetry this cycle exposed: three real gaps were found by *us* running the
-   library, none by an external reporter. Publish the salience write-up + the
-   infographic (LinkedIn is the measured top referrer). A **people problem, not a
-   measurement one** — the highest-leverage lever left.
+1. **Distribution / adoption** — the real bottleneck. Re-checked live 2026-07-30 via
+   `gh api`: **8 stars, 0 watchers, 2 forks** — unmoved in two days — and **exactly
+   one true issue ever** (#4, closed; filtering `has("pull_request")` out of the
+   issues endpoint, which otherwise counts all 150+ PRs as issues). The gap-reporting
+   loop has produced **0 external reports in 8 days**. The asymmetry is now sharper,
+   not softer: every gap closed in v1.19.3–v1.19.7 was found by *us* running the
+   library or by the maintainer aiming a prompt at it — **none by an external
+   reporter**. Publish the salience write-up + the infographic (LinkedIn is the
+   measured top referrer). A **people problem, not a measurement one** — the
+   highest-leverage lever left.
 2. **Agentic large-repo audit** — the *only* design that could move AUDIT off +0.00
    (all four single-prompt audit instruments saturate). Needs a new tool-using harness
    + a large ground-truth-defect fixture + two-axis (recall × efficiency) scoring;


### PR DESCRIPTION
Post-v1.19.7 documentation pass. Docs-only — no version bump, everything under `[Unreleased]`.

## Stale / invalid, removed

- **`CONTRIBUTING.md` carried the README's twin bug.** Rule 3: *"Every Markdown file is ≤ 500 lines"*. PR checklist: *"All touched files are ≤ 500 lines"*. Both wrong since **PR #100** (2026-07-15) — the cap is skill-files-only and README/CHANGELOG/`docs/` are deliberately uncapped. The v1.19.7 cut fixed this in the README and missed the twin here.
- **`AGENTS.md` was checked for the same defect and needed no change** — its wording already scopes the cap ("the cap is load-bearing only there"). Reported rather than edited for the sake of editing, so `CLAUDE.md`/`GEMINI.md` (its symlinks) are untouched.

Verified by sweep, not spot-check: `grep -rn "500 lines\|≤ 500\|<= 500" --include="*.md"` over the tree. The three remaining non-skill hits are correct in context (README's "296 files, each file under 500 lines" refers to those skill files; the router's parenthetical describes rule files; `WHY-IT-WORKS.md` says "every skill file").

## Process gap this session exposed, now closed

**No invariant catches a capability that never reached a front-door surface.** Invariant 6 fails the build on a wrong *number* in the README; nothing fails on a missing *feature*. That is how five audit capabilities shipped across v1.17.0–v1.19.7 with **0 README hits** for `adversarial`, `refut`, `decision ledger`, `inert`, `no-op`, `ADOPTION-LOG`. It is the same silent-surface shape `sota-code-security` rules/10 describes for controls — the surface looks fine because nothing errors.

New **`RELEASING.md` §2b "Front-door surfaces"** + a matching pre-tag checklist item: grep README and `docs/INDEX.md` for a distinctive term per capability the release added; zero hits is a documentation finding, not a polish item. Also documented there: **avoid dots in release branch names** — the assistant's `Bash(git checkout *.*)` deny rule matches a branch name containing dots, so `release/v1.19.7` is refused while `chore/release-v1-19-7` works. It bit again at this cut.

## Rot management

**`docs/MAINTENANCE.md` now names high-rot targets** instead of treating every claim as equally durable. First is §3.9.2's eight-project tool table, which demonstrated its own failure mode on landing day: two of the eight had been **renamed** under the URLs a manifest still carries. The runbook now says to re-verify via `gh api` **and read `full_name` back**, and flags that the Ruby row asserts a *negative* ("no established tool") which must be re-checked rather than assumed to hold.

## Roadmap re-stamped 2026-07-30 — every number re-verified live

| Claim | Method | Result |
|---|---|---|
| Adoption signals | `gh api repos/...` | 8 stars, 0 watchers, 2 forks — unmoved in 2 days |
| "1 issue ever" | `gh api .../issues --paginate --jq 'select(has("pull_request")\|not)'` | **exactly 1** (#4, closed). The unfiltered endpoint reports every PR as an issue — the previous figure was right by luck, not method |
| Gap reports | same | **0 external** in 8 days |
| Eval comparability | recomputed sha256 of the router BUILD block | `71a9d78ea5e9e341` — **matches the pin**, so v1.19.7's router edits landed outside it |
| Router headroom | `wc -l` | 497/500 (v1.19.7 was made net-zero on purpose) |

Four new open items recorded, including the observation that **§3.9 may be the one audit instrument that can move off +0.00**: every existing audit eval saturates because a frontier model handed the code *and* the question is already at ceiling, but §3.9 grades a **procedure** (copy the tree, delete the dependency, run the real build, report exit codes) rather than a recognition. Cheaper than the agentic large-repo audit, and shares its tool-using-harness blocker.

## Gates

`./scripts/check-invariants.sh` → **PASS, all 9**. `pre-commit run --all-files` → gitleaks + invariants pass.
