### PR TITLE
evals(dead-path): ran it — +0.00, and it refutes our own explanation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without a change, and behind-upstream — each verified to exit 0 without
   tripping `set -euo pipefail`.
 
+### Changed
+
+- **The dead-path eval was run, and it is an honest +0.00 that refutes our own
+  explanation.** Six live Claude Code sub-agents, 3 per arm, identical prompts
+  except the treatment: **both arms scored 1.000 verdict / 1.000 proof**, 12/12
+  items each, including both inverted traps and the REFUTED case. The
+  pre-registered hypothesis — *"a bare agent reasons and scores ~0.25 verdict /
+  0.00 proof; a library-guided one runs the mutations"* — is **wrong**. The bare
+  agents worked in scratch copies, mutated the controls, deleted the modules and
+  ran `trace.Trace` unprompted; one used `dis` to identify `POP_TOP` after the
+  control's `CALL` as the bytecode tell for a discarded return. Nothing asked them
+  to.
+  - This matters beyond one eval: the standing explanation for the other four
+    audit nulls was that they score *recognition*, and a procedure-graded
+    instrument would separate the arms. It did not. That explanation is retired,
+    and `RESULTS.md` says so at the top of the audit section.
+  - The arms differ only in **reporting discipline** — ACTIVE/LATENT labels 0/3 vs
+    3/3, claims bounded by what actually ran 0/3 vs 3/3, flagging that the fix
+    moves a decision boundary 0/3 vs 3/3. Post-hoc, n=3, and partly tautological
+    (the library arm was told to follow a file that defines that vocabulary).
+    **Not a lift, and not to be cited as one.**
+  - Two disclosures in the write-up: the scorer's execution regex was **widened
+    mid-run** after a false negative on a real, prose-described deletion proof (no
+    arm's ranking changed; the `--selftest` guard still separates the arms 0.000 vs
+    1.000), and one agent's report file is a transcription because the harness
+    blocked it from writing `.md` — its verdict lines are verbatim, its method text
+    abridged. Full detail: `evals/results/2026-07-30/DEAD-PATH.md`.
+
 ### Fixed
 
 - **The rest of the automation got the same treatment as the invariant checks**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -76,17 +76,28 @@ first.
   and a flaky gate gets disabled. Still open: the eval runners and CI steps print
   no duration, and there is no recorded baseline to compare a future run against,
   so "it got 30× faster" is visible only to a human reading two logs.
-- **The dead-path eval has never been run against a live agent.** The fixture,
-  ground truth, deterministic scorer, fixture selfcheck and scorer selftest all
-  exist and run in CI (2026-07-30) — but no arm has been executed, so there is **no
-  number**, and none should be cited. Running it needs a tool-using agent driven
-  over a scratch copy of `evals/cases/dead-path/`, then
-  `run-dead-path.py --report`. Cheap next step: 4–6 local Claude Code sub-agents,
-  with-library vs bare, no OpenRouter spend for the deterministic half. The
-  hypothesis worth testing is narrow and falsifiable: **a bare agent reasons and
-  scores ~0.25 verdict / 0.00 proof; a library-guided one runs the mutations.** If
-  both arms run the procedure unprompted, this lands at +0.00 like the other four
-  and that is a real answer worth recording.
+- ~~**The dead-path eval has never been run against a live agent.**~~ **Run
+  2026-07-30 — and the hypothesis was wrong.** Six local sub-agents, 3 per arm:
+  **both arms 1.000/1.000, +0.00**. The pre-registered prediction ("a bare agent
+  reasons and scores ~0.25 verdict / 0.00 proof") is **refuted** — the bare agents
+  worked in scratch copies, mutated the controls, deleted the modules, ran
+  `trace.Trace`, and one used `dis` to spot the discarded return, none of it
+  requested. So "these instruments score recognition, not procedure" no longer
+  explains the audit family's saturation
+  ([DEAD-PATH](../evals/results/2026-07-30/DEAD-PATH.md)). The arms differ only in
+  reporting discipline (ACTIVE/LATENT labels 0/3 vs 3/3, bounded claims 0/3 vs
+  3/3, decision-boundary fix-risk 0/3 vs 3/3) — post-hoc, partly tautological
+  since the library arm was told to use that vocabulary, and **not a lift**.
+- **Where the audit frontier actually is, after that null.** Two readings survive
+  and neither is tested. (a) *The brief did the work*: naming four suspects and
+  demanding a `PROOF` field is a strong nudge; a genuinely unscoped "audit this
+  repo" over a large tree might separate the arms — this run is weak evidence for
+  prioritising the **agentic large-repo audit** (item 2 below) over building more
+  small fixtures. (b) *The scored axes are the wrong ones*: an instrument grading
+  labels, bounded claims and fix-risk would measure something, but it would be
+  measuring adherence to our own vocabulary, a far weaker claim than "finds more
+  bugs" — it must never be reported as a lift. Do not build a sixth small fixture
+  without a reason to expect a different answer.
 
 - **No gate notices a capability that never reached a front-door surface.**
   Invariant 6 fails the build on a wrong *number* in the README; nothing fails on a

--- a/evals/README.md
+++ b/evals/README.md
@@ -27,8 +27,12 @@ audit STRAT-HIGH-2).
   accuracy and *proof compliance* (a right verdict with no executed evidence is not
   full credit). `selfcheck.sh` re-derives the fixture's six planted properties by
   mutation; `--selftest` proves the scorer still separates a report that reasoned
