### PR TITLE
feat(security): same-class checkers are not layers; a TEE does not fix completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`sota-code-security/rules/08` §1 — a same-class checker is not an independent
+  layer.** A classifier, judge or "second opinion" tier drawn from the same model
+  family as the system it guards shares that system's blind spots by construction:
+  **common-cause failure**, so the two do not multiply into defence in depth however
+  the diagram is drawn. Escalate-only cascades are worse *deductively*, not
+  empirically — a tier that only sees inputs the primary scored **uncertain** cannot
+  see one the primary scored **confidently wrong**, which is the failure it was added
+  to catch; its marginal recall on the hard class is bounded by the primary's
+  uncertainty coverage, not by its own accuracy, so a better second model does not fix
+  it. The rule's demand is a measurement: marginal recall **on the hard class**, not on
+  a mixed corpus where easy cases dominate the mean. Closes onto `rules/10` §1 — a
+  layer that adds nothing on the class you care about is a control that looks enabled
+  and does nothing. Same reasoning for any guard sharing a substrate (model family,
+  tokenizer, training corpus, or the normalization step that produced the miss).
+- **`sota-code-security/rules/04` §8 — a TEE does not fix a completeness gap.** §8
+  already separated integrity from completeness for audit ledgers; this names the
+  expensive wrong turn — reaching for confidential computing to fix *"records that were
+  never emitted"*. CC protects a record's confidentiality and integrity once it exists;
+  no hardware can compel a component to emit one. That is a **liveness** failure and
+  sits outside the guarantee. Cross-refs `sota-confidential-computing` rules/01 §2
+  (availability row) and rules/04 §7, which state it from the CC side — the new text
+  makes it reachable from the crypto side, where the mistake is actually made.
+- Audit-checklist entries for both, so each new rule is reachable from an audit pass.
+
 ### Changed
 
 - **`docs/ROADMAP.md` — one item was stale and is now marked superseded.** It said

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -79,6 +79,9 @@ lessons-log — its own best structural idea, applied to ourselves.
 | 2026-07-30 | Second prompt only | A fix that moves a detector's decision boundary needs known-bad/known-good validation before shipping | **adopted** | `rules/11` §5 · v1.19.8 |
 | 2026-07-30 | Both prompts | Mutation-test every gate; vacuous tests; telemetry silence; comments are a hypothesis; the disqualifier list | **rejected: already covered** | — (`rules/10` §3, §2.9, §4; `sota-testing` rules/06 + rules/09) |
 | 2026-07-30 | Second prompt's seed examples (target-repo `file:line` calibration) | Naming a specific repo's files as calibration anchors | **rejected: non-fit** | — (the library stays generic; the *classes* were adopted, the examples were not) |
+| 2026-08-01 | A separate live agent session, three proposals handed over as analysis | A same-class checker (classifier/judge from the same model family) is **not** an independent layer — common-cause failure; escalate-only cascades are deductively worse | **adopted** | `sota-code-security/rules/08` §1 · [Unreleased] |
+| 2026-08-01 | Same handover | A TEE does not fix a **completeness** gap — "never recorded" is a liveness failure, outside the confidential-computing guarantee | **adopted** | `sota-code-security/rules/04` §8 · [Unreleased] |
+| 2026-08-01 | Same handover | A vendor control-plane API reporting `confidentialCompute: true` over an instance whose CC status is OFF | **rejected: already covered** | — (`rules/10` §2.2 line 102 "check the shipped artifact, not the checkout" + §2.11 shipped-artifact gaps) |
 
 ## Entries
 
@@ -525,3 +528,49 @@ stays generic.
 **Measurement status:** content refinements adopted on reasoning plus one measured
 self-finding (the empty-scope defect, proven by mutation with before/after exit
 codes). **No efficacy lift is claimed or measured. Do not cite one.**
