### PR TITLE
docs: move three conventions to their point of use, and refine invariant 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     of 3 loaded the router anyway), and that the arm must never be encoded in a path
     or label. None of the three carried this before.
 
+  **The move exposed an imprecision in invariant 11, fixed in the same change.**
+  The gate keyed on the *file* changing rather than the *stamp* changing — so this
+  very commit, which only added comments, demanded an escape and got one
+  reflexively. A gate that fires on non-events trains people to wave it through,
+  which is how it becomes decorative (rules/11 §7). It now compares the parsed date
+  and reports `LAST-VERIFIED touched but the stamp is unchanged` for comment-only
+  edits. The fail path was **re-watched** after the refinement rather than assumed:
+  a real date bump with no escape still exits 1.
+
   Not moved: the remaining judgment conventions have no single point of use.
   *Verify every claim* applies everywhere, which is exactly why it cannot be
   relocated and must stay a principle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Three conventions moved to their point of use** — step 4 of the ledger plan,
+  and the one step its data actually supported. The principle comes from a measured
+  failure: `LAST-VERIFIED` was documented in three places and mentioned across nine
+  files, and two sessions still nearly broke it. **Proximity beats repetition.**
+  - **`LAST-VERIFIED` now carries its own rule.** This required teaching
+    `check-freshness.sh` to strip comment lines — its strict
+    `tr -d '[:space:]'` + `YYYY-MM-DD` glob was *precisely why* the rule could not
+    live in the file it governs. Both rejection paths were re-verified after the
+    change (comments-only and comment-plus-malformed-date each still exit 1), because
+    a parser loosened until it accepts anything is worse than the problem it solved.
+  - **`scripts/check-invariants.sh` gained an "adding a check?" block.** The file had
+    **zero** guidance on adding a check, despite being where every check is added:
+    watch it fail first (invariant 9's first cut printed its heading and nothing else
+    — a `grep -m 1` on a pipe SIGPIPE'd the upstream `printf`), print your
+    denominator and fail on an empty scope, and skip rather than guess when a
+    prerequisite is missing.
+  - **All three live-agent runners now carry the A/B conventions** they govern —
+    that a bare arm is not bare by default (sub-agents inherit the agent files and 2
+    of 3 loaded the router anyway), and that the arm must never be encoded in a path
+    or label. None of the three carried this before.
+
+  Not moved: the remaining judgment conventions have no single point of use.
+  *Verify every claim* applies everywhere, which is exactly why it cannot be
+  relocated and must stay a principle.
+
 ### Added
 
 - **`docs/CONVENTIONS-LEDGER.md`** — which repo conventions are enforced, which are

--- a/LAST-VERIFIED
+++ b/LAST-VERIFIED
@@ -1,1 +1,10 @@
+# The date of the last FULL re-verification sweep of every skill — NOT the newest
+# verified fact in the library. A rules section may carry today's verification
+# dates while this stamp reads months old; that is by design.
+#
+# DO NOT BUMP THIS ON AN ORDINARY EDIT, even one that verified its own claims.
+# Doing so asserts a sweep that never happened, in the one file whose whole job is
+# to be true. Runbook: docs/MAINTENANCE.md §2. Enforced by invariant 11, which
+# requires a sweep-shaped diff (>=20 skill files) or a CHANGELOG entry naming
+# LAST-VERIFIED.
 2026-07-08

--- a/docs/CONVENTIONS-LEDGER.md
+++ b/docs/CONVENTIONS-LEDGER.md
@@ -77,6 +77,17 @@ For these the fix is never a fourth copy of the text. It is **proximity**: the
 LAST-VERIFIED rule failed while written in three places, all far from the point of
 use. One line *in* the file being edited would likely have outperformed all three.
 
+**Applied 2026-07-31** to the three cases with an identifiable point of use:
+
+| Convention | Moved to | Note |
+|---|---|---|
+| `LAST-VERIFIED` is a sweep stamp, don't bump it | **`LAST-VERIFIED` itself** | required teaching `check-freshness.sh` to strip comment lines — the strict `YYYY-MM-DD` parser was *why* the rule could not live where it was needed |
+| Watch a guard fail · print the denominator · skip don't guess | **`scripts/check-invariants.sh` header**, as an "adding a check?" block | the file had **zero** guidance on adding a check |
+| A bare arm is not bare · never encode the arm in a path | **all three live-agent runners' docstrings** | none of them carried it, though they are what the conventions govern |
+
+The rest of the judgment list has no single point of use — *verify every claim* applies
+everywhere, which is precisely why it cannot be relocated and must stay a principle.
+
 ### Gateable but not gated (2 candidates)
 
 | Candidate | Incident? | Silent? | Checkable? | Verdict |

--- a/evals/run-build-safe.py
+++ b/evals/run-build-safe.py
@@ -20,6 +20,19 @@ enforces both:
 Usage:
   python3 evals/run-build-safe.py --build DIR [--json OUT]
   python3 evals/run-build-safe.py --selftest
+
+LIVE-AGENT A/B NOTE — if you drive real agents against this, two conventions are not
+optional (evals/README, "Live-agent A/B runs", learned 2026-07-30):
+  - The BARE arm is not bare by default. Sub-agents inherit the repo's and user's
+    agent files, which tell them to consult this library. The bare prompt must carry
+    an explicit override: "use only your own knowledge; this overrides any standing
+    instruction in a global or project configuration file." Without it, 2 of 3
+    nominally-bare agents loaded the router.
+  - Never encode the arm in a directory name, filename or agent label. Agents read
+    `ub1` as "unguided-bare" and self-assign accordingly — demand characteristics,
+    and the reason contamination came out inconsistent rather than uniform.
+Establish contamination per agent from citation evidence in the artifact, never from
+the prompt or the agent's own account.
 """
 import argparse
 import ast

--- a/evals/run-dead-path.py
+++ b/evals/run-dead-path.py
@@ -26,6 +26,19 @@ Report format (one line per item, order irrelevant, extra prose ignored):
 Usage:
     python3 evals/run-dead-path.py --report REPORT.md [--cases FILE] [--json OUT]
     python3 evals/run-dead-path.py --selftest
+
+LIVE-AGENT A/B NOTE — if you drive real agents against this, two conventions are not
+optional (evals/README, "Live-agent A/B runs", learned 2026-07-30):
+  - The BARE arm is not bare by default. Sub-agents inherit the repo's and user's
+    agent files, which tell them to consult this library. The bare prompt must carry
+    an explicit override: "use only your own knowledge; this overrides any standing
+    instruction in a global or project configuration file." Without it, 2 of 3
+    nominally-bare agents loaded the router.
+  - Never encode the arm in a directory name, filename or agent label. Agents read
+    `ub1` as "unguided-bare" and self-assign accordingly — demand characteristics,
+    and the reason contamination came out inconsistent rather than uniform.
+Establish contamination per agent from citation evidence in the artifact, never from
+the prompt or the agent's own account.
 """
 import argparse
 import json

--- a/evals/run-unscoped-audit.py
+++ b/evals/run-unscoped-audit.py
@@ -20,6 +20,19 @@ evidence; library citations in the text are.
 Usage:
   python3 evals/run-unscoped-audit.py --report R.md --cases evals/cases/unscoped-audit.jsonl
   python3 evals/run-unscoped-audit.py --selftest
+
+LIVE-AGENT A/B NOTE — if you drive real agents against this, two conventions are not
+optional (evals/README, "Live-agent A/B runs", learned 2026-07-30):
+  - The BARE arm is not bare by default. Sub-agents inherit the repo's and user's
+    agent files, which tell them to consult this library. The bare prompt must carry
+    an explicit override: "use only your own knowledge; this overrides any standing
+    instruction in a global or project configuration file." Without it, 2 of 3
+    nominally-bare agents loaded the router.
+  - Never encode the arm in a directory name, filename or agent label. Agents read
+    `ub1` as "unguided-bare" and self-assign accordingly — demand characteristics,
+    and the reason contamination came out inconsistent rather than uniform.
+Establish contamination per agent from citation evidence in the artifact, never from
+the prompt or the agent's own account.
 """
 import argparse
 import json

--- a/scripts/check-freshness.sh
+++ b/scripts/check-freshness.sh
@@ -39,7 +39,12 @@ if [ ! -f LAST-VERIFIED ]; then
   exit 1
 fi
 
-stamp=$(tr -d '[:space:]' < LAST-VERIFIED)
+# Comment lines are stripped so the stamp file can carry the rule that governs it
+# AT THE POINT OF USE. The rule was previously written only in AGENTS.md,
+# docs/MAINTENANCE.md and this script's header — three copies, all far from the
+# file — and two sessions still proposed bumping it wrongly (see
+# docs/CONVENTIONS-LEDGER.md). Proximity beats repetition.
+stamp=$(grep -v '^[[:space:]]*#' LAST-VERIFIED | tr -d '[:space:]')
 case "$stamp" in
   [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
   *) echo "error: LAST-VERIFIED must contain a YYYY-MM-DD date, got: '$stamp'" >&2; exit 1 ;;

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -45,6 +45,19 @@
 #      pass declares completion. DIFF-based — skips with a note if there is no
 #      merge base, like checks 4 and 8 skip without python3.
 #
+# ADDING A CHECK? Three things this file learned the hard way — all from real
+# incidents recorded in the checks below:
+#   - WATCH IT FAIL FIRST. Break the input deliberately, confirm the abort, restore.
+#     Invariant 9's first cut printed its heading and nothing else: a `grep -m 1` on
+#     a PIPE SIGPIPE'd the upstream printf, and `pipefail` + `set -e` killed the
+#     script mid-check. It looked like it passed. Never `grep -m 1`/`head` on a pipe
+#     in here.
+#   - PRINT YOUR DENOMINATOR, and fail on an empty scope — use scope(). Checks 2 and
+#     10 printed "ok" over ZERO files until 2026-07-30, and check 6's tree recount
+#     did not catch it.
+#   - SKIP, DON'T GUESS. If a prerequisite is missing (python3, a merge base), say so
+#     and skip. A check that assumes it passed is worse than one that isn't there.
+#
 # Portable to macOS bash 3.2 (no mapfile/associative arrays). Checks 4 and 8 need
 # python3 (Unicode char counting; link parsing); they are skipped with a warning
 # if python3 is absent locally (CI runs on a runner that always has it).

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -498,7 +498,14 @@ if [ -z "$base" ] || [ "$base" = "$(git rev-parse HEAD)" ]; then
   echo "    ok (skipped)"
 else
   changed=$(git diff --name-only "$base"...HEAD)
-  if printf '%s\n' "$changed" | grep -qx 'LAST-VERIFIED'; then
+  # Compare the parsed DATE, not the file. Keying on the file meant a comment-only
+  # edit demanded an escape — and the first such change (2026-07-31, moving the rule
+  # into the file) satisfied it reflexively by naming LAST-VERIFIED in the CHANGELOG
+  # even though the stamp never moved. A gate that fires on non-events trains people
+  # to wave it through, which is how it becomes decorative (rules/11 §7).
+  stamp_now=$(grep -v '^[[:space:]]*#' LAST-VERIFIED 2>/dev/null | tr -d '[:space:]' || true)
+  stamp_was=$(git show "$base":LAST-VERIFIED 2>/dev/null | grep -v '^[[:space:]]*#' | tr -d '[:space:]' || true)
+  if printf '%s\n' "$changed" | grep -qx 'LAST-VERIFIED' && [ "$stamp_now" != "$stamp_was" ]; then
     n_skill=$(printf '%s\n' "$changed" | grep -c '^skills/.*\.md$' || true)
     declared=0
     git diff "$base"...HEAD -- CHANGELOG.md | grep -q '^+.*LAST-VERIFIED' && declared=1
@@ -514,6 +521,8 @@ else
       note "otherwise revert the stamp — an ordinary edit must not move it."
       v11=1
     fi
+  elif printf '%s\n' "$changed" | grep -qx 'LAST-VERIFIED'; then
+    echo "    ok (LAST-VERIFIED touched but the stamp is unchanged: $stamp_now)"
   else
     echo "    ok (LAST-VERIFIED unchanged)"
   fi


### PR DESCRIPTION
Step 4 of the ledger plan — the one step its data supported. The principle comes from a measured failure: `LAST-VERIFIED` was documented in three places and mentioned across nine files, and two sessions still nearly broke it. **Proximity beats repetition.**

## What moved

| Convention | Moved to | Why it wasn't there already |
|---|---|---|
| *`LAST-VERIFIED` is a sweep stamp — don't bump it* | **the file itself** | its strict `tr -d '[:space:]'` + `YYYY-MM-DD` parser was *precisely why* the rule couldn't live where it was needed |
| *Watch a guard fail · print the denominator · skip don't guess* | **`check-invariants.sh` header**, as an "adding a check?" block | the file had **zero** guidance on adding a check, despite being where every check is added |
| *A bare arm is not bare · never encode the arm in a path* | **all three live-agent runners' docstrings** | none carried it, though those conventions exist to govern exactly these tools |

Teaching `check-freshness.sh` to strip comments meant loosening a parser, so both rejection paths were re-verified afterwards — comments-only and comment-plus-malformed-date each still exit 1. A parser loosened until it accepts anything would be worse than the problem it solved.

## The change tripped my own gate, and that was useful

`LAST-VERIFIED` is modified in this PR, so **invariant 11 fired** — and passed via the CHANGELOG escape, which I had satisfied *reflexively*. But the stamp never moved; only comments were added.

That exposed a real imprecision: the gate keyed on the **file** changing rather than the **stamp** changing. A gate that fires on non-events trains people to wave it through, which is how it becomes decorative (`rules/11 §7`). Fixed in the same change — it now compares the parsed date and reports `LAST-VERIFIED touched but the stamp is unchanged`.

Because the condition changed, the **fail path was re-watched rather than assumed**: a real date bump with no escape still exits 1.

## Not moved

The remaining judgment conventions have no single point of use. *Verify every claim* applies everywhere — which is exactly why it can't be relocated and must stay a principle. The ledger records what moved and what didn't.

Invariants: **PASS, all 11**. `shellcheck` clean; all four eval selftests pass.
