### PR TITLE
feat: version reporting + invariant 10, and two roadmap items proven wrong

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,16 @@ symlinks to it — edit only this file, never the symlinks.
    PRs each opened one above `[1.19.3]` and `main` carried both until a human
    noticed during the release cut. Fence-aware, so a heading quoted inside a
    code block doesn't count.
+10. **unindexed rules file** — every `skills/*/rules/*.md` must be referenced by
+    its own `SKILL.md`. The model reads only the rules files the index points at,
+    so an unindexed one is written, capped, checklist-ed — and never loaded. It is
+    the skill-level twin of invariant 7 (a skill missing from the router) and the
+    same class as `sota-devsecops` rules/03 §3.9, turned on ourselves. Invariant 8
+    does **not** cover it: **30 of 41** `SKILL.md` files list their rules as
+    plain backticked text rather than Markdown links, so a rename leaves nothing
+    for the link checker to resolve (measured 2026-07-30). All 255 rules files
+    passed when this landed — it is a regression gate, watched to fail on an
+    injected file and on a renamed reference first.
 
 Separately, `scripts/check-freshness.sh` (run monthly by
 `.github/workflows/freshness.yml`) tracks the root `LAST-VERIFIED` stamp —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Invariant 10 — every `skills/*/rules/*.md` must be referenced by its own
+  `SKILL.md`.** The library's loading model is that `SKILL.md` loads first and the
+  model reads only the rules files its index names, so an unindexed rules file is
+  written, capped, checklist-ed — and never loaded. It is the skill-level twin of
+  invariant 7 (a skill missing from the router) and the same class as the new
+  §3.9, turned on ourselves. **Invariant 8 does not cover it:** measured
+  2026-07-30, **30 of 41** `SKILL.md` files list their rules as plain backticked
+  text rather than Markdown links, so a rename leaves the link checker nothing to
+  resolve — verified by renaming `sota-golang/rules/01-errors.md` and watching
+  invariant 8 report `ok` while invariant 10 caught it. All 255 rules files pass,
+  so this is a **regression gate, not a repair**; watched to fail on two injected
+  cases (an unindexed new file, and a renamed reference) before being trusted,
+  per the harness convention.
+- **`scripts/install.sh --version`** — nothing reported which release was in use,
+  so a bug report ("the day-zero check fired wrongly") could not name the version
+  that produced it. Reports the release (read from `VERSION`, never hardcoded),
+  `git describe` incl. `-dirty`, whether the remote is ahead **as of the last
+  fetch** (no implicit network call), and whether skills are symlinked (update
+  live) or a pinned `--copy` snapshot. **`--update` now prints the version delta**
+  (`1.19.7 → 1.20.0 — see CHANGELOG.md`) or `(unchanged)`: because symlinked
+  skills change under you on a pull, "nothing happened" and "you just moved three
+  releases" previously looked identical. Tested on six paths — normal checkout,
+  non-git snapshot, missing `VERSION`, unlinked target, `--update` with and
+  without a change, and behind-upstream — each verified to exit 0 without
+  tripping `set -euo pipefail`.
+
 ### Changed
 
+- **The README told users auto-update would keep them current. It doesn't.** The
+  roadmap had flagged "git-hosted marketplaces also check at session start" as
+  documented-but-unverified; checked against the Claude Code docs 2026-07-30, it is
+  wrong in the way that matters: *"Third-party and local development marketplaces
+  have auto-update disabled by default"* — this is a third-party marketplace, so a
+  plugin user gets **no** automatic refresh unless they turn it on. Even enabled,
+  the check runs after session start "with a random delay of up to ten minutes"
+  while the running session keeps its launch versions. The section now carries the
+  quote, the opt-in path (`/plugin` → Marketplaces → Enable auto-update), and a
+  pointer to `--version`. This makes the open update-notification item **more**
+  pressing, not less: neither install path pushes updates by default.
+- **`docs/ROADMAP.md` corrected an item that was itself wrong.** It claimed
+  `install.sh --update` "already pulls and knows both versions — have it print the
+  delta". The script had **zero** references to `VERSION`
+  (`grep -c VERSION scripts/install.sh` → 0), so the cheap fix it proposed did not
+  exist. Now implemented, and the item split into what is done (report) and what
+  remains open (push).
+- **A third copy of the stale 500-line claim, this time inside the checker.**
+  `scripts/check-invariants.sh`'s own header said invariant 1 covers "every tracked
+  `*.md`", contradicting its own implementation (skills-only, with a comment
+  explaining why). Fixed. After the README and CONTRIBUTING fixes, that is three
+  places one policy change failed to reach — the reason RELEASING.md §2b now says
+  to re-read long-lived prose at each cut.
 - **`CONTRIBUTING.md` carried the same wrong cap the README did.** Rule 3 said
   "Every Markdown file is ≤ 500 lines" and the PR checklist said "All touched files
   are ≤ 500 lines". The cap has been **skill-files-only since PR #100**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,12 @@ are marked "needs verification", never asserted.
    already exists, **add to it** — don't open a second one. Invariant 5 only
    inspects the first `## [` heading, so duplicates below it used to pass CI
    (two PRs did exactly that on 2026-07-28).
