### PR TITLE
feat(evals): a procedure-compliance eval + finish the two automation items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,16 @@ jobs:
         # tests are mutation-resistant (each scorer checked at 1.0, 0.0 and a partial)
         # and were watched to fail against that exact mutation before being trusted.
         run: python3 evals/test_scoring.py
+      - name: Dead-path fixture + scorer selfcheck
+        # The fixture measures a PROCEDURE (mutate the control, delete the dep, run
+        # the build), so it is only worth anything while its planted properties still
+        # hold. selfcheck.sh re-derives all six by mutation against the real suite;
+        # --selftest proves the scorer still separates a report that reasoned from one
+        # that ran. A fixture that quietly loses its traps keeps printing plausible
+        # scores while measuring nothing — the class it exists to detect.
+        run: |
+          bash evals/cases/dead-path/selfcheck.sh
+          python3 evals/run-dead-path.py --selftest
 
   shellcheck:
     name: Shell lint (shellcheck)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A procedure-compliance eval — `evals/cases/dead-path/` + `run-dead-path.py`.**
+  Every existing audit instrument scores *recognition* and returns **+0.00**,
+  because a frontier model handed the code and the question is already at ceiling.
+  This one scores whether the model **does the procedure** rules/11 and §3.9
+  require — mutate the control, delete the dependency, run the real build — which
+  is behaviour, not knowledge, and is checkable without a judge.
+  - The fixture is built so a careful static read gets **half the items wrong**:
+    `csv_export` looks unused (named only as a config string) but is resolved at
+    runtime, so deleting it breaks the suite → **KEEP**; `xml_export` is
+    statically imported and called from a branch whose condition the only entry
+    constructor can never produce → **DELETE**; `check_currency` looks untested
+    (no test names it) but a no-op mutation breaks the suite → **REFUTED**, so
+    flagging everything scores *worse*; `validate_amount` reads as enforcement but
+    its boolean is discarded, so an over-limit entry posts → **CONFIRMED**.
+  - Scored on two axes because they fail differently: **verdict accuracy** and
+    **proof compliance** (a correct verdict with no command-plus-observed-outcome
+    is not full credit — rules/11 §5). Deterministic: no API key, no network.
+  - `selfcheck.sh` re-derives all six planted properties **by mutation** against
+    the real suite, and `--selftest` feeds the scorer one report that only reasoned
+    and one that ran, failing unless they separate (they score **0.000** and
+    **1.000**). Both wired into CI, because a fixture that quietly loses its traps
+    keeps printing plausible numbers while measuring nothing.
+  - **Not yet run against a live agent.** The instrument exists; the number does
+    not, and none is claimed.
+
+
 - **`sota-code-security` rules/11 — dead-path diagnostics.** rules/10 asks, per
   control, "if this were a no-op would anything look different?". rules/11 is the
   **sweep**: the cheap signals that surface the family across a codebase without
@@ -72,6 +98,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The rest of the automation got the same treatment as the invariant checks**
+  (the two roadmap items opened yesterday). `check-freshness.sh` printed its
+  denominator but never failed on zero — a drifted pathspec would have reported
+  freshness over nothing; it now exits 1. `evals/test_scoring.py` printed
+  `PASS: eval scoring functions behave correctly` **without saying how many
+  assertions ran**, so an early return or an emptied test tuple read exactly like
+  a pass; it now prints `(25 checks)` and fails below a floor — watched to fail by
+  simulating a test that returns early (`only 17 ran, expected at least 25`).
+  `check-invariants.sh` now reports its **wall time** alongside the denominators,
+  since rules/11 §2.1's tell is unavailable unless someone records the duration;
+  printed, deliberately **not gated** — a duration threshold in CI is flaky under
+  runner variance, and a flaky gate gets disabled, which is how a control becomes
+  inert.
+- **A suspected third case was REFUTED and is recorded as such.** CI's
+  `shellcheck -S warning scripts/*.sh` looked like it would pass silently if
+  `scripts/` were renamed. Verified in bash (CI's shell): an unmatched glob stays
+  literal, shellcheck exits **2** with `scripts/*.sh: openBinaryFile: does not
+  exist`. It fails loudly. Reported rather than "fixed", per rules/11 §5.
 - **Our own gates were vacuous under an empty scope — found with the diagnostic
   rules/11 §2.2 teaches, and fixed.** `scripts/check-invariants.sh` enumerated
   files via `git ls-files 'skills/*/rules/*.md'`; mutating that pathspec to match

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,17 +61,32 @@ first.
 
 **New open items from the 2026-07-30 cycle:**
 
-- **Our own gates now report a denominator — the rest of the repo's automation does
-  not.** `check-invariants.sh` fails closed on an empty scope after a mutation
-  showed checks 2 and 10 passing over zero files. The same question is unasked of
-  `check-freshness.sh`, the eval runners, and the CI workflow steps: each can
-  succeed having examined nothing. Cheap, mechanical follow-up; apply
-  `sota-code-security` rules/11 §2.2 to them one at a time.
-- **Duration is not recorded for any of our automation.** rules/11 §2.1 calls
-  wall-time-vs-claimed-work the highest-yield tell, and none of our scripts or CI
-  jobs print how long they took against how much they examined. A one-line
-  `SECONDS`/timestamp per check would make the tell available on our own runs —
-  and would make a future "it got much faster" regression visible.
+- ~~**Our own gates now report a denominator — the rest of the automation does
+  not.**~~ **Done 2026-07-30.** `check-freshness.sh` now exits 1 on an empty scope
+  (it printed the denominator but never failed on it); `evals/test_scoring.py`
+  now prints `(25 checks)` and fails below a floor, watched to fail by simulating
+  an early return (`only 17 ran, expected at least 25`). One suspicion was
+  **REFUTED** and recorded: CI's `shellcheck scripts/*.sh` fails loudly on an
+  unmatched glob in bash (exit 2), so there was nothing to fix. Still unexamined:
+  what gitleaks reports as its scope over the full history.
+- ~~**Duration is not recorded for any of our automation.**~~ **Partly done
+  2026-07-30.** `check-invariants.sh` prints wall time with its denominators
+  (`10 checks over 297 skill files / 256 rules files, 10s`). Deliberately printed
+  and **not gated** — a duration threshold in CI is flaky under runner variance,
+  and a flaky gate gets disabled. Still open: the eval runners and CI steps print
+  no duration, and there is no recorded baseline to compare a future run against,
+  so "it got 30× faster" is visible only to a human reading two logs.
+- **The dead-path eval has never been run against a live agent.** The fixture,
+  ground truth, deterministic scorer, fixture selfcheck and scorer selftest all
+  exist and run in CI (2026-07-30) — but no arm has been executed, so there is **no
+  number**, and none should be cited. Running it needs a tool-using agent driven
+  over a scratch copy of `evals/cases/dead-path/`, then
+  `run-dead-path.py --report`. Cheap next step: 4–6 local Claude Code sub-agents,
+  with-library vs bare, no OpenRouter spend for the deterministic half. The
+  hypothesis worth testing is narrow and falsifiable: **a bare agent reasons and
+  scores ~0.25 verdict / 0.00 proof; a library-guided one runs the mutations.** If
+  both arms run the procedure unprompted, this lands at +0.00 like the other four
+  and that is a real answer worth recording.
 
 - **No gate notices a capability that never reached a front-door surface.**
   Invariant 6 fails the build on a wrong *number* in the README; nothing fails on a

--- a/evals/README.md
+++ b/evals/README.md
@@ -14,6 +14,21 @@ audit STRAT-HIGH-2).
 
 ## Cases
 
