### PR TITLE
docs: only instruction files are capped at 500 lines — say so everywhere

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - repo: local
     hooks:
       - id: sota-invariants
-        name: SOTA-skills invariants (<=500 lines, audit checklists, no internal refs)
+        name: SOTA-skills invariants (skill files <=500 lines, audit checklists, no internal refs)
         entry: scripts/check-invariants.sh
         language: script
         pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,17 @@ symlinks to it — edit only this file, never the symlinks.
 `scripts/check-invariants.sh` fails the build on:
 
 1. any **skill** Markdown (`skills/*/SKILL.md` or `skills/*/rules/*.md`) over
-   **500 lines** — the cap is load-bearing only there (it keeps incremental
-   loading working; the model reads the rules that match the task, not a wall of
-   text). Non-skill Markdown (README, CHANGELOG, `docs/`) is human/agent-facing
-   prose, **not** loaded as a skill, so it is intentionally **uncapped** (decided
-   2026-07-15) — navigability there comes from a table of contents and
-   [docs/INDEX.md](docs/INDEX.md), not a line ceiling;
+   **500 lines**. The rule in one line: **only instruction files are capped.**
+   A file is capped if and only if an agent loads it *as instructions* — that is
+   `skills/*/SKILL.md` and `skills/*/rules/*.md`, and nothing else in the repo.
+   The cap is load-bearing only there: it keeps incremental loading working, so
+   the model reads the rules that match the task rather than a wall of text.
+   **Everything else is uncapped** and deliberately so (decided 2026-07-15) —
+   README, CHANGELOG, `docs/`, `evals/`, `AGENTS.md` itself and every script are
+   prose and code for people (and for an agent *reading*, not *obeying*, them);
+   navigability there comes from a table of contents and
+   [docs/INDEX.md](docs/INDEX.md), not a line ceiling. If you find a line-cap
+   claim anywhere that does not say *skill files*, it is stale — fix it;
 2. any `skills/*/rules/*.md` whose **last `## ` heading isn't
    `## Audit checklist`** (the checklist must end the file);
 3. an **internal-name denylist** — the library must stay generic. The private

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **The 500-line cap is stated as *instruction-files-only* everywhere it appears.**
+  A file is capped **iff an agent loads it as instructions** — `skills/*/SKILL.md`
+  and `skills/*/rules/*.md`, nothing else. README, CHANGELOG, `docs/`, `evals/`,
+  `AGENTS.md` and the scripts have **no line cap at all** (decided 2026-07-15,
+  PR #100). The scope was already correct in `check-invariants.sh`, `AGENTS.md`,
+  `CONTRIBUTING.md`'s checklist and the README's contributing section, but five
+  surfaces still read as a repo-wide rule and have been fixed: the README hero
+  ("each file under 500 lines"), the pre-commit hook's own name, the
+  `how-it-works` diagram, the router's opening paragraph, and
+  `CONVENTIONS-LEDGER`'s enforced list. `AGENTS.md`, `CONTRIBUTING.md` and the
+  script's header now lead with the rule in one line and say outright that any
+  line-cap claim not scoped to skill files is stale.
+- **Two stale invariant counts fixed.** `docs/MAINTENANCE.md` said
+  `check-invariants.sh` runs **7 checks** and `docs/WHY-IT-WORKS.md` said **eight
+  invariants**; both are **11** (the script prints its own count, so the drift was
+  only ever in the prose). `docs/ROADMAP.md`'s `test_scoring.py` floor note now
+  records that 25 has since risen to **38**.
+
 ## [1.19.9] - 2026-08-01
 
 **The counted-as-a-layer release.** Five changes with one shape between them: a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,10 @@ By contributing you agree your contribution is licensed under
    numbers are for semantic boundaries only ("GA since", "fixed in", CVE fix
    versions, spec editions). Recommend maintained tools; when one goes EOL,
    point at its maintained successor and keep a one-line EOL note.
-3. **Stay lean.** Every **skill** file (`skills/*/SKILL.md`, `skills/*/rules/*.md`)
-   is **≤ 500 lines** so skills load incrementally without blowing the context
-   window. If a topic outgrows that, split it into another `rules/NN-topic.md`.
+3. **Stay lean — instruction files only.** Every **skill** file
+   (`skills/*/SKILL.md`, `skills/*/rules/*.md`) is **≤ 500 lines** so skills load
+   incrementally without blowing the context window. Nothing else in the repo has
+   a line cap. If a topic outgrows that, split it into another `rules/NN-topic.md`.
    The cap is load-bearing *only* there: README, CHANGELOG and `docs/` are read
    by humans and agents rather than loaded as skills, so they are deliberately
    **uncapped** (decided 2026-07-15, PR #100) — navigability there comes from a
@@ -99,8 +100,10 @@ are marked "needs verification", never asserted.
 `scripts/check-invariants.sh` runs in pre-commit and CI and fails the build on:
 
 1. any **skill** Markdown (`skills/*/SKILL.md` or `skills/*/rules/*.md`) over
-   **500 lines** — the cap is skill-files-only (README/CHANGELOG/`docs/` are
-   uncapped prose, decided 2026-07-15);
+   **500 lines** — **only instruction files are capped**: a file is capped iff an
+   agent loads it *as instructions*. Everything else in the repo (README,
+   CHANGELOG, `docs/`, `evals/`, scripts) is uncapped prose or code, decided
+   2026-07-15;
 2. any `skills/*/rules/*.md` that doesn't **end** with an
    **`## Audit checklist`** (it must be the file's last `## ` heading);
 3. any **internal/private reference** leaking into tracked files (the private

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ instead of becoming one. Native on Claude Code; works with Gemini CLI, Codex, an
 agent that reads `AGENTS.md`.
 
 Under the hood: **41 skills (297 files, ~61k lines)** of state-of-the-art 2026
-practice, each file under 500 lines so only the matching rules load, every fast-moving
+practice, each **instruction** file under 500 lines so only the matching rules load —
+the cap applies to `skills/**` alone, never to README/CHANGELOG/`docs/` — every fast-moving
 claim web-verified against a primary source.
 
 Two commands to install:

--- a/assets/how-it-works.html
+++ b/assets/how-it-works.html
@@ -114,7 +114,7 @@
       <div class="stage">
         <div class="num">3 · SELECTIVE LOAD</div>
         <h2>Only what's needed</h2>
-        <p>Each skill's index picks the matching <b>rules files</b> (every file &lt; 500 lines) — never the whole library, so context stays lean.</p>
+        <p>Each skill's index picks the matching <b>rules files</b> (each &lt; 500 lines) — never the whole library, so context stays lean.</p>
         <div class="ex"><span class="chip dim">SKILL.md → rules/09-ingestion … nothing else</span></div>
       </div>
       <div class="arrow">→</div>

--- a/docs/CONVENTIONS-LEDGER.md
+++ b/docs/CONVENTIONS-LEDGER.md
@@ -49,7 +49,7 @@ A convention earns a gate only if it passes **all three**:
 
 ### Enforced (11) — invariants 1–11
 
-Line cap · audit-checklist placement · internal-name denylist · description cap ·
+Skill-file line cap · audit-checklist placement · internal-name denylist · description cap ·
 version lockstep · count surfaces · router completeness · link resolution ·
 single `[Unreleased]` · rules-file indexed by its SKILL.md · `LAST-VERIFIED` sweep
 pairing. Each is in `scripts/check-invariants.sh` and documented in `AGENTS.md`.

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -95,7 +95,7 @@ grow the golden sets as coverage warrants.
 
 | Dimension | Gate | Automated? |
 |---|---|---|
-| Structure (line cap, checklist-last, description cap, counts, router completeness) | `check-invariants.sh` (7 checks) | Yes — pre-commit + CI |
+| Structure (skill-file line cap, checklist-last, description cap, counts, router completeness, link resolution, rules-file indexing, `LAST-VERIFIED` pairing) | `check-invariants.sh` (**11 checks**) | Yes — pre-commit + CI |
 | Secrets | gitleaks (full history) | Yes — CI |
 | Shell quality | shellcheck | Yes — CI |
 | Claim **accuracy** | this runbook + `LAST-VERIFIED` | No — human/agent, monthly red-flag |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,7 +149,8 @@ first.
 - ~~**Our own gates now report a denominator — the rest of the automation does
   not.**~~ **Done 2026-07-30.** `check-freshness.sh` now exits 1 on an empty scope
   (it printed the denominator but never failed on it); `evals/test_scoring.py`
-  now prints `(25 checks)` and fails below a floor, watched to fail by simulating
+  now prints `(25 checks)` — the floor has since risen to **38** — and fails below
+  it, watched to fail by simulating
   an early return (`only 17 ran, expected at least 25`). One suspicion was
   **REFUTED** and recorded: CI's `shellcheck scripts/*.sh` fails loudly on an
   unmatched glob in bash (exit 2), so there was nothing to fix. Still unexamined:

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -145,10 +145,12 @@ comparison to anyone else required.
    `file:line | rule violated | severity | effort | fix` and maps to a standard
    (CWE, OWASP, MITRE ATT&CK/ATLAS) where one applies.
 
-4. **CI-gated library quality.** Eight invariants
+4. **CI-gated library quality.** Eleven invariants
    ([`check-invariants.sh`](../scripts/check-invariants.sh)) block a bad change at
-   the door: every skill file ≤ 500 lines (so the *right* rules load, not a wall
-   of text), every rules file ends with an audit checklist, skill descriptions
+   the door: every **skill** file ≤ 500 lines — `skills/*/SKILL.md` and
+   `skills/*/rules/*.md`, the files an agent actually loads, and nothing else (so
+   the *right* rules load, not a wall of text; README, CHANGELOG and `docs/` are
+   prose for people and are deliberately uncapped), every rules file ends with an audit checklist, skill descriptions
    stay within the Agent-Skills spec cap, versions stay in lockstep, the router
    lists every skill, internal Markdown links resolve (no dead cross-references),
    and no internal names leak. Plus gitleaks over the full history.

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -5,8 +5,9 @@
 #
 # Invariants:
 #   1. Every tracked SKILL file (skills/*/*.md, skills/*/rules/*.md) is <= 500
-#      lines, so skills load incrementally. Non-skill Markdown (README,
-#      CHANGELOG, docs/) is deliberately uncapped — see the check itself.
+#      lines, so skills load incrementally. ONLY INSTRUCTION FILES ARE CAPPED:
+#      a file is capped iff an agent loads it as instructions. Everything else
+#      (README, CHANGELOG, docs/, evals/, scripts) is deliberately uncapped.
 #   2. Every skills/*/rules/*.md ends with an "## Audit checklist".
 #   3. No internal/private references leak in (the library stays generic).
 #   4. Every skills/*/SKILL.md description is <= 1024 characters (Agent Skills
@@ -97,11 +98,13 @@ scope() {  # <count> <noun> — returns 1 on an empty scope; prints nothing on s
 }
 
 # --- 1. Line budget -------------------------------------------------------
-# The cap is load-bearing ONLY for skill files: a rules/SKILL file over ~500
-# lines defeats incremental loading (the whole point is that the model reads the
-# rules that match the task, not a wall of text). Non-skill Markdown (README,
-# CHANGELOG, docs/) is human/agent-facing prose, not loaded as a skill, so it is
-# intentionally uncapped (decided 2026-07-15) — navigability there comes from a
+# ONLY INSTRUCTION FILES ARE CAPPED. A file is capped iff an agent loads it as
+# instructions -- skills/*/SKILL.md and skills/*/rules/*.md, nothing else. The cap
+# is load-bearing only there: a rules/SKILL file over ~500 lines defeats
+# incremental loading (the whole point is that the model reads the rules matching
+# the task, not a wall of text). Everything else in this repo -- README,
+# CHANGELOG, docs/, evals/, AGENTS.md, these scripts -- is prose or code read by
+# people, deliberately uncapped since 2026-07-15; navigability there comes from a
 # table of contents and docs/INDEX.md, not a line ceiling.
 echo "[1/11] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
 over=0

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -7,7 +7,7 @@ description: >-
 # SOTA Engineering Skills — Master Router
 
 A library of 40 domain skills, each with a `SKILL.md` entry point and a `rules/`
-folder of focused rule files (every file < 500 lines). Each skill works in two
+folder of focused rule files (each under 500 lines). Each skill works in two
 modes:
 
 - **BUILD** — apply the rules while designing or writing code.


### PR DESCRIPTION
The 500-line cap applies **iff an agent loads the file as instructions** — `skills/*/SKILL.md` and `skills/*/rules/*.md`, nothing else. README, CHANGELOG, `docs/`, `evals/`, `AGENTS.md` and the scripts have **no line cap at all** (decided 2026-07-15, PR #100).

`check-invariants.sh`'s glob, `AGENTS.md` invariant 1, CONTRIBUTING's PR checklist and the README's contributing section already scoped it correctly. **Five surfaces still read as a repo-wide rule:**

| Surface | Was | Now |
|---|---|---|
| README hero | "each file under 500 lines" | "each **instruction** file …", + the scope spelled out |
| `.pre-commit-config.yaml` | the hook's **own name** said `<=500 lines` | `skill files <=500 lines` |
| `assets/how-it-works.html` | "(every file &lt; 500 lines)" | "(each &lt; 500 lines)" |
| `skills/sota/SKILL.md` | "(every file < 500 lines)" | "(each under 500 lines)" |
| `docs/CONVENTIONS-LEDGER.md` | "Line cap" | "Skill-file line cap" |

`AGENTS.md`, `CONTRIBUTING.md` and the script's header now **lead** with the rule in one line and state outright that a line-cap claim not scoped to skill files is stale — so the next sweep has a rule to check against rather than five phrasings to compare.

## Two stale counts found while sweeping

Both were checked against the primary source rather than memory — the script prints its own count (`11 checks`) and has 11 numbered `[N/11]` steps:

- `docs/MAINTENANCE.md` said `check-invariants.sh` runs **7 checks** → **11**, and its dimension list now names the four invariants added since.
- `docs/WHY-IT-WORKS.md` said **"Eight invariants"** → **"Eleven"**.
- `docs/ROADMAP.md`'s `test_scoring.py` note said the floor prints `(25 checks)`; verified `MIN_CHECKS = 38` and recorded the rise. The struck-through entry is dated, so the 25 is kept as the historical value rather than rewritten.

## Verification

- `./scripts/check-invariants.sh` → PASS, 11 checks over 297 skill files / 256 rules files.
- Re-grepped every `500`-line mention in tracked files; the four remaining unscoped hits are correct in context — a skill-tree diagram, a *quotation* of the stale wording in `RELEASING.md` §2b as an example of what to look for, an adoption-log line about two named rules files, and `len(removed) < 500` in an eval runner.
- `skills/sota/SKILL.md` is at **500/500** with zero headroom (recorded in ROADMAP), so its edit was chosen to be net-neutral on line count — confirmed still 500.
