### PR TITLE
evals(build-safe): thin spec does not discriminate either — instrument closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as an HTML comment — still text the agent reads, naming every leaked property —
   and now lives in the ground-truth file's header. General form: **keep guidance
   about the instrument out of the artifact the subject sees.**
+- **The build-safe instrument is closed, not pending.** The rewritten spec was
+  tested: two bare agents scored **1.000 / 1.000**, making five bare builds across
+  two spec versions all at ceiling. These seven defect classes are **not elicitable
+  from a spec** at this model tier. The residue is a distinction worth keeping —
+  the +0.39 completeness lift comes from *cross-cutting omissions* under a
+  one-sentence prompt (rate limiting, logging, TLS, tests), while these are *local
+  correctness decisions inside a feature the model is actively writing*. Defect
+  avoidance and practice completeness are different measurement targets, and only
+  the second has ever shown a gap here. Recorded with "do not rebuild this
+  instrument" so a third spec version is not attempted.
 - **`docs/INDEX.md` now reaches the day's results.** The find-it-fast index had
   **zero** pointers to the four 2026-07-30 result files, so the most consequential
   findings — why the audit half has no measured lift, a prediction written down

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,8 +61,15 @@ first.
 
 **New open items from the 2026-07-30 cycle:**
 
-- **Does the rewritten build-safe spec discriminate? Unknown — a bare pilot is
-  mid-flight.** `SPEC.md` was rewritten the same day to *state features and facts,
+- ~~**Does the rewritten build-safe spec discriminate?**~~ **Tested 2026-07-31: no.**
+  Two bare agents on the thin spec scored **1.000 / 1.000** — five bare builds across
+  two spec versions, all at ceiling. These seven classes are **not elicitable from a
+  spec** at this model tier. The useful residue is a distinction, not a number:
+  the +0.39 comes from **cross-cutting omissions** under a one-sentence prompt
+  (rate limiting, logging, TLS, tests), whereas these are **local correctness
+  decisions inside a feature the model is actively writing**, and it makes them
+  well. Defect-avoidance and practice-completeness are different targets; only the
+  second has ever shown a gap. **Do not rebuild this instrument.** Original entry: `SPEC.md` was rewritten the same day to *state features and facts,
   never the property to preserve* (verified: zero "must …" quality clauses, zero
   defect names, all six product tensions intact). Whether that restores discriminating
   power is untested: if the bare arm still scores 1.000, these classes may not be

--- a/evals/results/2026-07-30/BUILD-SAFE.md
+++ b/evals/results/2026-07-30/BUILD-SAFE.md
@@ -118,9 +118,35 @@ have been a worse leak than the original. It now lives in the header of
 `cases/build-safe.jsonl`, which never travels to a subject. General form: **keep
 guidance about the instrument out of the artifact the subject sees.**
 
-**Whether the thinner spec discriminates is not yet known.** A two-agent bare pilot
-was launched; if the bare arm still scores 1.000, the instrument is still at
-ceiling and the classes may simply not be elicitable from a spec at all. No claim
-either way until it lands.
+**The thinner spec did not restore discriminating power.** Two bare agents on the
+rewritten spec, both verified library-free: **1.000 and 1.000**. Same ceiling.
+
+One of them went past the reference answer: it noticed permissions are a pure
+function of role, so the "three-table join" computes a constant — and **deleted the
+cache** instead of adding invalidation. No cache, no staleness window. The other
+mutation-checked its own suite across nine controls and fixed two false claims it
+had written in its own comments after `EXPLAIN QUERY PLAN` contradicted them.
+
+## Conclusion: these classes are not elicitable from a spec at this tier
+
+Fat spec or thin, a capable agent asked to *build this service* writes an
+allowlisted sort, an ownership predicate, a non-swallowing webhook, a full-payload
+scan and real admin guards, and declines to wire a handler nothing emits. Five
+bare builds across two spec versions, all 1.000.
+
+**This is worth contrasting with the +0.39 completeness result rather than filed
+next to it.** Those rubric items are **cross-cutting omissions** under a
+one-sentence prompt — rate limiting, structured logging, TLS, tests — things a
+model drops because nobody named them and the task did not imply them. The seven
+classes here are **local correctness decisions inside a feature the model is
+actively writing**, and it makes them well.
+
+So defect-**avoidance** and practice-**completeness** are different measurement
+targets, and only the second has ever shown a gap in this project. That is the
+useful finding from this instrument, and it is a finding about *where a lift can
+exist at all* — not a result about the library, which never got a comparable arm
+because the bare arm never left the ceiling.
+
+**Do not rebuild this instrument.** A third spec version is not the missing piece.
 
 The fixture, scorer and both references are unchanged and reusable.


### PR DESCRIPTION
Closes the last open item, with a negative result.

## Result

Two bare agents on the rewritten spec, both verified library-free: **1.000 / 1.000**. That is **five bare builds across two spec versions, all at ceiling**.

The spec rewrite was the right fix for a real leak — and it did not change the outcome. So the leak was not what was holding the instrument down.

## What this actually establishes

These seven defect classes are **not elicitable from a spec** at this model tier. Fat spec or thin, a capable agent asked to build the service writes an allowlisted sort, an ownership predicate, a non-swallowing webhook, a full-payload scan and real admin guards, and declines to wire a handler nothing emits.

One pilot agent went past the reference answer: it noticed permissions are a pure function of role, so the "three-table join" computes a constant, and **deleted the cache** rather than adding invalidation. No cache, no staleness window.

## The residue is worth more than the eval would have been

| | +0.39 completeness | build-safe |
|---|---|---|
| Prompt | one sentence | a page of features |
| Rubric items | **cross-cutting omissions** — rate limiting, logging, TLS, tests | **local correctness decisions** inside a feature |
| Why the model misses them | nobody named them; the task didn't imply them | it doesn't — it makes them well |
| Measured gap | 0.59 → 0.98 | none, at ceiling |

**Defect-avoidance and practice-completeness are different measurement targets, and only the second has ever shown a gap here.** That is a finding about *where a lift can exist at all*, which is more useful than the number this instrument was built to produce.

Recorded with an explicit **do not rebuild this instrument** so a third spec version isn't attempted. No library-arm number is reported — the bare arm never left the ceiling, so there was nothing to compare against.

Invariants: PASS, all 10.