+10. **unindexed rules file**: every `skills/*/rules/*.md` must be referenced by
+    its own `SKILL.md`. Practical effect: when you add a rules file, add a row
+    for it to that skill's rules index in the same PR — otherwise the model
+    never loads it, because it reads only the files the index names. Invariant 8
+    does not catch this: **30 of 41** `SKILL.md` files list rules as plain
+    backticked text rather than links, so a rename leaves no link to resolve.
 
 Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`);
 CI scans the full git history, the pre-commit hook scans each commit.
@@ -169,6 +175,7 @@ Run the invariant checks any time:
 - [ ] Stays generic — no personal/company stack, project names, or "you run X".
 - [ ] New fast-moving claims cite a primary source.
 - [ ] Every touched `rules/*.md` still ends with `## Audit checklist`.
+- [ ] Any **new** `rules/*.md` has a row in its skill's rules index (invariant 10).
 - [ ] All touched **skill** files (`skills/**`) are ≤ 500 lines (README/CHANGELOG/`docs/` are uncapped).
 - [ ] No secrets in examples (masked/placeholder only).
 - [ ] `pre-commit` / `scripts/check-invariants.sh` passes.

--- a/README.md
+++ b/README.md
@@ -253,8 +253,23 @@ none of them.
 ### Updating
 
 **Plugin install:** updates ship when the version bumps — `/plugin update
-sota-skills@sota-skills` (or `/plugin marketplace update sota-skills`). Git-hosted
-marketplaces also check at session start.
+sota-skills@sota-skills` (or `/plugin marketplace update sota-skills`).
+
+**Do not assume auto-update covers you.** Per the
+[Claude Code docs](https://code.claude.com/docs/en/discover-plugins#configure-auto-updates)
+(checked 2026-07-30): *"Third-party and local development marketplaces have
+auto-update disabled by default"* — this is a third-party marketplace, so unless you
+turned it on (`/plugin` → **Marketplaces** → the entry → **Enable auto-update**),
+nothing updates on its own. Even with it enabled, the check runs *after* your session
+starts "with a random delay of up to ten minutes", and the running session keeps the
+versions it loaded at launch, so a refresh lands on `/reload-plugins` or your next
+launch — never mid-turn. Run `/plugin update` when you want a known-current library.
+
+**Which version am I on?** `scripts/install.sh --version` reports the release, the
+checkout (`git describe`), whether your remote is ahead as of the last fetch, and
+whether the skills are symlinked (update live) or a pinned `--copy` snapshot. Quote
+it in a bug report — otherwise a report about a rule's behaviour can't be tied to the
+release that produced it.
 
 **Clone install:** because linking is symlink-based, **existing skills update
 the moment you pull** — the symlinks already point at the live files:
@@ -620,7 +635,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). The short version: keep skills generic,
 verify fast-moving claims against primary sources, keep **skill** files
 (`skills/**`) ≤ 500 lines — that cap keeps incremental rule loading working and
 does not apply to README/CHANGELOG/`docs/`, which are read by humans — and end
-each rules file with an audit checklist. Nine invariants enforce this in
+each rules file with an audit checklist. Ten invariants enforce this in
 `scripts/check-invariants.sh` (pre-commit + CI), covering line caps, checklist
 placement, description limits, version and count drift, router completeness, and
 internal link resolution — plus gitleaks (full-history scan in CI; per-commit via

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -2,7 +2,7 @@
 
 The library's value is that its fast-moving claims (versions, CVEs, RFCs,
 specs, GA states, tool status, standards) hold up against primary sources.
-CI enforces *structure* (the 9 invariants in `scripts/check-invariants.sh` +
+CI enforces *structure* (the 10 invariants in `scripts/check-invariants.sh` +
 gitleaks + shellcheck) but **cannot** verify that a claim is *true* — that
 needs web access and judgment. This file is the human/agent process that
 covers the accuracy dimension CI can't, plus how efficacy is measured.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -94,15 +94,26 @@ first.
   moment you `git pull`, but nothing ever tells you to pull. The plugin's
   `SessionStart` notice (`hooks/hooks.json` → `scripts/plugin-notice.sh`) is
   marker-guarded to fire **once ever**, so it is onboarding, not a version
-  channel. Cheapest fix: `install.sh --update` already pulls and knows both
-  versions — have it print the delta and point at the CHANGELOG. A `SessionStart`
+  channel. **Partly done (2026-07-30).** The claim previously recorded here — that
+  `install.sh --update` "already knows both versions" — was **false**: the script
+  had **zero** references to `VERSION` (`grep -c VERSION scripts/install.sh` → 0).
+  It now reads `VERSION` before and after the pull and prints the delta
+  (`1.19.7 → 1.20.0 — see CHANGELOG.md`), and `--version` reports the release,
+  checkout, upstream state as of the last fetch, and whether the install is
+  symlinked or a pinned `--copy` snapshot. What remains open is the *push* half:
+  nothing tells a passive user to pull in the first place. A `SessionStart`
   version check would reach passive users but **phones home**; that is a
   deliberate privacy decision, needs a TTL cache and must fail open, and is not
   to be built without an explicit call.
-- **Nothing reports which version is in use.** No skill carries a version
-  reference, so a bug report ("the day-zero check fired wrongly") cannot say
-  which release produced it. Cheaper and less contentious than the notification
-  question; probably the first thing to do.
+- ~~**Nothing reports which version is in use.**~~ **Done 2026-07-30** —
+  `scripts/install.sh --version` reports it (release from `VERSION`, `git
+  describe`, upstream-ahead count as of the last fetch, symlink-vs-snapshot
+  install mode), and the README's Updating section tells reporters to quote it.
+  Tested on six paths: normal checkout, non-git snapshot, missing `VERSION`,
+  unlinked target, `--update` with and without a version change, and behind-
+  upstream. Still true that **no skill file carries a version**, deliberately:
+  a version string inside a skill is one more surface to bump every release, and
+  `VERSION` is already the invariant-5-guarded source of truth.
 - **`scripts/verify-setup.sh`** — the deterministic half of VERIFY-SETUP.md (does
   a gate exist, is the hook installed, has this workflow ever run non-skipped,
   licence present under any name). A script does that better than a prompt, per
@@ -122,10 +133,17 @@ first.
   `71a9d78ea5e9e341`, **re-computed and matched 2026-07-30**, so every router edit
   across v1.19.x landed outside the eval-pinned BUILD block and historical
   completeness runs stay comparable.
-- **Unverified claim in the README** — that git-hosted plugin marketplaces
-  re-check at session start. Documented, not checked against a primary source.
-  `rules/01` §7 now tells readers to verify claims like this; we should take our
-  own advice.
+- ~~**Unverified claim in the README** — that git-hosted plugin marketplaces
+  re-check at session start.~~ **Checked 2026-07-30 and it was wrong in the way
+  that matters.** The Claude Code docs state that *"third-party and local
+  development marketplaces have auto-update disabled by default"* — this is a
+  third-party marketplace, so a plugin user gets **no** automatic refresh unless
+  they explicitly enable it; and even enabled, the check runs after session start
+  "with a random delay of up to ten minutes" while the running session keeps its
+  launch versions. The README implied users were being kept current when by
+  default they are not. Fixed with the quote, the opt-in path, and a pointer to
+  `--version`. **This makes the notification item above more important, not less**:
+  neither install path pushes updates by default.
 
 **Prior open items, still open (2026-07-22 framing, re-checked today):**
 

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -4,7 +4,9 @@
 # Exits non-zero (and prints offenders) if any invariant is violated.
 #
 # Invariants:
-#   1. Every tracked *.md is <= 500 lines  (skills load incrementally).
+#   1. Every tracked SKILL file (skills/*/*.md, skills/*/rules/*.md) is <= 500
+#      lines, so skills load incrementally. Non-skill Markdown (README,
+#      CHANGELOG, docs/) is deliberately uncapped — see the check itself.
 #   2. Every skills/*/rules/*.md ends with an "## Audit checklist".
 #   3. No internal/private references leak in (the library stays generic).
 #   4. Every skills/*/SKILL.md description is <= 1024 characters (Agent Skills
@@ -31,6 +33,10 @@
 #      to VERSION, so a second [Unreleased] lower down passed CI silently — on
 #      2026-07-28 two feature PRs each added one above [1.19.3] and main
 #      carried both until the release cut noticed by hand.
+#  10. Every skills/*/rules/*.md is referenced by its own SKILL.md. The model
+#      reads only the rules files the SKILL.md index points at, so an unindexed
+#      rules file is never loaded — written, capped, checklist-ed, unreachable.
+#      Skill-level twin of check 7 (a skill missing from the router).
 #
 # Portable to macOS bash 3.2 (no mapfile/associative arrays). Checks 4 and 8 need
 # python3 (Unicode char counting; link parsing); they are skipped with a warning
@@ -53,7 +59,7 @@ note() { printf '    %s\n' "$1"; }
 # CHANGELOG, docs/) is human/agent-facing prose, not loaded as a skill, so it is
 # intentionally uncapped (decided 2026-07-15) — navigability there comes from a
 # table of contents and docs/INDEX.md, not a line ceiling.
-echo "[1/9] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
+echo "[1/10] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
 over=0
 while IFS= read -r f; do
   [ -f "$f" ] || { note "SKIPPED (tracked but missing from worktree): $f"; continue; }
@@ -67,7 +73,7 @@ done < <(git ls-files 'skills/*/*.md' 'skills/*/rules/*.md')
 if [ "$over" -eq 0 ]; then echo "    ok"; else fail=1; fi
 
 # --- 2. Audit checklist ends every rules file ------------------------------
-echo "[2/9] Every skills/*/rules/*.md ends with an '## Audit checklist'"
+echo "[2/10] Every skills/*/rules/*.md ends with an '## Audit checklist'"
 missing=0
 while IFS= read -r f; do
   [ -f "$f" ] || { note "SKIPPED (tracked but missing from worktree): $f"; continue; }
@@ -95,7 +101,7 @@ if [ "$missing" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # .denylist.local (git-ignored, one ERE per line, '#' comments). When neither
 # exists (e.g. an external fork's PR), only the generic phrases are checked —
 # the maintainer's pre-commit hook and this repo's CI carry the full list.
-echo "[3/9] No internal-name leaks"
+echo "[3/10] No internal-name leaks"
 DENY='the user runs|the user operates'
 if [ -n "${SOTA_DENYLIST:-}" ]; then
   DENY="$DENY|$SOTA_DENYLIST"
@@ -131,7 +137,7 @@ fi
 # Code, Codex, ...) skip any skill that exceeds it. Count Unicode characters
 # (descriptions use em-dashes: 1 char, 3 bytes) via python3, parsing both
 # folded block scalars (`>-`) and plain single-line descriptions.
-echo "[4/9] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
+echo "[4/10] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
 if command -v python3 >/dev/null 2>&1; then
   if desc_out=$(python3 - "$MAX_DESC" <<'PY'
 import sys, glob, re
@@ -185,7 +191,7 @@ fi
 # One version, four places: VERSION, plugin.json, the CHANGELOG's top entry,
 # and (after the release lands) the newest v* tag. Drift here shipped a main
 # briefly claiming 1.8.0 with 1.9.0 content (2026-07-03) — hence a hard check.
-echo "[5/9] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
+echo "[5/10] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
 v5=0
 ver=$(tr -d '[:space:]' < VERSION)
 # Strict X.Y.Z: rejects interior malformations (1..2, 1.2, 1.2.3.4) the old
@@ -219,7 +225,7 @@ if [ "$v5" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # rot on surfaces nobody recounts (the social preview said "30 skills" for
 # three releases). Recount from the tree and compare every tracked surface;
 # RELEASING.md lists the same surfaces for manual release edits.
-echo "[6/9] Count-bearing surfaces match the tree"
+echo "[6/10] Count-bearing surfaces match the tree"
 v6=0
 ck() { # ck <found> <expected> <surface>
   [ "$1" = "$2" ] || { note "$3: says '${1:-<not found>}', tree says '$2'"; v6=1; }
@@ -265,7 +271,7 @@ if [ "$v6" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # library-map entry must name a real skill dir. Catches the drift the
 # 2026-07-10 audit found: sota-confidential-computing was added to the table
 # but missing from the map for a full release.
-echo "[7/9] Router lists every skill (routing table + library map)"
+echo "[7/10] Router lists every skill (routing table + library map)"
 v7=0
 router=skills/sota/SKILL.md
 bt='`'
@@ -290,7 +296,7 @@ if [ "$v7" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # with no rot-catching upside. Fenced AND inline code are stripped so link-shaped
 # examples (in ``` fences or `backticks`) are not scanned. Idea from vault-doctor
 # (training-knowledge-vault); see docs/ADOPTION-LOG.md.
-echo "[8/9] Internal Markdown links resolve (*.md targets)"
+echo "[8/10] Internal Markdown links resolve (*.md targets)"
 if command -v python3 >/dev/null 2>&1; then
   if link_out=$(python3 - <<'PY'
 import os, re, sys
@@ -336,7 +342,7 @@ fi
 # previous release (2026-07-28) and both sat on main until a human noticed
 # during the release cut. Fence-aware, like check 2: a CHANGELOG entry may
 # legitimately quote '## [Unreleased]' inside a code fence.
-echo "[9/9] CHANGELOG has at most one [Unreleased], and it is the top entry"
+echo "[9/10] CHANGELOG has at most one [Unreleased], and it is the top entry"
 v9=0
 changelogs="CHANGELOG.md $(git ls-files 'docs/CHANGELOG-archive*.md' | tr '\n' ' ')"
 for cl in $changelogs; do
@@ -370,6 +376,33 @@ for cl in $changelogs; do
   esac
 done
 if [ "$v9" -eq 0 ]; then echo "    ok"; else fail=1; fi
+
+# --- 10. Every rules file is indexed by its own SKILL.md ---------------------
+# The library's loading model is: SKILL.md loads first, and the model reads only
+# the rules files its index points at. So a rules file that no SKILL.md mentions
+# is written, reviewed, capped, checklist-ed — and never loaded. It is the
+# skill-level twin of the problem invariant 7 solved one level up (a skill
+# missing from the router) and of the front-door gap RELEASING.md §2b covers
+# (a capability with no README mention): the artifact exists, nothing errors,
+# and it is unreachable. Same class as `sota-devsecops` rules/03 §3.9, applied
+# to ourselves. All 255 rules files passed when this landed, so it is a
+# regression gate, not a repair; it was watched to fail on an injected file
+# and on a renamed reference before being trusted.
+echo "[10/10] Every skills/*/rules/*.md is referenced by its own SKILL.md"
+v10=0
+while IFS= read -r rf; do
+  skill_dir=$(dirname "$(dirname "$rf")")
+  sk="$skill_dir/SKILL.md"
+  base=$(basename "$rf")
+  if [ ! -f "$sk" ]; then
+    note "$rf: no SKILL.md in $skill_dir"
+    v10=1
+  elif ! grep -qF "$base" "$sk"; then
+    note "$rf: not referenced in $sk — the model never loads it (add it to the rules index)"
+    v10=1
+  fi
+done < <(git ls-files 'skills/*/rules/*.md')
+if [ "$v10" -eq 0 ]; then echo "    ok"; else fail=1; fi
 
 # --- Result ---------------------------------------------------------------
 echo

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,6 +24,7 @@
 #   scripts/install.sh                 # link skills into ~/.claude/skills (all projects)
 #   scripts/install.sh --project DIR   # link into DIR/.claude/skills (one project)
 #   scripts/install.sh --update        # git pull --ff-only first, then re-link
+#   scripts/install.sh --version       # report which release is installed, and where
 #   scripts/install.sh --copy          # copy instead of symlink (pin a snapshot)
 #   scripts/install.sh --routing       # also set up always-on routing (force)
 #   scripts/install.sh --no-routing    # skip the routing offer
@@ -39,6 +40,7 @@ readonly SKILLS_SRC="$REPO/skills"
 
 TARGET="$HOME/.claude/skills"
 DO_UPDATE=0
+DO_VERSION=0
 USE_COPY=0
 DO_ROUTING=-1   # -1 = ask/auto, 0 = skip, 1 = force
 ASSUME_YES=0
@@ -51,6 +53,49 @@ warn() { printf 'warning: %s\n' "$*" >&2; }
 die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
 
 usage() { sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//; /^set -euo/d'; exit "${1:-0}"; }
+
+# --- version reporting -------------------------------------------------------
+# Nothing in the library reported which release was in use, so a bug report
+# ("the day-zero check fired wrongly") could not name the version that produced
+# it. VERSION is the single source of truth (invariant 5 keeps it in lockstep
+# with plugin.json and the CHANGELOG top entry), so read it rather than
+# hardcoding a number anywhere.
+read_version() {  # <repo> — prints the release string, or "unknown"
+  local f="$1/VERSION"
+  [ -r "$f" ] && tr -d '[:space:]' <"$f" || printf 'unknown'
+}
+
+report_version() {
+  local v git_desc="" head="" behind=""
+  v="$(read_version "$REPO")"
+  printf 'SOTA-skills %s\n' "$v"
+  if git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    # --dirty marks uncommitted local edits, so no separate dirty check is needed.
+    git_desc="$(git -C "$REPO" describe --tags --always --dirty 2>/dev/null || true)"
+    head="$(git -C "$REPO" rev-parse --short HEAD 2>/dev/null || true)"
+    log "checkout: ${git_desc:-?} (HEAD $head)"
+    # Is a newer release already fetched? Report it without touching the network.
+    if git -C "$REPO" rev-parse --verify -q '@{upstream}' >/dev/null 2>&1; then
+      behind="$(git -C "$REPO" rev-list --count 'HEAD..@{upstream}' 2>/dev/null || printf '0')"
+      if [ "${behind:-0}" -gt 0 ]; then
+        log "upstream: $behind commit(s) ahead — run scripts/install.sh --update"
+      else
+        log "upstream: level as of the last fetch (a fetch is not implied)"
+      fi
+    fi
+  else
+    log "checkout: not a git repository (snapshot or plugin cache)"
+  fi
+  # Where the skills actually resolve from — a --copy snapshot does NOT track VERSION.
+  local probe="$TARGET/sota"
+  if [ -L "$probe" ]; then
+    log "install:  symlinked → $(readlink "$probe") (updates live on git pull)"
+  elif [ -d "$probe" ]; then
+    log "install:  copied snapshot at $probe — pinned, will NOT update; re-run with --copy to refresh"
+  else
+    log "install:  not linked into $TARGET"
+  fi
+}
 
 # --- interactive / routing helpers -------------------------------------------
 readonly RT_BEGIN="<!-- >>> sota-skills routing (managed by install.sh) >>> -->"
@@ -267,6 +312,7 @@ maybe_setup_routing() {
 while [ $# -gt 0 ]; do
   case "$1" in
     --update)     DO_UPDATE=1 ;;
+    --version)    DO_VERSION=1 ;;
     --copy)       USE_COPY=1 ;;
     --project)    shift; [ $# -gt 0 ] || die "--project needs a directory"; TARGET="$1/.claude/skills" ;;
     --routing)    DO_ROUTING=1 ;;
@@ -280,11 +326,26 @@ done
 
 [ -d "$SKILLS_SRC" ] || die "no skills/ dir at $SKILLS_SRC — run from a SOTA-skills checkout"
 
+# --version is a read-only report: print and exit before touching anything.
+if [ "$DO_VERSION" -eq 1 ]; then
+  report_version
+  exit 0
+fi
+
 # --- optional self-update ----------------------------------------------------
 if [ "$DO_UPDATE" -eq 1 ]; then
   if git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    was="$(read_version "$REPO")"
     log "updating $(basename "$REPO") (git pull --ff-only)…"
     git -C "$REPO" pull --ff-only || die "pull failed — resolve manually, then re-run"
+    now="$(read_version "$REPO")"
+    # Report the delta explicitly: symlinked skills change under you on a pull,
+    # so "nothing to do" and "you just moved three releases" looked identical.
+    if [ "$was" != "$now" ]; then
+      log "version:  $was → $now — see CHANGELOG.md for what changed"
+    else
+      log "version:  $now (unchanged)"
+    fi
   else
     warn "$REPO is not a git checkout — skipping --update"
   fi


### PR DESCRIPTION
Executes three open roadmap items. Each was validated against a primary source first — and **two of the items themselves contained false claims**, which is the more interesting result.

## 1. Version reporting — the roadmap's "probably the first thing to do"

`scripts/install.sh --version` now reports:

```
SOTA-skills 1.19.7
  checkout: v1.19.7-1-ga054b74-dirty (HEAD a054b74)
  upstream: level as of the last fetch (a fetch is not implied)
  install:  symlinked → /path/to/SOTA-skills/skills/sota (updates live on git pull)
```

`--update` now prints the delta (`1.19.7 → 1.20.0 — see CHANGELOG.md` / `(unchanged)`). With symlinked skills, "nothing happened" and "you just moved three releases" previously looked identical.

**The roadmap's justification for this being cheap was false.** It said `install.sh --update` "already pulls and knows both versions — have it print the delta". `grep -c VERSION scripts/install.sh` → **0**. The script had no version awareness at all. Corrected in the roadmap rather than quietly implemented around.

**Tested on six paths, not assumed** — built a real origin/clone pair and rewound it to exercise the update paths:

| Path | Result |
|---|---|
| Normal git checkout | version + describe + upstream + symlink mode |
| Non-git snapshot | `checkout: not a git repository (snapshot or plugin cache)` |
| `VERSION` missing | `SOTA-skills unknown` |
| Target not linked | `install: not linked into <target>` |
| `--update` with a change | `version: 1.0.0 → 2.0.0` |
| `--update` no change / behind upstream | `(unchanged)` / `1 commit(s) ahead — run --update` |

All exit 0 without tripping `set -euo pipefail`. `shellcheck` clean. Two defects in my own first draft were caught and fixed before commit (a misplaced `git -C`, an unused variable).

## 2. Invariant 10 — every rules file must be indexed by its own `SKILL.md`

The model reads only the rules files a `SKILL.md` index names, so an unindexed rules file is written, capped, checklist-ed — **and never loaded**. Skill-level twin of invariant 7, and the same "declared but not reached" class as the §3.9 shipped in v1.19.7, turned on ourselves.

**Invariant 8 does not cover this.** Measured: **30 of 41** `SKILL.md` files list their rules as plain backticked text rather than Markdown links, so a rename leaves the link checker nothing to resolve. Demonstrated by renaming `sota-golang/rules/01-errors.md` — invariant 8 printed `ok`, invariant 10 caught it.

All 255 rules files pass, so this is a **regression gate, not a repair**. Per the harness convention it was **watched to fail** on two injected cases before being trusted: an unindexed new file, and a renamed reference.

## 3. The README's flagged auto-update claim — checked, and wrong

The roadmap listed "git-hosted marketplaces also check at session start" as documented-but-unverified, noting *"`rules/01` §7 now tells readers to verify claims like this; we should take our own advice."* Taken.

Per the [Claude Code docs](https://code.claude.com/docs/en/discover-plugins#configure-auto-updates), fetched this session: **"Third-party and local development marketplaces have auto-update disabled by default."** This *is* a third-party marketplace — so a plugin user gets **no** automatic refresh unless they explicitly enable it. Even enabled, the check runs after session start *"with a random delay of up to ten minutes"* while the running session keeps its launch versions.

The README was telling users they were being kept current when by default they are not. Now carries the quote, the opt-in path, and a pointer to `--version`. **This makes the open update-notification item more pressing, not less:** neither install path pushes updates by default.

## Also: a third copy of the stale 500-line claim

`scripts/check-invariants.sh`'s own header said invariant 1 covers "every tracked `*.md`" — contradicting its own implementation, which is skills-only and has a comment explaining why. After the README (v1.19.7) and CONTRIBUTING (#154) fixes, that is **three places** one 2026-07-15 policy change failed to reach. Exactly the reason RELEASING.md §2b now says to re-read long-lived prose at each cut.

## Docs, same change

AGENTS.md (invariant 10 — so CLAUDE.md/GEMINI.md get it via symlink), CONTRIBUTING.md (invariant list + a PR-checklist item), README (Updating section + "Ten invariants"), docs/MAINTENANCE.md, docs/ROADMAP.md (two items closed, one corrected), CHANGELOG `[Unreleased]`.

## Gates

`./scripts/check-invariants.sh` → **PASS, all 10**. `pre-commit run --all-files` → gitleaks, invariants, and eval scoring tests all pass. `shellcheck` clean on both touched scripts.