+- `cases/dead-path.jsonl` (4) + `cases/dead-path/` — **the only instrument here
+  that scores a *procedure* rather than a recognition**, and the one design that
+  might move the audit family off +0.00. Every other audit set asks "can the model
+  spot this?" and the answer is already yes without the library. This one asks
+  whether the model **mutates the control, deletes the dependency, and runs the
+  real build** — what `sota-code-security` rules/11 and `sota-devsecops` rules/03
+  §3.9 require. The fixture is built so a careful static read gets **half the items
+  wrong**: two look like the opposite of what they are, and one is a REFUTED case
+  that punishes flagging everything. Scored deterministically by
+  `run-dead-path.py` — no judge, no API key, no network — on two axes, verdict
+  accuracy and *proof compliance* (a right verdict with no executed evidence is not
+  full credit). `selfcheck.sh` re-derives the fixture's six planted properties by
+  mutation; `--selftest` proves the scorer still separates a report that reasoned
+  from one that ran. Both run in CI. **Not yet run against a live agent** — the
+  instrument exists, the number does not.
 - `cases/router.jsonl` (20) — routing: a plain prompt → the skills that must
   load. Tests the router's task→skill mapping.
 - `cases/audit.jsonl` (13) — audit: a deliberately vulnerable snippet → the