+
+### 2026-08-01 — three proposals from a handover session, two adopted
+
+The two adoptions share a shape: **a control that is counted in a threat model
+while being structurally incapable of covering the case it is counted for.**
+
+**1. Same-class checkers (`rules/08` §1).** A classifier or judge drawn from the
+same model family as the system it guards shares that system's blind spots by
+construction, so the two do not multiply into defence in depth. The sharper half
+is the escalate-only variant, which is wrong *deductively* rather than
+empirically: a tier that only sees inputs the primary scored **uncertain** cannot
+see an input the primary scored **confidently wrong** — the exact failure it was
+added to catch. Its marginal recall on the hard class is bounded by the primary's
+uncertainty coverage, not by its own accuracy, so a better second model does not
+repair it. The rule's demand is therefore a measurement, not an architecture:
+measure marginal recall **on the hard class specifically** before calling it a
+layer. It closes onto `rules/10` §1 — a layer that adds nothing on the class you
+care about is a control that looks enabled and does nothing.
+
+**2. TEEs and completeness (`rules/04` §8).** §8 already separated integrity from
+completeness for audit ledgers. The addition names the wrong turn people actually
+take: reaching for confidential computing to fix "records that were never
+emitted". Hardware can protect a record once it exists; nothing in the CC
+guarantee compels a component to emit one. That is **liveness**, and
+`sota-confidential-computing` rules/01 §2 (availability row) and rules/04 §7
+already state it from the CC side — the cross-ref makes it reachable from the
+crypto side, where the mistake is made.
+
+**3. Rejected: already covered.** The third proposal — a vendor control-plane API
+reporting `confidentialCompute: true` for an instance whose CC status is OFF — is
+`rules/10` at the hardware layer. §2.2 already says outright *"check the shipped
+artifact, not the checkout"* (line 102) and §2.11 is *"Shipped-artifact gaps"*,
+whose whole subject is a control that is present where you look and absent where
+it runs. A vendor's assertion about a machine is the checkout; the machine's own
+attestation is the artifact. Adding a cloud-specific instance would narrow a
+general rule to one provider's field name.
+
+**Verification.** Every quoted claim in the handover was checked verbatim against
+the files before editing (one grep of mine missed on case — the text is
+`**Self-preference**` — so the handover was right and I was wrong). Both edited
+files stayed under the 500-line cap (316 and 306), both kept `## Audit checklist`
+as the last heading, and both gained a checklist item — an addition with no
+checklist entry is a rule the audit pass cannot reach.
+
+**Measurement status:** adopted on reasoning. **No efficacy lift is claimed or
+measured. Do not cite one.**

--- a/skills/sota-code-security/rules/04-cryptography.md
+++ b/skills/sota-code-security/rules/04-cryptography.md
@@ -236,6 +236,15 @@ records: hash-chained audit logs, compliance trails (EU AI Act Art. 12, FINRA
   SDKs, server-assigned sequence numbers) leave no gap. If completeness is a
   claim, attest it separately (source-assigned sequence numbers, declared
   counts, close markers) and report the two verdicts separately.
+  **A TEE does not fix this** — a common and expensive wrong turn. Confidential
+  computing protects a record's confidentiality and integrity *once it exists*;
+  no hardware can compel a component to emit one. "Never recorded" is a
+  **liveness** failure, and liveness sits explicitly outside the CC guarantee:
+  the host may refuse to schedule, pause, or destroy the enclave at will
+  (`sota-confidential-computing` rules/01 §2, availability row; rules/04 §7
+  states that any design assuming a TEE guarantees liveness is wrong). The fix is
+  the separate completeness attestation above, taken at a vantage the monitored
+  component does not control — see the vantage bullet below.
 - Verification must be possible **off the system that stores the data**
   (standalone verifier + a documented, cross-language canonicalization spec).
   A `verify` that only runs on the server being audited proves little.
