### PR TITLE
feat(ci): invariant 12 — a rendered asset is never older than its source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,22 @@ that verifies nothing (`sota-code-security` rules/11 §2.2).
     failing is `sota-code-security` rules/10 §2.12, an instruction standing in for
     an enforced control. This is the first **diff-based** invariant; with no merge
     base it skips with a note rather than guessing.
+12. **a rendered asset is never older than its source** — every `assets/*.png` must
+    be committed no earlier than the `assets/*.html` it renders. The PNGs are
+    committed **build outputs** and nothing regenerates them, so an HTML fix that is
+    not re-rendered reaches nobody: the README embeds the *image*, never the source.
+    Added 2026-08-01, the same day it failed — PR #173 rewrote the stale line-cap
+    claim in `how-it-works.html` (the entire point of that PR) and left the PNG at
+    its 2026-07-09 render, so `main` served the old claim all day while the diff,
+    the commit message and the CHANGELOG all read as done. It is the invariant-1
+    story from the outside: a fix *counted* on a surface it never reached.
+    Compares **commit** times, not mtimes — a fresh clone stamps every file with
+    the checkout time, so an mtime check would pass on any runner while examining
+    nothing. Equal timestamps pass, since rendering in the same commit is the
+    wanted behaviour. Escape: **`[no-render]` in the HTML's own commit subject**,
+    a declaration rather than a heuristic, because nothing short of rendering both
+    can tell a cosmetic HTML edit from a load-bearing one. Render command and
+    per-asset sizes: [CONTRIBUTING.md](CONTRIBUTING.md) → *Rendered assets*.
 
 Separately, `scripts/check-freshness.sh` (run monthly by
 `.github/workflows/freshness.yml`) tracks the root `LAST-VERIFIED` stamp —
@@ -174,7 +190,7 @@ pre-commit hook scans each commit locally.
   library handed back three proposals citing this repo's own `file:line` — the
   ledger takes those on the same terms, rejections included
 - [docs/CONVENTIONS-LEDGER.md](docs/CONVENTIONS-LEDGER.md) — which of this repo's