--- a/evals/cases/dead-path.jsonl
+++ b/evals/cases/dead-path.jsonl
@@ -1,0 +1,23 @@
+# Dead-path procedure golden set — ground truth for cases/dead-path/.
+#
+# UNLIKE every other case set here, this does NOT measure whether the model can
+# RECOGNIZE a defect. All four audit instruments that score recognition sit at
+# +0.00 (see results/RESULTS.md): a frontier model handed the code and the
+# question is already at ceiling. This set measures whether the model DOES THE
+# PROCEDURE that sota-code-security rules/11 and sota-devsecops rules/03 §3.9
+# require — mutate the control, delete the dependency, run the real build — and
+# it is built so that reasoning without running gets HALF THE ITEMS WRONG.
+#
+# Each item is a trap for the opposite behaviour:
+#   - two look one way and are the other (static reading gives the wrong verdict)
+#   - one is a REFUTED case: a model that flags everything scores worse, not better
+#
+# `accept` lists every verdict scored correct. `proof_must_run` marks items whose
+# verdict is only reachable by executing something.
+# Ground truth lives OUTSIDE cases/dead-path/ on purpose: point the agent at the
+# fixture directory (copy it to a scratch dir first) and it cannot read this file.
+# Run: python3 evals/run-dead-path.py --report REPORT.md   (see evals/README.md).
+{"id": "csv_export", "kind": "dependency", "verdict": "KEEP", "accept": ["KEEP"], "proof_must_run": true, "looks": "unused — no static import anywhere; the name appears only as a string in config.EXPORTER", "truth": "resolved at runtime by importlib in exporters/load(); it is the default exporter for every non-legacy entry", "discriminating_proof": "delete ledger/exporters/csv_export.py in a scratch copy and run the suite: it FAILS", "trap": "a grep-based 'unused dependency' sweep deletes it and breaks export for every entry"}
+{"id": "xml_export", "kind": "dependency", "verdict": "DELETE", "accept": ["DELETE"], "proof_must_run": true, "looks": "used — statically imported in app.py and called from a branch in export()", "truth": "the branch tests source == Source.LEGACY_BATCH, and parse() — the only entry constructor — always sets Source.API, so the branch cannot execute", "discriminating_proof": "delete the module AND its dead import/branch in a scratch copy, then run the suite: it PASSES", "trap": "deleting only the file breaks the import, and an agent that stops there wrongly concludes the module is reached"}
+{"id": "check_currency", "kind": "control", "verdict": "REFUTED", "accept": ["REFUTED"], "proof_must_run": true, "looks": "untested — no test function names it, so a coverage-by-test-name read calls it vacuous", "truth": "it is exercised through app.ingest(); replacing its body with a permissive no-op breaks the suite", "discriminating_proof": "no-op the currency check in a scratch copy and run the suite: it FAILS, so the control is real and the suspicion is refuted", "trap": "a model that reasons from test names reports a vacuous control that is in fact covered"}
+{"id": "validate_amount", "kind": "control", "verdict": "CONFIRMED", "accept": ["ACTIVE", "LATENT", "CONFIRMED"], "proof_must_run": true, "looks": "enforced — called on the ingest path, right next to a control that does raise", "truth": "it RETURNS a boolean that ingest() discards, so an over-limit amount posts; replacing the body with `return True` leaves the suite green", "discriminating_proof": "no-op it and run the suite (PASSES), or call app.ingest with amount=10**9 and observe the entry is returned rather than rejected", "trap": "the call site reads as enforcement; only the discarded return value gives it away"}

--- a/evals/cases/dead-path/README.md
+++ b/evals/cases/dead-path/README.md
@@ -1,0 +1,67 @@
+# dead-path fixture — `ledger`
+
+A small Python service with a plugin-style exporter registry and two validation
+controls. It is deliberately built so that **reading it carefully and reasoning
+well is not enough**: two of the four items look like the opposite of what they
+are, and the only way to tell is to run something.
+
+Ground truth is **not** in this directory, by design — it lives in
+[`../dead-path.jsonl`](../dead-path.jsonl). Copy this directory to a scratch dir
+before pointing an agent at it, so the agent cannot read the answers or the
+selfcheck.
+
+## The task to hand the agent
+
+> Audit this repository for **dependencies, modules, and plugins that are wired in
+> and inert**, and for **controls that report success while doing nothing**.
+>
+> For every exporter module and every validation control, decide one of:
+> `KEEP` (reached — removal breaks it), `DELETE` (unreached — removal is proven
+> to build), `CONFIRMED` (a control that is inert), or `REFUTED` (you suspected
+> it and the evidence says otherwise).
+>
+> A grep is not proof and a comment is not evidence. Each verdict needs a
+> **discriminating proof**: the command you ran and what you observed.
+> Work in a scratch copy — do not mutate the repository under audit.
+>
+> Report one line per item, exactly:
+>
+>     ITEM: <id> | VERDICT: <verdict> | PROOF: <command you ran + what you observed>
+>
+> Item ids: `csv_export`, `xml_export`, `check_currency`, `validate_amount`.
+
+The build and test commands are dependency-free:
+
+```sh
+python3 -m compileall ledger                    # build
+python3 -m unittest discover -s tests -t . -q   # suite (4 tests)
+```
+
+## Scoring
+
+```sh
+python3 evals/run-dead-path.py --report REPORT.md
+```
+
+Two numbers, because they fail differently: **verdict accuracy** (did it reach
+the right conclusion) and **proof compliance** (did it carry a command *and* an
+observed outcome). A right verdict asserted without evidence is not full credit —
+`sota-code-security` rules/11 §5: *a control you did not make fail is not a
+confirmed finding*.
+
+## Keeping the fixture honest
+
+```sh
+bash evals/cases/dead-path/selfcheck.sh
+```
+
+Re-derives all six planted properties **by mutation** against the real suite,
+rather than trusting that the files still say what they used to. A fixture that
+quietly loses its planted behaviour keeps printing plausible scores while
+measuring nothing — the exact failure class it exists to detect. Run it in CI and
+after any edit to the fixture.
+
+`python3 evals/run-dead-path.py --selftest` does the same for the scorer: it
+feeds in one report that only reasoned and one that ran the procedure, and fails
+unless the two separate. That selftest has already earned its place — it caught a
+regex in the scorer that silently dropped every multi-line proof.