@@ -295,3 +304,4 @@ createCipheriv\(.*, *(['"]).{1,16}\1  (short/static key/nonce)
 - [ ] Is there a single crypto wrapper module rather than scattered primitive calls?
 - [ ] Is any "tamper-evident"/audit ledger keyed (HMAC/signature) or externally anchored — not a bare unkeyed hash chain — with tail truncation and whole-stream deletion detectable?
 - [ ] Is ledger completeness attested separately from integrity (source-assigned seq / close markers), and is verification possible off the storing system?
+- [ ] Is a TEE/confidential-computing control proposed to fix a **completeness** gap ("records that were never emitted")? That is a liveness failure and sits outside the CC guarantee — the fix is a separate completeness attestation at a vantage the monitored component does not control.

--- a/skills/sota-code-security/rules/08-llm-ai-security.md
+++ b/skills/sota-code-security/rules/08-llm-ai-security.md
@@ -42,6 +42,26 @@ code around it, never by the prompt itself.
     send_email/exfiltrate-capable tools) — taint tracking at the orchestrator.
   - Prompt-injection classifiers/heuristics as telemetry and friction, not as
     the security boundary.
+  - **A same-class checker is not an independent layer.** A classifier, judge, or
+    "second opinion" tier drawn from the same model family as the system it
+    guards shares that system's blind spots *by construction*: the inputs that
+    slip past the primary are disproportionately the ones the checker also reads
+    as benign. This is **common-cause failure** — two components that fail
+    together do not multiply into defence in depth, however the diagram is drawn.
+    **Escalate-only cascades are strictly worse**, and deductively so: a tier that
+    only sees inputs the primary scored *uncertain* cannot see an input the
+    primary scored confidently — and a confidently-wrong score is precisely the
+    failure you needed caught. Its marginal recall on the hard class is bounded
+    by the primary's uncertainty coverage, not by its own accuracy, so a better
+    second model does not fix it.
+    Therefore: **do not count such a tier as a layer in a threat model** until you
+    have measured its marginal recall *on the hard class specifically* — the
+    inputs the primary gets wrong — rather than on a mixed corpus where easy
+    cases dominate the mean. A layer that adds nothing on the class you care
+    about is a control that looks enabled and does nothing (rules/10 §1). The
+    same reasoning applies to any guard sharing a substrate with the guarded
+    system: the same model family, the same tokenizer, the same training corpus,
+    or the same normalization step that produced the miss.
 - The lethal trifecta to refuse by design: (a) access to private data +
   (b) exposure to untrusted content + (c) an exfiltration channel (tool that
   sends data out, markdown image rendering, link generation). Any agent with
@@ -294,3 +314,4 @@ mcpServers|\.mcp\.json|claude_desktop_config entries without version pin or defi
 - [ ] Are MCP tool definitions hash-pinned at approval with re-approval forced on any change (rug pull), and is the *full* description shown to the approver (tool poisoning)?
 - [ ] Are high-privilege tools isolated from third-party servers in separate sessions/agents (tool shadowing), with tool listings treated as untrusted input before any invocation (line jumping)?
 - [ ] Are reasoning-token budgets capped per request with consumption-anomaly alerting (OverThink-class), and is untrusted content kept out of reasoning scaffolds (H-CoT/CoT hijacking)?
+- [ ] Is any classifier/judge/"second opinion" tier counted as a defence layer in the threat model **from the same model family** as the system it guards — without a measured marginal recall on the hard class (the inputs the primary gets wrong)? Common-cause failure; an escalate-only tier is bounded by the primary's uncertainty coverage and cannot see a confidently-wrong score.


### PR DESCRIPTION
Three proposals handed over from a separate session; two adopted, one rejected as already covered. All three logged in `docs/ADOPTION-LOG.md`.

## Adopted

**`sota-code-security/rules/08` §1 — a same-class checker is not an independent layer.**
A classifier/judge/"second opinion" drawn from the same model family as the system it guards shares that system's blind spots *by construction* — common-cause failure, so the two do not multiply into defence in depth. The escalate-only variant is worse **deductively**: a tier that only sees inputs the primary scored *uncertain* cannot see one the primary scored *confidently wrong*, which is the failure it was added to catch. Marginal recall on the hard class is bounded by the primary's uncertainty coverage, not by the second model's accuracy. The rule therefore demands a measurement — marginal recall on the hard class specifically — before the tier counts as a layer. Closes onto `rules/10` §1.

**`sota-code-security/rules/04` §8 — a TEE does not fix a completeness gap.**
§8 already separated integrity from completeness for audit ledgers. This names the wrong turn people take: reaching for confidential computing to fix "records that were never emitted". CC protects a record once it exists; no hardware compels a component to emit one. That is liveness. Cross-refs `sota-confidential-computing` rules/01 §2 (availability row) and rules/04 §7 — which state it from the CC side; the new text makes it reachable from the crypto side, where the mistake is made.

## Rejected: already covered

A vendor control-plane API reporting `confidentialCompute: true` for an instance whose CC status is OFF is `rules/10` at the hardware layer — §2.2 already says *"check the shipped artifact, not the checkout"* (line 102) and §2.11 is *"Shipped-artifact gaps"*. Adding a cloud-specific instance would narrow a general rule to one provider's field name.

## Verification

- Every quoted claim in the handover checked verbatim before editing.
- `316` and `306` lines — under the 500 cap; `## Audit checklist` still the last heading in both; **both gained a checklist item** (a rule an audit pass cannot reach is not a rule).
- `./scripts/check-invariants.sh` → PASS, 11 checks over 297 skill files / 256 rules files.
- No efficacy lift is claimed or measured for either addition, and the log says so.
