### PR TITLE
docs: retire a superseded roadmap item, record this cycle, sync the freshness header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`docs/ROADMAP.md` — one item was stale and is now marked superseded.** It said
+  *"the BUILD-safe eval needs a thinner spec before it measures anything"*, while a
+  closed item twenty lines above records that the thinner spec was written **and**
+  tested and did not discriminate either. Kept for the diagnosis it holds; the
+  remedy it proposes is done and did not work. Also records this cycle's items: the
+  one remaining gateable convention (a Samples-column regression guard, low priority
+  because it currently passes), §2b's grep still blocked, the reimplement set being
+  documentation-never-run, and an explicit note **not** to "finish" the point-of-use
+  work by relocating the other ~18 judgment conventions.
+- **`scripts/check-freshness.sh`'s header caught up with its own parser** — it still
+  described `LAST-VERIFIED` as holding only a date, after the parser was taught to
+  strip `#` comments so the file could carry the rule that governs it. Now also
+  points at invariant 11.
+
 - **Three conventions moved to their point of use** — step 4 of the ledger plan,
   and the one step its data actually supported. The principle comes from a measured
   failure: `LAST-VERIFIED` was documented in three places and mentioned across nine

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,6 +59,31 @@ a vague three-word prompt routed to clarifying questions instead and skipped it.
 Silence is therefore not evidence the rule is broken — check the router loaded
 first.
 
+**New open items from the 2026-07-31 cycle:**
+
+- **One gateable convention remains ungated: every scoreboard row must declare its
+  sample size.** Surfaced by [CONVENTIONS-LEDGER.md](CONVENTIONS-LEDGER.md), which
+  extracted **41 distinct conventions** from the five agent-facing docs and found
+  **11 enforced as invariants plus 4 more enforced inside the eval runners** — so
+  reading `check-invariants.sh` alone undercounts enforcement by about a third.
+  Applying three filters (has it already failed · does it fail silently · is it
+  mechanically checkable) left exactly **one** actionable candidate against a
+  predicted 2–4. It would be a **regression guard**, not a repair: all 10 rows
+  currently populate the Samples column. Low priority precisely because it passes
+  today.
+- **`RELEASING.md` §2b's front-door grep stays blocked** on needing machine-readable
+  capability names per release — carried forward, still the only other candidate.
+- **The reimplement case set is documentation, never run**
+  (`evals/cases/reimplement.jsonl`). If anyone ever runs it, the predictions written
+  *before* any run exist in the case-file header and must be used rather than fresh
+  ones. A null there is the **eighth** and the recorded conclusion is to stop, not
+  to author a ninth.
+- **The remaining ~18 judgment conventions were deliberately not relocated.** Three
+  with an identifiable point of use were moved 2026-07-31 (the stamp file, the
+  invariant script's "adding a check?" block, the live-agent runners). The rest —
+  *verify every claim* chief among them — apply everywhere, which is why they cannot
+  be moved and must stay principles. Do not "finish" this by relocating the other 18.
+
 **New open items from the 2026-07-30 cycle:**
 
 - ~~**Does the rewritten build-safe spec discriminate?**~~ **Tested 2026-07-31: no.**
@@ -82,7 +107,10 @@ first.
   to our own reporting doctrine — a far weaker claim than "finds more bugs" — so if
   it is ever built, it must not be reported as a lift.
 
-- **The BUILD-safe eval needs a thinner spec before it measures anything.**
+- ~~**The BUILD-safe eval needs a thinner spec before it measures anything.**~~
+  **SUPERSEDED 2026-07-31** — the thinner spec was written *and* tested, and it did
+  not discriminate either (see the closed item above). Kept for the diagnosis it
+  records; the remedy it proposes is done and did not work.
   Built 2026-07-30 to test whether the library stops these defect classes being
   *written* rather than found. The bare arm scored **1.000 (n=3, verified
   library-free)** — ceiling, so no lift is measurable

--- a/scripts/check-freshness.sh
+++ b/scripts/check-freshness.sh
@@ -7,7 +7,11 @@
 # stamp: the root `LAST-VERIFIED` file holds the date (YYYY-MM-DD) of the last
 # full-library re-verification sweep (per-skill research against primary
 # sources — see the runbook in docs/MAINTENANCE.md). Update it only after such
-# a sweep, not on ordinary edits (git history already records those).
+# a sweep, not on ordinary edits (git history already records those) — now
+# enforced by invariant 11, which compares the parsed DATE and requires either a
+# sweep-shaped diff or a CHANGELOG entry naming LAST-VERIFIED.
+# The file may carry '#' comment lines, which this script strips: it holds the
+# rule that governs it, at the point of use (docs/CONVENTIONS-LEDGER.md).
 #
 # This script:
 #   - fails (exit 1) if the stamp is older than the re-verify window


### PR DESCRIPTION
Staleness sweep after the conventions ledger and invariant 11.

## Stale, now fixed

**`docs/ROADMAP.md` contradicted itself.** It carried *"the BUILD-safe eval needs a thinner spec before it measures anything"* while a **closed** item twenty lines above records that the thinner spec was written *and* tested and didn't discriminate either. Marked superseded — the diagnosis it holds is worth keeping, the remedy it proposes is done and failed.

**`check-freshness.sh`'s header lagged its own parser.** It still described `LAST-VERIFIED` as holding only a date, after the parser was taught to strip `#` comments precisely so the file could carry the rule that governs it. Header now matches, and points at invariant 11.

## Recorded for next session

- The **one** remaining gateable convention — every scoreboard row declares its sample size. A regression guard, low priority because all 10 rows currently pass.
- §2b's front-door grep, still **blocked** on machine-readable capability names.
- The reimplement set is **documentation, never run**, with its pre-run predictions preserved in the case file so running it later stays honest.
- An explicit **do not** "finish" the point-of-use work by relocating the other ~18 judgment conventions. They apply everywhere, which is exactly why they can't be moved.

## Memory

`repo-workflow` and `MEMORY.md` still said **10** invariants and described `LAST-VERIFIED` as prose-only. Both now carry invariant 11, its diff-based nature, its two escapes, and the date-not-file refinement.

`harness-silent-failures` gains one behavioural line: **when your own new gate fires, check whether it fired *correctly* before satisfying it.** I tripped invariant 11 with a non-event and satisfied its escape reflexively before noticing the gate keyed on the wrong thing. The reflex to make a gate go green is the same reflex that makes gates decorative.

## Verified unchanged

41 skills / 297 files · 11 invariants consistent across README, MAINTENANCE, AGENTS and CONTRIBUTING · all four eval selftests pass · shellcheck clean · invariants **PASS, all 11**.