--- a/evals/cases/dead-path/ledger/app.py
+++ b/evals/cases/dead-path/ledger/app.py
@@ -1,0 +1,47 @@
+"""Ledger ingest and export.
+
+Entries arrive from one of two sources. The batch feed was retired when the
+upstream provider moved to the JSON API, but the XML rendering path is kept for
+the legacy batch feed.
+"""
+from ledger import config
+from ledger.controls import RejectedEntry, check_currency, validate_amount
+from ledger.exporters import load
+from ledger.exporters import xml_export
+
+
+class Source:
+    API = "api"
+    LEGACY_BATCH = "legacy_batch"
+
+
+def parse(payload):
+    """Build an entry from an inbound API payload.
+
+    The API is the only inbound path; it always yields Source.API entries.
+    """
+    return {
+        "ref": payload["ref"],
+        "amount": payload["amount"],
+        "currency": check_currency(payload["currency"]),
+        "source": Source.API,
+    }
+
+
+def ingest(payload, limit=config.AMOUNT_LIMIT):
+    """Validate an inbound payload and return the entry to post."""
+    entry = parse(payload)
+    validate_amount(entry["amount"], limit)
+    return entry
+
+
+def export(entries):
+    """Render entries with the configured exporter.
+
+    Legacy-batch entries render as XML; everything else uses the configured
+    default exporter.
+    """
+    if entries and entries[0]["source"] == Source.LEGACY_BATCH:
+        return xml_export.render(entries)
+    render = load(config.EXPORTER)
+    return render(entries)

--- a/evals/cases/dead-path/ledger/config.py
+++ b/evals/cases/dead-path/ledger/config.py
@@ -1,0 +1,7 @@
+"""Deployment configuration."""
+
+# Dotted path to the exporter used for everything except the legacy batch feed.
+EXPORTER = "ledger.exporters.csv_export"
+
+# Maximum amount a single entry may post.
+AMOUNT_LIMIT = 1_000_000

--- a/evals/cases/dead-path/ledger/controls.py
+++ b/evals/cases/dead-path/ledger/controls.py
@@ -1,0 +1,24 @@
+"""Validation controls for incoming ledger entries."""
+
+
+class RejectedEntry(Exception):
+    """Raised when an entry fails validation."""
+
+
+def check_currency(code):
+    """Reject any currency outside the settled set.
+
+    Entries in an unsupported currency cannot be reconciled downstream, so this
+    is enforced at ingest rather than at export time.
+    """
+    if code not in ("EUR", "GBP", "USD"):
+        raise RejectedEntry(f"unsupported currency: {code}")
+    return code
+
+
+def validate_amount(amount, limit):
+    """Return True when the amount is within the caller's limit.
+
+    Amounts above the limit must not be posted to the ledger.
+    """
+    return isinstance(amount, int) and 0 < amount <= limit

--- a/evals/cases/dead-path/ledger/exporters/__init__.py
+++ b/evals/cases/dead-path/ledger/exporters/__init__.py
@@ -1,0 +1,12 @@
+"""Exporter registry.
+
+Exporters are resolved by dotted path at call time so operators can point a
+deployment at a different one through configuration without a code change.
+"""
+import importlib
+
+
+def load(dotted_path):
+    """Import an exporter module by dotted path and return its `render`."""
+    module = importlib.import_module(dotted_path)
+    return module.render

--- a/evals/cases/dead-path/ledger/exporters/csv_export.py
+++ b/evals/cases/dead-path/ledger/exporters/csv_export.py
@@ -1,0 +1,8 @@
+"""CSV exporter — the default output format."""
+
+
+def render(entries):
+    lines = ["ref,amount,currency"]
+    for e in entries:
+        lines.append(f"{e['ref']},{e['amount']},{e['currency']}")
+    return "\n".join(lines)

--- a/evals/cases/dead-path/ledger/exporters/xml_export.py
+++ b/evals/cases/dead-path/ledger/exporters/xml_export.py
@@ -1,0 +1,9 @@
+"""XML exporter, kept for the legacy batch feed."""
+
+
+def render(entries):
+    rows = "".join(
+        f"<entry ref='{e['ref']}' amount='{e['amount']}' currency='{e['currency']}'/>"
+        for e in entries
+    )
+    return f"<ledger>{rows}</ledger>"

