### PR TITLE
docs: preserve the reimplement pre-registration, index it, record LAST-VERIFIED semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`docs/INDEX.md`** reaches the reimplement case set, and the case file now
+  carries the predictions written **before** any run existed — so if it is ever
+  run, the pre-registration is the authoring session's, not one composed after
+  seeing data. It also records, in advance, that a null there is the **eighth**
+  and the conclusion is to stop rather than author a ninth.
 - **`evals/cases/reimplement.jsonl` + `run-reimplement.py` — documentation, not a
   measured instrument.** Ten cases (5 disqualified / 5 legitimate) encoding the
   §3.9.4-vs-§3.9.6 conflict, with every legitimate case resembling a disqualified one

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -37,6 +37,7 @@ trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issu
 | Understand why the **audit** half has no measured lift (7 instruments, 3 designs) | [UNSCOPED-AUDIT.md](../evals/results/2026-07-30/UNSCOPED-AUDIT.md) · [DEAD-PATH.md](../evals/results/2026-07-30/DEAD-PATH.md) |
 | See a prediction written down **before** the run that killed it | [PRE-REGISTRATION.md](../evals/results/2026-07-30/PRE-REGISTRATION.md) |
 | Read an eval that failed as an *instrument* rather than as a result | [BUILD-SAFE.md](../evals/results/2026-07-30/BUILD-SAFE.md) |
+| See the edges of the do-not-reimplement rule (§3.9.6), as worked cases | [`evals/cases/reimplement.jsonl`](../evals/cases/reimplement.jsonl) — documentation, never run |
 | Know what the audit hunts that a scanner can't (inert controls, unreached dependencies, stale decisions, refutation, absence claims) | [README → What the audit hunts](../README.md#what-the-audit-hunts-that-a-scanner-cant) |
 | Read the retraction + the retired anchoring hypothesis | [SILENT-FAILURE.md](../evals/results/2026-07-20/SILENT-FAILURE.md) |
 

--- a/evals/cases/reimplement.jsonl
+++ b/evals/cases/reimplement.jsonl
@@ -15,7 +15,18 @@
 # legitimate REPLACE, conditional on stating which side you are on, pinning the
 # spec version, and testing against AWS's published vectors.
 #
-# It is deliberately NOT added back: the 5/5 split is what pins both degenerate
+# IF THIS IS EVER RUN, these predictions were written BEFORE any run existed
+# (authoring session, 2026-07-31) and must be used rather than fresh ones — a
+# prediction composed after seeing data is not a prediction:
+#     decision  bare 0.70 (0.50-0.90) | library 0.85 (0.65-1.00) | delta +0.15
+#     reason    bare 0.30 (0.10-0.55) | library 0.75 (0.50-1.00) | delta +0.45
+#     confidence the reason delta exceeds +0.15: ~40%
+# The honest prior is null: seven instruments already read +0.00, and the reason
+# axis is the only part with a real shot because it asks for a mechanism rather
+# than a recognition. Decided in advance: if both axes come back null, that is the
+# EIGHTH null and the conclusion is to stop, not to author a ninth.
+#
+# The s3_put case is deliberately NOT added back: the 5/5 split is what pins both degenerate
 # strategies at exactly 0.500, and a sixth REPLACE would move refuse-everything to
 # 0.455 and cost the instrument its cleanest property.
 #


### PR DESCRIPTION
Sweep after the §3.9.6 amendment. Three gaps, each verified rather than assumed.

## 1. The pre-registration existed only in conversation

The predictions for the reimplement case set (decision bare 0.70 / library 0.85; reason bare 0.30 / library 0.75; ~40% confidence the reason delta clears +0.15) were written before any run existed — and would have been lost. They are now in the case-file header, marked as such, **because a prediction composed after seeing data is not a prediction**.

It also records in advance that a null there would be the **eighth**, and the conclusion is to stop rather than author a ninth.

## 2. `docs/INDEX.md` could not reach the artifact

Added, labelled *documentation, never run*, so nobody mistakes it for a measured instrument.

## 3. Memory had the freshness window but not the semantics

That's the part that was nearly got wrong. `LAST-VERIFIED` stamps the last **full 41-skill sweep**, not the newest verified fact — so a rule section can legitimately carry 2026-07-30 verification dates while the stamp reads 2026-07-08. **Two separate sessions have now proposed bumping it and caught themselves on verification**, which makes the temptation structural: an edit that verified its own facts *feels* like it should update the stamp.

Bumping it would plant a false green in the one gate whose entire job is detecting stale claims — the failure class this library exists to catch.

## Counts re-verified, unchanged

41 skills / 297 files (reimplement lives in `evals/`, not `skills/`), 10 invariants in README and MAINTENANCE, invariant 10 in AGENTS.md, `rules/03` at 440/500, three eval selftest steps in CI.

Invariants: **PASS, all 10**.
