### PR TITLE
docs: conventions ledger — what is enforced, what is prose, and why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`docs/CONVENTIONS-LEDGER.md`** — which repo conventions are enforced, which are
+  prose, and why the rest should stay prose. Built after invariant 11, so the next
+  documented-but-unenforced rule is found deliberately rather than by luck.
+  Mechanically extracted from the five agent-facing docs: **49 raw entries, 8
+  duplicates, 41 distinct**, of which **11** are invariants and **4** more are
+  enforced inside the eval runners — so reading `check-invariants.sh` alone
+  undercounts what this repo enforces by about a third.
+  - It corrects an earlier estimate of "~122 conventions", which came from a loose
+    regex matching any bold line or any line containing *must/never/always* — an
+    over-count of roughly 3×, recorded so it is not repeated.
+  - Applying three filters (has it already failed · does it fail silently · is it
+    mechanically checkable) yields **one** actionable candidate, not the 2–4
+    predicted: a regression guard requiring every scoreboard row to declare its
+    sample size. The other candidate (§2b's front-door grep) stays **blocked** on
+    needing machine-readable capability names.
+  - For the ~18 judgment conventions the ledger argues against a fourth copy of the
+    text and for **proximity**: `LAST-VERIFIED` failed while documented in three
+    places, all far from the point of use.
+
+### Changed
+
+- **`evals/README` — the n=1 convention contradicted itself.** Its bolded headline
+  read *"Never publish from n=1"* while the next sentence permitted it *"or state
+  the sample size"*. A skim-reader saw a prohibition, a close reader a disclosure
+  rule, and the scoreboard follows the body (the audit row is a declared `1×`, and
+  is therefore compliant). Headline reworded to match the rule it actually states.
+  Found by checking the scoreboard for a violation and discovering a wording defect
+  instead.
+
 - **Invariant 11 — `LAST-VERIFIED` moves only alongside a sweep.** The stamp
   records the last *full* re-verification pass, not the newest verified fact, so a
   rules section may legitimately carry today's verification dates while the stamp

--- a/docs/CONVENTIONS-LEDGER.md
+++ b/docs/CONVENTIONS-LEDGER.md
@@ -1,0 +1,111 @@
+# Conventions ledger — which rules are enforced, which are prose, and why
+
+A rule written in prose is a **hypothesis that people will read it**. This repo has
+one measured counter-example: `LAST-VERIFIED` was documented in three separate
+places, mentioned across nine files, and **two separate sessions still proposed
+bumping it wrongly**, catching themselves only on verification. That is
+`sota-code-security` rules/10 §2.12 — *a natural-language instruction standing in
+for an enforced control* — occurring in this repo's own tooling, so it became
+invariant 11 (2026-07-31).
+
+This ledger exists so the next such case is found deliberately rather than by luck.
+It is **not** an argument for gating everything: a gate per convention means false
+positives, and rules/11 §7 is explicit that a flaky gate gets disabled, which leaves
+you worse off than the prose you replaced.
+
+## Method
+
+Extracted mechanically from the five agent-facing docs — `AGENTS.md`,
+`CONTRIBUTING.md`, `RELEASING.md`, `evals/README.md`, `docs/MAINTENANCE.md` — by
+matching the repo's convention format (a bolded lead-in on a bullet or numbered
+item).
+
+| | |
+|---|---|
+| Raw entries | 49 |
+| Duplicates (the invariant list appears in both `AGENTS.md` and `CONTRIBUTING.md`) | 8 |
+| **Distinct conventions** | **41** |
+| Already enforced as invariants | 11 |
+
+An earlier estimate of "~122" came from a loose regex that matched any bold line or
+any line containing *must/never/always*. It was an over-count by ~3×, and is
+recorded here so the number is not repeated.
+
+## The three filters
+
+A convention earns a gate only if it passes **all three**:
+
+1. **Has it already failed?** The repo records its own incidents. A convention with
+   a real incident is *proven fallible*; one without is a hypothesis, and gating
+   hypotheses is how a repo accumulates checks nobody trusts.
+2. **Does it fail silently?** The discriminator that matters. A violation that
+   breaks CI, fails a test, or annoys somebody already has feedback. A violation
+   that produces a **plausible-looking result** — a green stamp, a `+0.00`, a scorer
+   returning `1.0` — is the rules/10 class and cannot be caught by attention.
+3. **Is it mechanically checkable?** Many are not, and pretending otherwise
+   produces a gate that measures the wrong thing.
+
+## The ledger
+
+### Enforced (11) — invariants 1–11
+
+Line cap · audit-checklist placement · internal-name denylist · description cap ·
+version lockstep · count surfaces · router completeness · link resolution ·
+single `[Unreleased]` · rules-file indexed by its SKILL.md · `LAST-VERIFIED` sweep
+pairing. Each is in `scripts/check-invariants.sh` and documented in `AGENTS.md`.
+
+### Enforced in code, outside the invariant script (4)
+
+| Convention | Where enforced |
+|---|---|
+| Pin what you mirror | `ROUTER_BUILD_SHA` aborts `run-completeness.py` on drift |
+| Assert the corpus is non-empty / a filter removed something | guards inside each runner |
+| Guards abort, never warn | the runners' own abort paths |
+| Don't trust the scrub | gitleaks is the backstop, in pre-commit and CI |
+
+### Judgment — correctly ungateable (≈18)
+
+*Verify every claim against a primary source* · *keep it generic* (the judgment half;
+the denylist covers the mechanical half) · *watch the guard fail before trusting it* ·
+*assert a scripted edit landed* · *wait on a terminal artifact* · *grow the set before
+trusting a subgroup signal* · *adversarially re-verify* · the sweep runbook's steps ·
+the live-agent A/B conventions (*a bare arm is not bare by default*, *never encode the
+arm in a path*) — these govern work that happens **outside the repo**, in prompts and
+scratch directories a gate cannot see.
+
+For these the fix is never a fourth copy of the text. It is **proximity**: the
+LAST-VERIFIED rule failed while written in three places, all far from the point of
+use. One line *in* the file being edited would likely have outperformed all three.
+
+### Gateable but not gated (2 candidates)
+
+| Candidate | Incident? | Silent? | Checkable? | Verdict |
+|---|---|---|---|---|
+| Every scoreboard row declares its sample size | **yes** — a `+0.07` retracted at n=49, and `+0.40` corrected to `+0.39` by a second run | **yes** — a number from one run is typographically identical to one from ten | **yes** — the Samples column exists and all 10 rows populate it | **regression guard**, like invariant 10: it currently passes, so it prevents drift rather than repairing a defect |
+| Front-door capability grep (`RELEASING.md` §2b) | **yes** — five capabilities shipped with no README mention | **yes** — nothing errors | **no** — needs a machine-readable capability list per release | **blocked**, recorded in ROADMAP |
+
+## Findings
+
+**1. The "never publish from n=1" convention contradicts itself.** The bolded
+headline reads *"One run is a data point, not a number. Never publish from n=1."*
+The very next sentence permits it: *"Report a mean across ≥2 runs, **or state the
+sample size**."* A reader skimming bold sees a prohibition; a reader of the body
+sees a disclosure requirement. The scoreboard follows the body — the audit row is
+`1×`, declared — so it is **compliant, not a violation**. I checked expecting to
+find a breach and found a wording defect instead, which is the more useful result.
+
+**2. The gateable set is small — 2, and one is blocked.** Against a prediction of
+2–4, the ledger yields **one actionable candidate**, and it is a regression guard
+rather than a repair. That is the honest output: most conventions here either are
+already enforced or govern judgment a gate cannot reach.
+
+**3. Enforcement is not concentrated in the invariant script.** Four conventions are
+enforced inside the eval runners. Anyone auditing "what does this repo actually
+enforce?" by reading `check-invariants.sh` alone would undercount by a third.
+
+## What this does not claim
+
+No convention outside the two candidates was found to be both failure-prone and
+checkable. This ledger is a snapshot: it should be re-derived after any batch of new
+conventions, and the extraction is mechanical enough to repeat. It measures *what is
+enforced*, not *whether the conventions are correct*.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -47,6 +47,7 @@ trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issu
 |---|---|
 | Land a change (branch → PR → checks → merge) | [AGENTS.md → Landing a change](../AGENTS.md#landing-a-change) |
 | Know the invariants CI enforces | [AGENTS.md → Invariants](../AGENTS.md#invariants-enforced-in-pre-commit-and-ci) |
+| See which conventions are *enforced* vs. prose, and why the rest aren't gated | [CONVENTIONS-LEDGER.md](CONVENTIONS-LEDGER.md) |
 | Full contribution conventions | [CONTRIBUTING.md](../CONTRIBUTING.md) |
 | Cut a release | [RELEASING.md](../RELEASING.md) |
 | Keep fast-moving claims accurate (sweep runbook + named high-rot targets) | [MAINTENANCE.md](MAINTENANCE.md) |

--- a/evals/README.md
+++ b/evals/README.md
@@ -332,7 +332,7 @@ trusted.**
 
 ## Measurement conventions
 
-- **One run is a data point, not a number. Never publish from n=1.** Twice in one week
+- **One run is a data point, not a number. Never publish an n=1 figure without its sample size attached.** Twice in one week
   a single run produced a figure a larger sample walked back: `+0.07` on
   silent-control detection (retracted at n=49) and `+0.40` on completeness (a two-run
   mean put it back at `+0.39`). Report a mean across ≥2 runs, or state the sample size


### PR DESCRIPTION
Step 1 of the four-step plan. Its purpose is to decide whether steps 2–4 are worth doing — and the answer is **mostly no**, which is the useful result.

## Why it exists

`LAST-VERIFIED` was documented in three places and mentioned across nine files, and **two separate sessions still proposed bumping it wrongly**. That is `rules/10 §2.12` — a natural-language instruction standing in for an enforced control — in this repo's own tooling. It shouldn't take a third near-miss to find the next one.

## What the extraction found

| | |
|---|---|
| Raw entries | 49 |
| Duplicates (invariant list appears in both AGENTS and CONTRIBUTING) | 8 |
| **Distinct conventions** | **41** |
| Enforced as invariants | 11 |
| **Also enforced, inside the eval runners** | **4** |

That last row matters: anyone auditing *"what does this repo actually enforce?"* by reading `check-invariants.sh` alone **undercounts by about a third**.

It also corrects my own earlier estimate of "~122 conventions" — that came from a loose regex matching any bold line or any line containing *must/never/always*, an over-count of roughly 3×. Recorded in the ledger so it isn't repeated.

## The result: one candidate, not twenty

Applying the three filters (has it already failed · does it fail silently · is it mechanically checkable) yields **one** actionable candidate against a predicted 2–4 — a regression guard requiring every scoreboard row to declare its sample size. The other (§2b's front-door grep) stays **blocked** on needing machine-readable capability names.

The ledger argues explicitly *against* gating the ~18 judgment conventions, and for **proximity** instead: the LAST-VERIFIED rule failed while written three times, all far from the point of use. One line *in* the edited file would likely have beaten all three copies.

## A defect found on the way

`evals/README`'s n=1 convention **contradicted itself** — bolded headline *"Never publish from n=1"*, next sentence *"or state the sample size"*. I checked the scoreboard expecting a violation and found the audit row is a **declared `1×`**, i.e. compliant with the body. So: no violation, but a real wording defect where a skim-reader and a close reader get different rules. Headline reworded to match the rule it actually states.

Invariants: **PASS, all 11**.