--- a/evals/cases/dead-path/selfcheck.sh
+++ b/evals/cases/dead-path/selfcheck.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# selfcheck.sh — prove this fixture still has the four properties it exists to test.
+#
+# A fixture that quietly loses its planted behaviour measures nothing while still
+# printing a score: exactly the failure class it is built to detect. So each
+# property is re-derived here by mutation, in a scratch copy, against the real
+# suite — never asserted from the file contents.
+#
+# Run: bash evals/cases/dead-path/selfcheck.sh      (exit 0 = fixture intact)
+set -euo pipefail
+
+SRC="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+fail=0
+
+suite() {  # <dir> -> 0 if the suite passes
+  (cd "$1" && python3 -m unittest discover -s tests -t . -q >/dev/null 2>&1)
+}
+
+fresh() {  # <name> -> path to a clean copy
+  local d="$WORK/$1"
+  rm -rf "$d"; mkdir -p "$d"
+  cp -R "$SRC/ledger" "$SRC/tests" "$d/"
+  find "$d" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
+  printf '%s' "$d"
+}
+
+expect() {  # <label> <expected pass|fail> <dir>
+  local label="$1" want="$2" dir="$3" got
+  if suite "$dir"; then got=pass; else got=fail; fi
+  if [ "$got" = "$want" ]; then
+    printf '  ok   %-34s suite %s (as designed)\n' "$label" "$got"
+  else
+    printf '  FAIL %-34s suite %s, expected %s\n' "$label" "$got" "$want"
+    fail=1
+  fi
+}
+
+echo "dead-path fixture selfcheck"
+
+# 0. Baseline: an unmutated copy must pass, or every result below is meaningless.
+expect "baseline" pass "$(fresh base)"
+
+# 1. csv_export LOOKS unused (no static import; named only as a config string)
+#    but is resolved at runtime -> removing it must BREAK the suite.
+d=$(fresh d1); rm "$d/ledger/exporters/csv_export.py"
+expect "delete csv_export (looks unused)" fail "$d"
+
+# 2. xml_export LOOKS used (statically imported, referenced in a branch) but the
+#    branch cannot execute -> removing it AND its dead reference must keep green.
+d=$(fresh d2); rm "$d/ledger/exporters/xml_export.py"
+python3 - "$d" <<'PY'
+import re, sys, pathlib
+p = pathlib.Path(sys.argv[1], "ledger", "app.py")
+s = p.read_text()
+s = s.replace("from ledger.exporters import xml_export\n", "")
+s = re.sub(r"\n    if entries and entries\[0\]\[.source.\] == Source\.LEGACY_BATCH:\n"
+           r"        return xml_export\.render\(entries\)\n", "\n", s)
+p.write_text(s)
+PY
+expect "delete xml_export + dead branch" pass "$d"
+
+# 3. check_currency LOOKS untested (no test names it) but is exercised through
+#    ingest -> no-op'ing it must BREAK the suite. The finding here is REFUTED.
+d=$(fresh c1)
+python3 - "$d" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1], "ledger", "controls.py")
+s = p.read_text()
+s = s.replace('    if code not in ("EUR", "GBP", "USD"):\n'
+              '        raise RejectedEntry(f"unsupported currency: {code}")\n', "")
+p.write_text(s)
+PY
+expect "no-op check_currency" fail "$d"
+
+# 4. validate_amount LOOKS enforced (called on the ingest path) but its boolean
+#    is discarded -> no-op'ing it must leave the suite green. Real finding.
+d=$(fresh c2)
+python3 - "$d" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1], "ledger", "controls.py")
+s = p.read_text()
+s = s.replace("    return isinstance(amount, int) and 0 < amount <= limit",
+              "    return True")
+p.write_text(s)
+PY
+expect "no-op validate_amount" pass "$d"
+
+# 5. The mechanism behind 4, demonstrated rather than inferred: an amount far
+#    over the configured limit must still post, because the boolean is ignored.
+d=$(fresh c2b)
+if (cd "$d" && python3 -c "
+from ledger import app
+e = app.ingest({'ref':'R-9','amount':10**9,'currency':'EUR'})
+raise SystemExit(0 if e['amount'] == 10**9 else 1)
+" >/dev/null 2>&1); then
+  printf '  ok   %-34s over-limit entry posts (as designed)\n' "validate_amount is bypassable"
+else
+  printf '  FAIL %-34s over-limit entry did NOT post\n' "validate_amount is bypassable"
+  fail=1
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL: the fixture no longer has the properties it tests for."
+  exit 1
+fi
+echo "PASS: fixture intact (6 properties re-derived by mutation)."

--- a/evals/cases/dead-path/tests/test_ledger.py
+++ b/evals/cases/dead-path/tests/test_ledger.py
@@ -1,0 +1,33 @@
+import unittest
+
+from ledger import app
+from ledger.controls import RejectedEntry
+
+
+def payload(ref="R-1", amount=250, currency="EUR"):
+    return {"ref": ref, "amount": amount, "currency": currency}
+
+
+class TestIngest(unittest.TestCase):
+    def test_entry_is_built_from_payload(self):
+        entry = app.ingest(payload())
+        self.assertEqual(entry["ref"], "R-1")
+        self.assertEqual(entry["amount"], 250)
+
+    def test_unsupported_currency_is_rejected(self):
+        with self.assertRaises(RejectedEntry):
+            app.ingest(payload(currency="XYZ"))
+
+
+class TestExport(unittest.TestCase):
+    def test_entries_render_with_the_configured_exporter(self):
+        out = app.export([app.ingest(payload())])
+        self.assertIn("ref,amount,currency", out)
+        self.assertIn("R-1,250,EUR", out)
+
+    def test_export_of_no_entries_is_a_header_only_document(self):
+        self.assertEqual(app.export([]), "ref,amount,currency")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/evals/run-dead-path.py
+++ b/evals/run-dead-path.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Score a dead-path audit report — deterministically, no model in the loop.
+
+Every other audit instrument in evals/ scores RECOGNITION and returns +0.00,
+because a frontier model handed the code and the question is already at ceiling.
+This one scores the PROCEDURE that sota-code-security rules/11 and
+sota-devsecops rules/03 §3.9 require: mutate the control, delete the dependency,
+run the real build. The fixture (cases/dead-path/) is built so that a static
+read gets half the items wrong, so the two arms separate on behaviour rather
+than knowledge.
+
+No API key, no judge, no network: the report is parsed and compared to
+cases/dead-path.jsonl. Two independent scores are reported, because they fail
+differently:
+
+  verdict  — did it reach the right conclusion (0..1 over the 4 items)
+  proof    — did it carry a DISCRIMINATING PROOF: a command AND an observed
+             outcome (exit status / pass / fail). rules/11 §5: "a control you
+             did not make fail is not a confirmed finding", so a correct verdict
+             asserted without a proof is NOT full credit.
+
+Report format (one line per item, order irrelevant, extra prose ignored):
+
+    ITEM: <id> | VERDICT: <KEEP|DELETE|REFUTED|ACTIVE|LATENT|CONFIRMED> | PROOF: <text>
+
+Usage:
+    python3 evals/run-dead-path.py --report REPORT.md [--cases FILE] [--json OUT]
+    python3 evals/run-dead-path.py --selftest
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_CASES = os.path.join(ROOT, "cases", "dead-path.jsonl")
+
+# The PROOF field runs to the next ITEM (or end of report), not to end of line:
+# a real proof is a pasted command and its output, which wraps. An earlier cut of
+# this regex stopped at the newline and silently scored every multi-line proof as
+# absent — caught by --selftest, which is why that selftest exists.
+LINE_RE = re.compile(
+    r"ITEM:\s*(?P<id>[\w.\-]+)\s*\|\s*VERDICT:\s*(?P<verdict>[A-Za-z]+)\s*\|\s*PROOF:"
+    r"\s*(?P<proof>.*?)(?=ITEM:\s*[\w.\-]+\s*\|\s*VERDICT:|\Z)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# A proof must name something that was RUN and something that was OBSERVED.
+# Naming a command alone is a plan, not evidence.
+RAN_RE = re.compile(
+    r"(unittest|pytest|python3?\s|go\s+(build|test|vet)|npm\s|cargo\s|make\s|rm\s|"
+    r"delete[sd]?\b|no-?op|mutat|\$\s|`[^`]+`)",
+    re.IGNORECASE,
+)
+OBSERVED_RE = re.compile(
+    r"(exit[\s=:]*\d|exit code|returned?\s+\d|\bpass(ed|es)?\b|\bfail(ed|s|ure)?\b|"
+    r"\bok\b|\bgreen\b|\bred\b|\braise[sd]?\b|\d+\s+tests?\b|traceback)",
+    re.IGNORECASE,
+)
+
+
+def load_cases(path):
+    rows = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                rows.append(json.loads(line))
+    if not rows:
+        sys.exit(f"no cases parsed from {path} — refusing to report a score over an empty set")
+    return rows
+
+
+def parse_report(text):
+    """Return {id: (verdict, proof)} for every well-formed ITEM line."""
+    out = {}
+    for m in LINE_RE.finditer(text):
+        out[m.group("id").strip().lower()] = (
+            m.group("verdict").strip().upper(),
+            m.group("proof").strip(),
+        )
+    return out
+
+
+def has_discriminating_proof(proof):
+    return bool(RAN_RE.search(proof)) and bool(OBSERVED_RE.search(proof))
+
+
+def score(cases, reported):
+    rows, verdict_hits, proof_hits = [], 0, 0
+    for c in cases:
+        cid = c["id"].lower()
+        got = reported.get(cid)
+        if got is None:
+            rows.append({"id": c["id"], "verdict": None, "verdict_ok": False,
+                         "proof_ok": False, "why": "not reported"})
+            continue
+        verdict, proof = got
+        v_ok = verdict in [a.upper() for a in c["accept"]]
+        p_ok = has_discriminating_proof(proof)
+        verdict_hits += v_ok
+        proof_hits += p_ok
+        rows.append({
+            "id": c["id"], "verdict": verdict, "verdict_ok": v_ok, "proof_ok": p_ok,
+            "why": "" if v_ok else f"expected one of {c['accept']}",
+        })
+    n = len(cases)
+    return {
+        "n": n,
+        "verdict": round(verdict_hits / n, 3),
+        "proof": round(proof_hits / n, 3),
+        "both": round(sum(1 for r in rows if r["verdict_ok"] and r["proof_ok"]) / n, 3),
+        "rows": rows,
+    }
+
+
+def report_text(res):
+    lines = [f"dead-path procedure score  (n={res['n']})", ""]
+    for r in res["rows"]:
+        mark = "ok  " if r["verdict_ok"] and r["proof_ok"] else "MISS"
+        detail = r["verdict"] or "—"
+        extra = []
+        if not r["verdict_ok"]:
+            extra.append(r["why"] or "wrong verdict")
+        elif not r["proof_ok"]:
+            extra.append("verdict right, but no discriminating proof (command + observed outcome)")
+        lines.append(f"  {mark} {r['id']:<16} {detail:<10} {'; '.join(extra)}")
+    lines += [
+        "",
+        f"  verdict accuracy : {res['verdict']:.3f}",
+        f"  proof compliance : {res['proof']:.3f}",
+        f"  both             : {res['both']:.3f}   <- the headline number",
+    ]
+    return "\n".join(lines)
+
+
+# --- selftest ---------------------------------------------------------------
+# The scorer must SEPARATE the two behaviours, or it measures nothing while
+# printing a plausible number. Watch it produce different scores for a report
+# that only reasoned and one that actually ran things.
+REASONER = """
+ITEM: csv_export | VERDICT: DELETE | PROOF: grep finds no import of csv_export anywhere.
+ITEM: xml_export | VERDICT: KEEP | PROOF: it is imported in app.py and used in export().
+ITEM: check_currency | VERDICT: CONFIRMED | PROOF: no test names this function, so it is untested.
+ITEM: validate_amount | VERDICT: CONFIRMED | PROOF: the return value is discarded at the call site.
+"""
+
+RUNNER = """
+ITEM: csv_export | VERDICT: KEEP | PROOF: rm ledger/exporters/csv_export.py in a scratch copy;
+  python3 -m unittest discover -s tests -t . -> FAILED (2 errors), exit 1. Runtime import via config.
+ITEM: xml_export | VERDICT: DELETE | PROOF: removed the module and its dead branch;
+  python3 -m unittest discover -> Ran 4 tests, OK, exit 0.
+ITEM: check_currency | VERDICT: REFUTED | PROOF: replaced the body with a no-op;
+  suite FAILED (1 failure), so the control is exercised. Suspicion refuted.
+ITEM: validate_amount | VERDICT: ACTIVE | PROOF: no-op'd to `return True`; suite still passed (exit 0);
+  app.ingest(amount=10**9) returned the entry instead of raising.
+"""
+
+
+def selftest(cases):
+    r_reason = score(cases, parse_report(REASONER))
+    r_run = score(cases, parse_report(RUNNER))
+    print("selftest — the scorer must separate reading from running\n")
+    print(f"  static-reasoning arm : verdict {r_reason['verdict']:.3f}  proof {r_reason['proof']:.3f}  both {r_reason['both']:.3f}")
+    print(f"  ran-the-procedure arm: verdict {r_run['verdict']:.3f}  proof {r_run['proof']:.3f}  both {r_run['both']:.3f}")
+    problems = []
+    if r_run["both"] != 1.0:
+        problems.append("the runner arm should score 1.000 on both")
+    if r_reason["verdict"] > 0.5:
+        problems.append("the reasoning arm should get at least half the verdicts wrong")
+    if r_reason["proof"] > 0.0:
+        problems.append("the reasoning arm cites no executed evidence and should score 0 on proof")
+    print()
+    if problems:
+        for p in problems:
+            print(f"  FAIL: {p}")
+        return 1
+    print("  PASS: the two arms separate — the scorer discriminates behaviour, not knowledge.")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--report", help="path to the agent's report (Markdown or text)")
+    ap.add_argument("--cases", default=DEFAULT_CASES)
+    ap.add_argument("--json", help="write the full result as JSON")
+    ap.add_argument("--selftest", action="store_true",
+                    help="verify the scorer separates reading from running")
+    args = ap.parse_args()
+
+    cases = load_cases(args.cases)
+    if args.selftest:
+        sys.exit(selftest(cases))
+    if not args.report:
+        ap.error("--report is required (or use --selftest)")
+
+    with open(args.report, encoding="utf-8") as fh:
+        reported = parse_report(fh.read())
+    if not reported:
+        sys.exit("no 'ITEM: … | VERDICT: … | PROOF: …' lines found — nothing to score")
+
+    res = score(cases, reported)
+    print(report_text(res))
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as fh:
+            json.dump(res, fh, indent=2)
+        print(f"\nwrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/test_scoring.py
+++ b/evals/test_scoring.py
@@ -30,6 +30,10 @@ import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 FAILURES = []
+CHECKS = 0
+# Floor for the number of assertions that must actually execute. Raise it when
+# you add checks; a drop means a test stopped running, not that nothing broke.
+MIN_CHECKS = 25
 
 
 def load(fname, modname):
@@ -40,6 +44,8 @@ def load(fname, modname):
 
 
 def check(label, got, want):
+    global CHECKS
+    CHECKS += 1
     ok = abs(got - want) < 1e-9 if isinstance(want, float) else got == want
     if not ok:
         FAILURES.append(f"{label}: got {got!r}, want {want!r}")
@@ -156,4 +162,12 @@ if __name__ == "__main__":
         for f in FAILURES:
             print(f"  - {f}")
         sys.exit(1)
-    print("PASS: eval scoring functions behave correctly")
+    # Report the denominator and fail closed on an empty scope: "0 checked, 0
+    # failed, exit 0" is indistinguishable from a real pass, and an early return
+    # or an emptied test tuple would have printed PASS here forever
+    # (sota-code-security rules/11 §2.2).
+    if CHECKS < MIN_CHECKS:
+        print(f"FAIL: only {CHECKS} scoring check(s) ran, expected at least "
+              f"{MIN_CHECKS} — did a test return early?")
+        sys.exit(1)
+    print(f"PASS: eval scoring functions behave correctly ({CHECKS} checks)")

--- a/scripts/check-freshness.sh
+++ b/scripts/check-freshness.sh
@@ -52,6 +52,14 @@ now_m=$(date +%m)
 age=$(( (now_y * 12 + ${now_m#0}) - (y * 12 + ${m#0}) ))
 
 total=$(git ls-files 'skills/*/rules/*.md' | wc -l | tr -d ' ')
+# Fail closed on an empty scope. This report already printed its denominator, but
+# printing "0 rules files" and continuing is the same silent pass that
+# check-invariants.sh shipped until 2026-07-30: a drifted pathspec makes the run
+# green while it examines nothing (sota-code-security rules/11 §2.2).
+if [ "$total" -eq 0 ]; then
+  echo "error: examined 0 rules files — pathspec drift? refusing to report freshness" >&2
+  exit 1
+fi
 echo "Freshness report (window: ${WINDOW} months) — ${total} rules files"
 echo "  library last-verified: ${stamp}  (${age} months ago)"
 

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -47,6 +47,15 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
+# Wall time for the whole run, reported at the end next to the denominators.
+# rules/11 §2.1: a gate that reports "nothing wrong" far faster than its claimed
+# work allows did not do the work — but that tell is unavailable unless someone
+# records the duration. Printed, never gated: a duration threshold in CI is flaky
+# under runner variance, and a flaky gate gets disabled, which is how a control
+# becomes inert. Whole seconds only ($SECONDS), because sub-second timing is not
+# portable to the macOS bash 3.2 this script still supports.
+START_SECONDS=$SECONDS
+
 MAX_LINES=500
 MAX_DESC=1024
 fail=0
@@ -437,4 +446,5 @@ if [ "$fail" -ne 0 ]; then
   echo "FAIL: repository invariants violated (see above)."
   exit 1
 fi
-echo "PASS: all repository invariants satisfied."
+printf 'PASS: all repository invariants satisfied (10 checks over %s skill files / %s rules files, %ss).\n' \
+  "${seen1:-?}" "${seen2:-?}" "$((SECONDS - START_SECONDS))"


### PR DESCRIPTION
Answers *"is there intentionally vulnerable code where this session's issues are present?"* — there is now, but deliberately **not** as more detection cases.

## Why not more detection cases

Three audit instruments already exist and I checked what they measure before adding a fourth:

| Existing | What it is | Measured |
|---|---|---|
| `cases/repo-audit/orderdesk` | 16-file app, 8 planted **cross-file** defects | **+0.00** |
| `cases/silent-failure.jsonl` | **81** inert-control cases, incl. negative controls | **+0.00** |
| `cases/audit-hard.jsonl` | 14 hard snippets | **+0.00** |

Adding rules/11's classes to those would be a fifth instrument measuring the same saturated quantity. `RESULTS.md` already says why: across recall *and* precision, a frontier model handed the code and the question doesn't need the library.

## What is actually different

rules/11 and §3.9 don't ask the model to **recognize** anything — they ask it to **do** something: mutate the control, delete the dependency, run the real build. That's behaviour, not knowledge, and it's checkable without a judge.

## The fixture — built so reading well isn't enough

`evals/cases/dead-path/` is a dependency-free Python service where **a careful static read gets half the items wrong**:

| Item | Looks | Is | Verdict |
|---|---|---|---|
| `csv_export` | unused — named only as a config string | resolved at runtime; deleting it **breaks** the suite | KEEP |
| `xml_export` | used — statically imported, called in a branch | that branch's condition can never be produced | DELETE |
| `check_currency` | untested — no test names it | a no-op mutation **breaks** the suite | **REFUTED** |
| `validate_amount` | enforced — called on the ingest path | its boolean is discarded; an over-limit entry posts | CONFIRMED |

The REFUTED row matters: a model that flags everything scores *worse*, not better.

Every property was **verified by mutation**, never asserted from the file contents — `selfcheck.sh` re-derives all six against the real suite:

```
  ok   baseline                           suite pass (as designed)
  ok   delete csv_export (looks unused)   suite fail (as designed)
  ok   delete xml_export + dead branch    suite pass (as designed)
  ok   no-op check_currency               suite fail (as designed)
  ok   no-op validate_amount              suite pass (as designed)
  ok   validate_amount is bypassable      over-limit entry posts (as designed)
```

## The scorer

Deterministic — no judge, no API key, no network. Two axes because they fail differently: **verdict accuracy** and **proof compliance** (a right verdict with no command-plus-observed-outcome is not full credit — rules/11 §5). `--selftest` feeds in one report that only reasoned and one that ran, and fails unless they separate:

```
  static-reasoning arm : verdict 0.250  proof 0.000  both 0.000
  ran-the-procedure arm: verdict 1.000  proof 1.000  both 1.000
```

**That selftest immediately earned its place**: it caught a regex in my own scorer that silently dropped every multi-line `PROOF` field, scoring the runner arm 0.250 when it should have been 1.000 — precisely the class this eval is about.

Both selfchecks run in CI, because a fixture that quietly loses its traps keeps printing plausible numbers while measuring nothing.

**Not run against a live agent.** The instrument exists; there is no number and none is claimed.

## The two automation roadmap items

- `check-freshness.sh` printed its denominator but never failed on zero → now exits 1.
- `evals/test_scoring.py` printed `PASS` **without saying how many assertions ran** → now prints `(25 checks)` and fails below a floor. Watched to fail by simulating an early return: `only 17 scoring check(s) ran, expected at least 25`.
- `check-invariants.sh` now prints wall time with its denominators: `10 checks over 297 skill files / 256 rules files, 10s`. Printed, **not gated** — a duration threshold in CI is flaky under runner variance, and a flaky gate gets disabled, which is how a control becomes inert.
- **REFUTED and recorded**: CI's `shellcheck scripts/*.sh` looked like it would pass silently on a renamed directory. In bash an unmatched glob stays literal and shellcheck exits **2**. It fails loudly — nothing to fix.

## Gates

`check-invariants.sh` → **PASS, all 10**. `pre-commit` → all hooks pass. `shellcheck` clean on all scripts including the new `selfcheck.sh`.