-  from one that ran. Both run in CI. **Not yet run against a live agent** — the
-  instrument exists, the number does not.
+  from one that ran. Both run in CI. **Run 2026-07-30, 6 live sub-agents, 3 per
+  arm: +0.00 — both arms 1.000/1.000.** The pre-registered hypothesis (bare agents
+  reason, guided ones run the procedure) is **refuted**: the bare agents mutated
+  the controls, deleted the modules and traced execution unprompted, and got both
+  inverted traps and the REFUTED case right
+  ([DEAD-PATH](results/2026-07-30/DEAD-PATH.md)).
 - `cases/router.jsonl` (20) — routing: a plain prompt → the skills that must
   load. Tests the router's task→skill mapping.
 - `cases/audit.jsonl` (13) — audit: a deliberately vulnerable snippet → the

--- a/evals/results/2026-07-30/DEAD-PATH.md
+++ b/evals/results/2026-07-30/DEAD-PATH.md
@@ -1,0 +1,123 @@
+# Dead-path procedure eval — the hypothesis was wrong (+0.00)
+
+**Date:** 2026-07-30 · **n:** 3 per arm, 6 live Claude Code sub-agents ·
+**Instrument:** `evals/cases/dead-path/` + `evals/run-dead-path.py` ·
+**Result: +0.00 on both scored axes. Both arms scored 1.000/1.000.**
+
+## What this was testing, and why it should have been different
+
+Four audit instruments already sat at +0.00, and the working explanation was that
+they all score **recognition**: hand a frontier model the code and the question
+and it is already at ceiling. `rules/11` and `rules/03 §3.9` do not ask for
+recognition — they ask the model to *mutate the control, delete the dependency,
+and run the real build*. That is **behaviour**, so the pre-registered hypothesis
+(written into the roadmap before this ran) was:
+
+> a bare agent reasons and scores ~0.25 verdict / 0.00 proof; a library-guided one
+> runs the mutations.
+
+**That hypothesis is refuted.** The bare agents ran the mutations unprompted.
+
+## Setup
+
+Six `general-purpose` sub-agents, identical prompts except the treatment:
+
+- **bare (3):** the task, the four item ids, the verdict vocabulary, the report
+  format. Nothing about procedure, evidence, or the library.
+- **library (3):** the same, plus *"read and follow"* `rules/11` and
+  `rules/03 §3.9`, and *"read only those two files from that repository"* (so an
+  agent could not wander into `cases/dead-path.jsonl` and read the answers).
+
+Each got its own copy containing **only** `ledger/` and `tests/` (9 files). The
+fixture's `README.md` names the traps and `selfcheck.sh` contains the answers in
+its comments — neither travelled, verified by grepping the handed-over copy for
+every ground-truth term before launch.
+
+## Result
+
+| Arm | Verdict accuracy | Proof compliance | Both |
+|---|---|---|---|
+| bare1 / bare2 / bare3 | 1.000 / 1.000 / 1.000 | 1.000 / 1.000 / 1.000 | **1.000** |
+| lib1 / lib2 / lib3 | 1.000 / 1.000 / 1.000 | 1.000 / 1.000 / 1.000 | **1.000** |
+
+**12/12 items correct in each arm**, including both inverted traps and the
+REFUTED case that punishes over-flagging. Every agent in both arms worked in a
+scratch copy, mutated the controls, deleted the modules, and ran the suite.
+
+The bare agents did not merely comply — they went further than asked. One drove
+`trace.Trace` over the suite to show `xml_export`'s render body never executes;
+one used `dis` and identified `POP_TOP` after the control's `CALL` as the
+bytecode tell for a discarded return; one fuzzed `parse()` across inputs to show
+the reachable set of `source` values is exactly `{'api'}`. None of that was
+requested.
+
+## What differs, and why it is not in the score
+
+Both arms reach the same verdicts with real evidence. What separates them is
+**reporting discipline** — and the scorer does not grade it:
+
+| Behaviour (post-hoc marker count) | bare | library |
+|---|---|---|
+| ACTIVE / LATENT label on the finding | 0/3 | 3/3 |
+| Claim bounded by what actually ran ("the only suite is 4 tests") | 0/3 | 3/3 |
+| Flags that the fix **moves a decision boundary** → needs known-good/known-bad validation | 0/3 | 3/3 |
+| Severity / blast-radius statement | 1/3 | 3/3 |
+
+Read this weakly. It is **post-hoc**, n=3, and partly tautological: the library
+arm was told to follow a file that defines that vocabulary, so using it is
+compliance rather than insight. Whether labelling and bounding *change any
+outcome* is untested here. The honest summary is: **on everything this instrument
+measures, the library adds nothing; the difference that remains is in how the
+finding is written up, and its value is unmeasured.**
+
+## Two disclosures
+
+**1. The scorer was widened mid-run.** `lib3`'s `csv_export` proof initially
+scored 0 because `RAN_RE` required a command-shaped token, and the proof said
+"removed the file, ran the full suite → ModuleNotFoundError, 2 errors, exit 1" —
+a real executed deletion, described in prose. That is a false negative in the
+instrument, so execution verbs were added. The guard that keeps this honest is
+`--selftest`, which still separates the arms **0.000 vs 1.000** after the change;
+the reasoning arm cites greps and reads, which match no execution verb. Changing
+an instrument after seeing data is a methodological red flag, so: the pre-fix
+numbers were 6/6 arms at verdict 1.000, with proof 1.000 for five arms and 0.750
+for `lib3`. **No arm's ranking changed** — the fix moved one arm from 0.750 to
+1.000 in an already-saturated field.
+
+**2. `lib3`'s report file is a transcription.** The harness blocked that agent
+from writing a `.md` file (a subagent report-file guard; `bare2` hit the same
+guard and worked around it via Bash). Its verdict lines were transcribed verbatim
+from its returned output, but the surrounding method text was abridged — which is
+why its raw marker counts looked low before correction. Its full returned output
+did contain the ACTIVE label, the bounded claim, the decision-boundary warning and
+a severity rating. Future runs should have the agent return the report in its
+final message and let the parent write the file.
+
+## What this means for the instrument
+
+The fixture is not broken — its traps work, and `selfcheck.sh` re-derives all six
+planted properties by mutation on every CI run. What is now known is that **the
+traps do not discriminate at this model tier**: a capable agent handed a
+four-item audit brief runs the procedure whether or not it is told to.
+
+So this joins the other four as an honest null, and the "procedure not
+recognition" explanation for their saturation does not survive. Two readings
+remain open, neither tested:
+
+- **The brief did the work.** Naming four suspects and demanding a `PROOF` field
+  is itself a strong nudge. A genuinely unscoped prompt ("audit this repo") over a
+  much larger tree might separate the arms — that is the agentic large-repo
+  frontier already in the roadmap, and this run is weak evidence *for* prioritising
+  it over more small fixtures.
+- **The scored axes are the wrong ones.** If the real difference is labelling,
+  bounding, and fix-risk, an instrument that grades those would measure something
+  — but it would be measuring adherence to our own vocabulary, which is a much
+  weaker claim than "finds more bugs", and should never be reported as a lift.
+
+## Reproduce
+
+```sh
+bash evals/cases/dead-path/selfcheck.sh          # fixture still has its traps
+python3 evals/run-dead-path.py --selftest        # scorer still separates the arms
+python3 evals/run-dead-path.py --report REPORT.md
+```

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -19,6 +19,7 @@ Same model, same task, library loaded vs. nothing.
 | Audit **precision** (30 claims, 15 false) | 1.00 | 1.00 | +0.00 | 3×, temp 0.7 | [AUDIT-PROCESS](2026-07-20/AUDIT-PROCESS.md) |
 | Audit (14 hard snippets) | 1.00 | 1.00 | +0.00 | 1× | [BASELINE](2026-07-10/BASELINE.md) |
 | Cross-file audit (8-defect repo) | 1.00 | 1.00 | +0.00 | 2 models | [REPO-AUDIT](2026-07-13/REPO-AUDIT.md) |