-  conventions are **enforced** (11 invariants + 4 more inside the eval runners) and
+  conventions are **enforced** (12 invariants + 4 more inside the eval runners) and
   which are prose, with the three filters a convention must pass to earn a gate
   (has it already failed · does it fail silently · is it mechanically checkable).
   Read it before proposing a new gate — it argues against gating the ~18 judgment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,13 +49,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RELEASING.md`: the failure happened in an ordinary docs PR, not at a release cut,
   so release-time guidance would have been guidance at the wrong point of use
   (v1.19.9's proximity finding, applied).
-- **A candidate invariant 12 is logged, not built** — fail when an `assets/*.html`
-  has a newer last-commit than its paired `*.png`. It passes all three
-  [CONVENTIONS-LEDGER](docs/CONVENTIONS-LEDGER.md) filters (it has already failed;
-  it fails silently, since nobody reads the HTML; it is mechanically checkable from
-  `git log -1`), which makes it the second gateable candidate that ledger has found.
-  Deliberately deferred to its own PR so the gate can be **watched to fail** on this
-  exact commit's parent before it is trusted.
+- **Invariant 12 — a rendered asset is never older than its source.** Every
+  `assets/*.png` must be committed no earlier than the `assets/*.html` it renders.
+  It passes all three [CONVENTIONS-LEDGER](docs/CONVENTIONS-LEDGER.md) filters (it
+  had already failed, that same day; it fails silently, since nobody reads the HTML
+  and the PNG looks fine — it just says the old thing; and it is checkable from
+  `git log -1` alone).
+  - **Commit times, not mtimes.** A fresh clone stamps every file with the checkout
+    time, so an mtime comparison would pass on every CI runner while examining
+    nothing — `rules/11` §2.2, built into the gate meant to prevent it. Equal
+    timestamps pass: rendering in the same commit as the edit is the wanted
+    behaviour, not a violation.
+  - **Escape: `[no-render]` in the HTML's own commit subject**, for an edit that
+    cannot change the output. A declaration rather than a heuristic, because
+    nothing short of rendering both can distinguish a cosmetic HTML edit from a
+    load-bearing one — and invariant 11 already learned that a gate firing on
+    non-events gets waved through until it is decorative.
+  - **Watched to fail on six paths before being trusted**, per the script's own
+    "adding a check?" block: the real defect (a worktree at `0f08094`, the commit
+    where the drift existed → exit 1), a live HTML-only commit (exit 1), an HTML
+    with no committed PNG (exit 1), a drifted pathspec (`SCOPE EMPTY`, exit 1), the
+    declared escape (exit 0), and current `main` (exit 0, `ok (2 asset pairs)`).
+  - One earlier attempt at the fail-watch was **vacuous** and is recorded because
+    it is the failure mode this repo keeps rediscovering: a `git reset --hard`
+    reverted the still-uncommitted script, so two mutation cases ran against a
+    build with no check 12 in it and printed nothing at all. Empty output — not a
+    passing result — is what exposed it. The check is now committed before any
+    mutation runs, and the mutations run in a throwaway worktree.
+  - The first diagnostic printed `%cs` (date only) and so reported the **same date**
+    on both lines of a same-day miss while asserting one was older. It prints full
+    timestamps now: a finding that reads as a broken check is one people switch off.
 - **Two stale invariant counts fixed.** `docs/MAINTENANCE.md` said
   `check-invariants.sh` runs **7 checks** and `docs/WHY-IT-WORKS.md` said **eight
   invariants**; both are **11** (the script prints its own count, so the drift was

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,13 @@ are marked "needs verification", never asserted.
     it on an ordinary edit, even one that verified its own facts. If you really did
     complete a pass, either the diff is sweep-shaped (≥ 20 skill files) or you name
     `LAST-VERIFIED` in the CHANGELOG entry.
+12. **rendered assets are current**: every `assets/*.png` must be committed no
+    earlier than the `assets/*.html` it renders. Practical effect: edit the HTML,
+    re-render the PNG, commit **both together** (see
+    [Rendered assets](#rendered-assets)). If the edit genuinely cannot change the
+    output, put `[no-render]` in the commit subject. Added the day it failed —
+    #173's whole point was fixing a claim in `how-it-works.html`, the PNG was not
+    re-rendered, and the README kept showing the old text.
 
 Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`);
 CI scans the full git history, the pre-commit hook scans each commit.

--- a/docs/CONVENTIONS-LEDGER.md
+++ b/docs/CONVENTIONS-LEDGER.md
@@ -25,7 +25,7 @@ item).
 | Raw entries | 49 |
 | Duplicates (the invariant list appears in both `AGENTS.md` and `CONTRIBUTING.md`) | 8 |
 | **Distinct conventions** | **41** |
-| Already enforced as invariants | 11 |
+| Already enforced as invariants | 12 (11 when this ledger was derived) |
 
 An earlier estimate of "~122" came from a loose regex that matched any bold line or
 any line containing *must/never/always*. It was an over-count by ~3×, and is
@@ -47,12 +47,13 @@ A convention earns a gate only if it passes **all three**:
 
 ## The ledger
 
-### Enforced (11) — invariants 1–11
+### Enforced (12) — invariants 1–12
 
 Skill-file line cap · audit-checklist placement · internal-name denylist · description cap ·
 version lockstep · count surfaces · router completeness · link resolution ·
 single `[Unreleased]` · rules-file indexed by its SKILL.md · `LAST-VERIFIED` sweep
-pairing. Each is in `scripts/check-invariants.sh` and documented in `AGENTS.md`.
+pairing · rendered asset no older than its source. Each is in
+`scripts/check-invariants.sh` and documented in `AGENTS.md`.
 
 ### Enforced in code, outside the invariant script (4)
 
@@ -88,6 +89,21 @@ use. One line *in* the file being edited would likely have outperformed all thre
 The rest of the judgment list has no single point of use — *verify every claim* applies
 everywhere, which is precisely why it cannot be relocated and must stay a principle.
 
+### Gated after this ledger was derived (1)
+
+| Candidate | Incident? | Silent? | Checkable? | Verdict |
+|---|---|---|---|---|
+| A rendered `assets/*.png` is never older than its `*.html` | **yes** — PR #173 (2026-08-01) fixed a stale line-cap claim in `how-it-works.html` and did not re-render the PNG; `main` served the old claim all day | **yes** — nobody reads the HTML, and the PNG looks fine, it just says the old thing | **yes** — commit times from `git log -1`, no rendering required | **gated same day** as invariant 12 |
+
+This one is the ledger's most useful entry, because **it was not on the list.**
+The ledger was derived by matching the repo's convention format across the five
+agent-facing docs — and this convention was *nowhere in those docs to be matched*.
+It was not an ungated convention; it was an **unwritten** one, and the extraction
+method is structurally blind to that class. The finding below that "the gateable set
+is small" is therefore a statement about *written* conventions only. A second source
+of candidates exists and is not searchable: things this repo does by habit and has
+never said out loud, which surface only when one of them fails.
+
 ### Gateable but not gated (2 candidates)
 
 | Candidate | Incident? | Silent? | Checkable? | Verdict |
@@ -109,6 +125,14 @@ find a breach and found a wording defect instead, which is the more useful resul
 2–4, the ledger yields **one actionable candidate**, and it is a regression guard
 rather than a repair. That is the honest output: most conventions here either are
 already enforced or govern judgment a gate cannot reach.
+
+**2b. …but only among conventions that were written down (added 2026-08-01).**
+One day after this ledger shipped, a real defect produced invariant 12 — a
+convention that passed all three filters and appeared in *none* of the five source
+documents, because nobody had ever written it. The extraction method cannot find
+what was never stated, so finding 2 bounds the **documented** set, not the real one.
+Practical consequence: re-deriving this ledger will not find the next invariant 12.
+Only an incident will.
 
 **3. Enforcement is not concentrated in the invariant script.** Four conventions are
 enforced inside the eval runners. Anyone auditing "what does this repo actually

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -2,7 +2,7 @@
 
 The library's value is that its fast-moving claims (versions, CVEs, RFCs,
 specs, GA states, tool status, standards) hold up against primary sources.
-CI enforces *structure* (the 11 invariants in `scripts/check-invariants.sh` +
+CI enforces *structure* (the 12 invariants in `scripts/check-invariants.sh` +
 gitleaks + shellcheck) but **cannot** verify that a claim is *true* — that
 needs web access and judgment. This file is the human/agent process that
 covers the accuracy dimension CI can't, plus how efficacy is measured.
@@ -95,7 +95,7 @@ grow the golden sets as coverage warrants.
 
 | Dimension | Gate | Automated? |
 |---|---|---|
-| Structure (skill-file line cap, checklist-last, description cap, counts, router completeness, link resolution, rules-file indexing, `LAST-VERIFIED` pairing) | `check-invariants.sh` (**11 checks**) | Yes — pre-commit + CI |
+| Structure (skill-file line cap, checklist-last, description cap, counts, router completeness, link resolution, rules-file indexing, `LAST-VERIFIED` pairing) | `check-invariants.sh` (**12 checks**) | Yes — pre-commit + CI |
 | Secrets | gitleaks (full history) | Yes — CI |
 | Shell quality | shellcheck | Yes — CI |
 | Claim **accuracy** | this runbook + `LAST-VERIFIED` | No — human/agent, monthly red-flag |

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -145,7 +145,7 @@ comparison to anyone else required.
    `file:line | rule violated | severity | effort | fix` and maps to a standard
    (CWE, OWASP, MITRE ATT&CK/ATLAS) where one applies.
 
-4. **CI-gated library quality.** Eleven invariants
+4. **CI-gated library quality.** Twelve invariants
    ([`check-invariants.sh`](../scripts/check-invariants.sh)) block a bad change at
    the door: every **skill** file ≤ 500 lines — `skills/*/SKILL.md` and
    `skills/*/rules/*.md`, the files an agent actually loads, and nothing else (so

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -45,6 +45,14 @@
 #      100), or naming LAST-VERIFIED in the CHANGELOG, which is how a rolling
 #      pass declares completion. DIFF-based — skips with a note if there is no
 #      merge base, like checks 4 and 8 skip without python3.
+#  12. Every assets/*.png is no older than the assets/*.html it renders. The PNGs
+#      are committed build outputs and nothing regenerates them, so an un-rendered
+#      HTML fix is invisible: the README embeds the image, never the source. PR
+#      #173 fixed a stale line-cap claim in how-it-works.html and left the PNG at
+#      its 2026-07-09 render, so main served the old claim all day while the diff
+#      read as done. HISTORY-based (commit times, not mtimes — a fresh clone
+#      stamps every file identically); escape is "[no-render]" in the HTML's own
+#      commit subject.
 #
 # ADDING A CHECK? Three things this file learned the hard way — all from real
 # incidents recorded in the checks below:
@@ -106,7 +114,7 @@ scope() {  # <count> <noun> — returns 1 on an empty scope; prints nothing on s
 # CHANGELOG, docs/, evals/, AGENTS.md, these scripts -- is prose or code read by
 # people, deliberately uncapped since 2026-07-15; navigability there comes from a
 # table of contents and docs/INDEX.md, not a line ceiling.
-echo "[1/11] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
+echo "[1/12] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
 over=0
 seen1=0
 while IFS= read -r f; do
@@ -123,7 +131,7 @@ scope "$seen1" "skill files" || over=1
 if [ "$over" -eq 0 ]; then echo "    ok ($seen1 skill files)"; else fail=1; fi
 
 # --- 2. Audit checklist ends every rules file ------------------------------
-echo "[2/11] Every skills/*/rules/*.md ends with an '## Audit checklist'"
+echo "[2/12] Every skills/*/rules/*.md ends with an '## Audit checklist'"
 missing=0
 seen2=0
 while IFS= read -r f; do
@@ -154,7 +162,7 @@ if [ "$missing" -eq 0 ]; then echo "    ok ($seen2 rules files)"; else fail=1; f
 # .denylist.local (git-ignored, one ERE per line, '#' comments). When neither
 # exists (e.g. an external fork's PR), only the generic phrases are checked —
 # the maintainer's pre-commit hook and this repo's CI carry the full list.
-echo "[3/11] No internal-name leaks"
+echo "[3/12] No internal-name leaks"
 DENY='the user runs|the user operates'
 if [ -n "${SOTA_DENYLIST:-}" ]; then
   DENY="$DENY|$SOTA_DENYLIST"
@@ -190,7 +198,7 @@ fi
 # Code, Codex, ...) skip any skill that exceeds it. Count Unicode characters
 # (descriptions use em-dashes: 1 char, 3 bytes) via python3, parsing both
 # folded block scalars (`>-`) and plain single-line descriptions.
-echo "[4/11] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
+echo "[4/12] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
 if command -v python3 >/dev/null 2>&1; then
   if desc_out=$(python3 - "$MAX_DESC" <<'PY'
 import sys, glob, re
@@ -244,7 +252,7 @@ fi
 # One version, four places: VERSION, plugin.json, the CHANGELOG's top entry,
 # and (after the release lands) the newest v* tag. Drift here shipped a main
 # briefly claiming 1.8.0 with 1.9.0 content (2026-07-03) — hence a hard check.
-echo "[5/11] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
+echo "[5/12] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
 v5=0
 ver=$(tr -d '[:space:]' < VERSION)
 # Strict X.Y.Z: rejects interior malformations (1..2, 1.2, 1.2.3.4) the old
@@ -278,7 +286,7 @@ if [ "$v5" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # rot on surfaces nobody recounts (the social preview said "30 skills" for
 # three releases). Recount from the tree and compare every tracked surface;
 # RELEASING.md lists the same surfaces for manual release edits.
-echo "[6/11] Count-bearing surfaces match the tree"
+echo "[6/12] Count-bearing surfaces match the tree"
 v6=0
 ck() { # ck <found> <expected> <surface>
   [ "$1" = "$2" ] || { note "$3: says '${1:-<not found>}', tree says '$2'"; v6=1; }
@@ -324,7 +332,7 @@ if [ "$v6" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # library-map entry must name a real skill dir. Catches the drift the
 # 2026-07-10 audit found: sota-confidential-computing was added to the table
 # but missing from the map for a full release.
-echo "[7/11] Router lists every skill (routing table + library map)"
+echo "[7/12] Router lists every skill (routing table + library map)"
 v7=0
 seen7=0
 router=skills/sota/SKILL.md
@@ -352,7 +360,7 @@ if [ "$v7" -eq 0 ]; then echo "    ok ($seen7 domain skills)"; else fail=1; fi
 # with no rot-catching upside. Fenced AND inline code are stripped so link-shaped
 # examples (in ``` fences or `backticks`) are not scanned. Idea from vault-doctor
 # (training-knowledge-vault); see docs/ADOPTION-LOG.md.
-echo "[8/11] Internal Markdown links resolve (*.md targets)"
+echo "[8/12] Internal Markdown links resolve (*.md targets)"
 if command -v python3 >/dev/null 2>&1; then
   if link_out=$(python3 - <<'PY'
 import os, re, sys
@@ -398,7 +406,7 @@ fi
 # previous release (2026-07-28) and both sat on main until a human noticed
 # during the release cut. Fence-aware, like check 2: a CHANGELOG entry may
 # legitimately quote '## [Unreleased]' inside a code fence.
-echo "[9/11] CHANGELOG has at most one [Unreleased], and it is the top entry"
+echo "[9/12] CHANGELOG has at most one [Unreleased], and it is the top entry"
 v9=0
 changelogs="CHANGELOG.md $(git ls-files 'docs/CHANGELOG-archive*.md' | tr '\n' ' ')"
 for cl in $changelogs; do
@@ -444,7 +452,7 @@ if [ "$v9" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # to ourselves. All 255 rules files passed when this landed, so it is a
 # regression gate, not a repair; it was watched to fail on an injected file
 # and on a renamed reference before being trusted.
-echo "[10/11] Every skills/*/rules/*.md is referenced by its own SKILL.md"
+echo "[10/12] Every skills/*/rules/*.md is referenced by its own SKILL.md"
 v10=0
 seen10=0
 while IFS= read -r rf; do
@@ -487,7 +495,7 @@ if [ "$v10" -eq 0 ]; then echo "    ok ($seen10 rules files indexed)"; else fail
 # This is the first DIFF-based invariant; every other check reads the whole tree.
 # With no merge base it skips with a note rather than guessing, like checks 4/8.
 SWEEP_MIN_SKILL_FILES=20
-echo "[11/11] LAST-VERIFIED moves only with a sweep (batched diff, or declared in CHANGELOG)"
+echo "[11/12] LAST-VERIFIED moves only with a sweep (batched diff, or declared in CHANGELOG)"
 v11=0
 base=""
 for ref in origin/main main; do
@@ -532,11 +540,96 @@ else
 fi
 if [ "$v11" -ne 0 ]; then fail=1; fi
 
+# --- 12. Rendered assets are current --------------------------------------
+# assets/*.png are committed BUILD OUTPUTS of the assets/*.html beside them, and
+# nothing regenerates them. The README embeds the PNG and never the source — so an
+# HTML edit that is not re-rendered is invisible to every reader, while the diff,
+# the commit message and the CHANGELOG all report the surface fixed.
+#
+# Not hypothetical: PR #173 (2026-08-01) changed how-it-works.html from "every file
+# < 500 lines" to "each < 500 lines" — the entire point of that PR — and left
+# how-it-works.png at its #55 render from 2026-07-09. main served the stale claim
+# for the rest of the day on the one surface anybody actually looks at.
+#
+# Passes all three docs/CONVENTIONS-LEDGER.md filters: it has already failed; it
+# fails SILENTLY (nobody reads the HTML, and the PNG looks fine — it just says the
+# old thing); and it is mechanically checkable from git log alone.
+#
+# COMMIT times, not mtimes: a fresh clone stamps every file with the checkout time,
+# so an mtime comparison would pass on any CI runner — green while examining
+# nothing (rules/11 §2.2). Equal timestamps PASS: rendering in the same commit as
+# the edit is the wanted behaviour, not a violation.
+#
+# Escape: "[no-render]" in the HTML's own last commit subject, for an edit that
+# cannot change the output. Deliberately a DECLARATION and not a heuristic —
+# invariant 11 learned that a gate firing on non-events gets waved through until it
+# is decorative, and nothing short of rendering both can tell a cosmetic HTML edit
+# from a load-bearing one.
+#
+# HISTORY-based, like check 11's diff: with no commit history for a pair it skips
+# with a note rather than guessing, because a shallow clone must not read as a pass.
+echo "[12/12] Rendered assets: each assets/*.png is no older than its *.html"
+v12=0
+seen12=0
+checked12=0
+while IFS= read -r html; do
+  seen12=$((seen12 + 1))
+  png="${html%.html}.png"
+  html_ct=$(git log -1 --format=%ct -- "$html" 2>/dev/null || true)
+  if [ -z "$html_ct" ]; then
+    note "SKIPPED (no commit history for $html — shallow clone?)"
+    continue
+  fi
+  if ! git ls-files --error-unmatch "$png" >/dev/null 2>&1; then
+    note "NEVER RENDERED: $html has no committed $png"
+    note "  Render it and commit both (CONTRIBUTING.md -> Rendered assets)."
+    v12=1
+    continue
+  fi
+  png_ct=$(git log -1 --format=%ct -- "$png" 2>/dev/null || true)
+  if [ -z "$png_ct" ]; then
+    note "SKIPPED (no commit history for $png — shallow clone?)"
+    continue
+  fi
+  checked12=$((checked12 + 1))
+  if [ "$html_ct" -gt "$png_ct" ]; then
+    # Captured into a variable, NOT piped into grep -q: an early-exiting grep on a
+    # pipe SIGPIPEs the upstream git and pipefail turns a MATCH into a failure —
+    # the exact shape that made invariant 9's first cut look like it passed.
+    subject=$(git log -1 --format=%s -- "$html" 2>/dev/null || true)
+    case "$subject" in
+      *"[no-render]"*)
+        note "ok, declared [no-render]: $html"
+        continue
+        ;;
+    esac
+    note "STALE RENDER: $png is older than $html"
+    # Full timestamp, not %cs: a same-day miss printed the SAME date on both lines
+    # while asserting one was older, which reads as a broken check rather than a
+    # real finding — and a check nobody believes is one they turn off.
+    note "  $html last changed $(git log -1 --format=%ci -- "$html")"
+    note "  $png last changed $(git log -1 --format=%ci -- "$png")"
+    note "  The README embeds the PNG, not the source. Re-render and commit both"
+    note "  (CONTRIBUTING.md -> Rendered assets), or put [no-render] in the commit"
+    note "  subject when the edit cannot change the output."
+    v12=1
+  fi
+done < <(git ls-files 'assets/*.html')
+scope "$seen12" "rendered asset sources" || v12=1
+if [ "$v12" -eq 0 ]; then
+  if [ "$checked12" -eq 0 ] && [ "$seen12" -gt 0 ]; then
+    echo "    ok (skipped — no usable commit history)"
+  else
+    echo "    ok ($checked12 asset pairs)"
+  fi
+fi
+if [ "$v12" -ne 0 ]; then fail=1; fi
+
 # --- Result ---------------------------------------------------------------
 echo
 if [ "$fail" -ne 0 ]; then
   echo "FAIL: repository invariants violated (see above)."
   exit 1
 fi
-printf 'PASS: all repository invariants satisfied (11 checks over %s skill files / %s rules files, %ss).\n' \
+printf 'PASS: all repository invariants satisfied (12 checks over %s skill files / %s rules files, %ss).\n' \
   "${seen1:-?}" "${seen2:-?}" "$((SECONDS - START_SECONDS))"


### PR DESCRIPTION
Follow-up to #174, which fixed the defect but deliberately left the gate to its
own PR so it could be **watched failing** against the exact commit where the
drift existed.

## The invariant

Every `assets/*.png` must be committed no earlier than the `assets/*.html` it
renders. The PNGs are committed **build outputs** and nothing regenerates them,
so an un-rendered HTML fix reaches nobody — the README embeds the image, never
the source.

It had already failed the day it was written: #173 rewrote the stale line-cap
claim in `how-it-works.html` (the entire point of that PR) and left the PNG at
its 2026-07-09 render from #55. `main` served the old claim all day while the
diff, the commit message and the CHANGELOG all read as done.

Passes all three [CONVENTIONS-LEDGER](docs/CONVENTIONS-LEDGER.md) filters:
already failed · fails silently (nobody reads the HTML, and the PNG looks fine —
it just says the old thing) · checkable from `git log -1` alone.

## Watched to fail first

Per the script's own "adding a check?" block:

| Case | Exit | Output |
|---|---|---|
| Worktree at `0f08094` — **the real defect** | 1 | `STALE RENDER` |
| Live HTML-only commit | 1 | `STALE RENDER` |
| HTML with no committed PNG | 1 | `NEVER RENDERED` |
| Drifted pathspec | 1 | `SCOPE EMPTY` |
| Declared `[no-render]` | 0 | escape honoured |
| Current `main` | 0 | `ok (2 asset pairs)` |

**One earlier fail-watch was vacuous, and the CHANGELOG says so.** A `git reset
--hard` reverted the still-uncommitted script, so two mutation cases ran against
a build containing no check 12 and printed *nothing*. Empty output — not a
passing result — is what exposed it. The check is now committed before any
mutation runs, and mutations run in a throwaway worktree.

## Design notes

- **Commit times, not mtimes.** A fresh clone stamps every file with the
  checkout time, so an mtime comparison would pass on every CI runner while
  examining nothing — `rules/11` §2.2, inside the gate built to prevent it.
  Equal timestamps **pass**: rendering in the same commit is the wanted
  behaviour.
- **Escape is a declaration, not a heuristic** — `[no-render]` in the HTML's own
  commit subject. Nothing short of rendering both can tell a cosmetic HTML edit
  from a load-bearing one, and invariant 11 already learned that a gate firing on
  non-events gets waved through until it is decorative.
- **The subject is captured into a variable, never piped into `grep -q`.** An
  early-exiting grep on a pipe SIGPIPEs the upstream `git`, and `pipefail` turns
  a *match* into a failure — the exact shape that made invariant 9's first cut
  look green.
- **Skips, doesn't guess**, when a pair has no commit history: a shallow clone
  must not read as a pass.

## Ledger correction

`docs/CONVENTIONS-LEDGER.md` predicted 2 gateable candidates and this was not
one of them — it appeared in **none** of the five documents the ledger extracts
from, because nobody had ever written it down. It was *unwritten*, not merely
ungated, and the extraction method is structurally blind to that class. The
ledger now records that its "the gateable set is small" finding bounds the
**documented** set only, and that re-deriving it will not find the next
invariant 12 — only an incident will.

## Verification

- `./scripts/check-invariants.sh` → `PASS (12 checks over 297 skill files / 256
  rules files)`
- `shellcheck scripts/check-invariants.sh` → clean
- Counts updated in `AGENTS.md`, `docs/MAINTENANCE.md`, `docs/WHY-IT-WORKS.md`;
  invariant lists updated in `AGENTS.md` + `CONTRIBUTING.md`