+| Dead-path **procedure** (4 items, live sub-agents) | 1.00 | 1.00 | +0.00 | 3 per arm | [DEAD-PATH](2026-07-30/DEAD-PATH.md) |
 
 **Completeness re-verified against the workflow that actually ships (2026-07-20).**
 `run-completeness.py`'s `BUILD_WORKFLOW` is a hand-compressed **mirror** of router
@@ -56,6 +57,19 @@ is all in the unguided arm. Audit is +0.00 and reported, not hidden — a capabl
 model already recognizes vulnerabilities, even cross-file when the repo fits in
 context. The real remaining audit frontier is an **agentic large-repo** audit
 (too big to hold at once); logged in the [roadmap](../../docs/ROADMAP.md).
+
+**Update (2026-07-30) — the leading explanation for the audit nulls is refuted.**
+The four nulls below were explained by "these instruments score *recognition*, and
+a frontier model is already at ceiling there". `rules/11`/§3.9 grade a
+**procedure** instead — mutate the control, delete the dependency, run the build —
+so a fifth instrument was built specifically to test that distinction, with a
+fixture whose traps make a careful static read get **half the items wrong**. Six
+live sub-agents, 3 per arm: **both arms scored 1.000/1.000, +0.00**. The bare
+agents ran the mutations, deletions and traces unprompted, and hit both inverted
+traps and the REFUTED case. So the saturation is not about recognition-vs-procedure
+([DEAD-PATH](2026-07-30/DEAD-PATH.md); the arms differ only in *reporting*
+discipline — labels, bounded claims, fix-risk — which nothing here measures and
+which must not be cited as a lift).
 
 **The audit-family result, stated plainly (2026-07-21).** All four rows above that
 score audit ability sit at **+0.00**: audit-hard recall, cross-file repo audit,

--- a/evals/run-dead-path.py
+++ b/evals/run-dead-path.py
@@ -48,9 +48,17 @@ LINE_RE = re.compile(
 
 # A proof must name something that was RUN and something that was OBSERVED.
 # Naming a command alone is a plan, not evidence.
+# Execution is often reported in prose ("removed the file, ran the full suite")
+# rather than as a pasted command line. Requiring a command token scored those as
+# unproven — a false negative found on 2026-07-30 when a live agent's correct,
+# executed deletion proof was marked absent. The narrow forms stay; natural-
+# language execution verbs are added. The OBSERVED_RE half is what keeps this
+# honest: "ran the suite" alone still fails without an observed outcome, and the
+# --selftest reasoning arm (grep/reads/asserts, no execution) must still score 0.
 RAN_RE = re.compile(
     r"(unittest|pytest|python3?\s|go\s+(build|test|vet)|npm\s|cargo\s|make\s|rm\s|"
-    r"delete[sd]?\b|no-?op|mutat|\$\s|`[^`]+`)",
+    r"delete[sd]?\b|remov(e|ed|ing)\b|\bran\b|re-?ran\b|execut(e|ed|ing)\b|"
+    r"no-?op|mutat|trace[sd]?\b|\$\s|`[^`]+`)",
     re.IGNORECASE,
 )
 OBSERVED_RE = re.compile(


### PR DESCRIPTION
Six live Claude Code sub-agents, 3 per arm, identical prompts except the treatment.

| Arm | Verdict | Proof | Both |
|---|---|---|---|
| bare1 / bare2 / bare3 | 1.000 | 1.000 | **1.000** |
| lib1 / lib2 / lib3 | 1.000 | 1.000 | **1.000** |

12/12 items correct in each arm — including both inverted traps and the REFUTED case that punishes over-flagging.

## The pre-registered hypothesis was wrong

Written into the roadmap *before* the run:

> a bare agent reasons and scores ~0.25 verdict / 0.00 proof; a library-guided one runs the mutations

The bare agents ran the mutations. Unprompted, they worked in scratch copies, deleted the modules, no-op'd the controls, ran `trace.Trace` to prove a render body never executes, fuzzed `parse()` to establish that the reachable `source` set is exactly `{'api'}` — and one used `dis` to identify `POP_TOP` after the control's `CALL` as the bytecode tell for a discarded return.

## Why this matters beyond one eval

The standing explanation for the other four audit nulls was that they score **recognition**, where a frontier model is already at ceiling, and that an instrument grading a **procedure** would separate the arms. This fixture was built specifically to test that, with traps designed so a careful static read gets half the items wrong.

It did not separate them. **That explanation is retired**, and `RESULTS.md` now says so at the top of the audit section rather than leaving the old reasoning standing.

## What differs — held weakly

Only reporting discipline: ACTIVE/LATENT labels **0/3 vs 3/3**, claims bounded by what actually ran **0/3 vs 3/3**, flagging that the fix moves a decision boundary **0/3 vs 3/3**. Post-hoc, n=3, and partly tautological — the library arm was told to follow a file that defines that vocabulary, so using it is compliance, not insight. **Not a lift, and the write-up says so explicitly.**

## Two disclosures

**The scorer was widened mid-run.** A real deletion proof described in prose — *"removed the file, ran the full suite → ModuleNotFoundError, 2 errors, exit 1"* — scored as unproven because the pattern demanded a command-shaped token. That is a false negative in the instrument. Changing an instrument after seeing data is a methodological red flag, so the write-up states: pre-fix, 6/6 arms at verdict 1.000 with proof 1.000 for five arms and 0.750 for one; **no arm's ranking changed**; and `--selftest` still separates the arms **0.000 vs 1.000** afterwards.

**One report file is a transcription.** The harness blocked that agent from writing `.md` (another hit the same guard and worked around it via Bash). Its verdict lines are verbatim; its method text was abridged by me — which is why its raw marker counts read low until corrected against its full returned output.

## Fixture integrity

Unaffected — `selfcheck.sh` still re-derives all six planted properties by mutation, in CI. What is now known is that **the traps do not discriminate at this model tier**.

## Roadmap

Two readings survive, neither tested: the brief may have done the work (naming four suspects and demanding a `PROOF` field is a strong nudge — weak evidence for prioritising the **agentic large-repo audit** over more small fixtures), or the scored axes are the wrong ones (but grading adherence to our own vocabulary is a far weaker claim than "finds more bugs"). Recorded explicitly: **do not build a sixth small fixture without a reason to expect a different answer.**

`check-invariants.sh` PASS all 10 · fixture selfcheck PASS · scorer selftest PASS.
