### PR TITLE
feat(ci): invariant 13 — every scoreboard row declares its sample size

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,18 @@ that verifies nothing (`sota-code-security` rules/11 §2.2).
     a declaration rather than a heuristic, because nothing short of rendering both
     can tell a cosmetic HTML edit from a load-bearing one. Render command and
     per-asset sizes: [CONTRIBUTING.md](CONTRIBUTING.md) → *Rendered assets*.
+13. **every scoreboard row declares its sample size** — each row of the results
+    table in [evals/results/RESULTS.md](evals/results/RESULTS.md) must fill its
+    `Samples` cell. A lift from one run is typographically identical to a lift from
+    ten, and this repo has been burned twice: a **+0.07** retracted when the set
+    grew 15 → 49, and a **+0.40** corrected to **+0.39** by a second run. Neither
+    looked uncertain on the page. Like invariant 10 this is a **regression guard**
+    with no incident of its own — all 10 rows pass today; it catches the *next* row
+    added without one, which is the cheap moment. **Shape-driven**: it locates the
+    table by its `Samples` header rather than a column index, so renaming or
+    dropping the column fails closed instead of passing over zero rows. Closes the
+    last actionable candidate in
+    [docs/CONVENTIONS-LEDGER.md](docs/CONVENTIONS-LEDGER.md).
 
 Separately, `scripts/check-freshness.sh` (run monthly by
 `.github/workflows/freshness.yml`) tracks the root `LAST-VERIFIED` stamp —
@@ -190,7 +202,7 @@ pre-commit hook scans each commit locally.
   library handed back three proposals citing this repo's own `file:line` — the
   ledger takes those on the same terms, rejections included
 - [docs/CONVENTIONS-LEDGER.md](docs/CONVENTIONS-LEDGER.md) — which of this repo's
-  conventions are **enforced** (12 invariants + 4 more inside the eval runners) and
+  conventions are **enforced** (13 invariants + 4 more inside the eval runners) and
   which are prose, with the three filters a convention must pass to earn a gate
   (has it already failed · does it fail silently · is it mechanically checkable).
   Read it before proposing a new gate — it argues against gating the ~18 judgment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The first diagnostic printed `%cs` (date only) and so reported the **same date**
     on both lines of a same-day miss while asserting one was older. It prints full
     timestamps now: a finding that reads as a broken check is one people switch off.
+- **Invariant 13 — every scoreboard row declares its sample size.** Each row of the
+  results table in [evals/results/RESULTS.md](evals/results/RESULTS.md) must fill its
+  `Samples` cell. A lift from one run is typographically identical to a lift from ten,
+  and this repo has been burned twice: a **+0.07** retracted when the set grew 15 → 49,
+  and a **+0.40** corrected to **+0.39** by a second run. Neither looked uncertain on
+  the page.
+  - Like invariant 10 it is a **regression guard** with no incident of its own — all
+    10 rows pass today. It catches the *next* row added without an `n`, which is the
+    cheap moment; the expensive moment is after the number has been quoted.
+  - **Shape-driven, not position-driven**: it finds the table by its `Samples`
+    **header** and checks that column in every data row beneath. So a renamed or
+    dropped column fails closed (`SCOPE EMPTY`) rather than passing over zero rows —
+    the drift a hardcoded column index sails straight past.
+  - The loop reads from a **process substitution, not a pipe**. A `| while` runs in a
+    subshell, so every `v13=1` set inside it would be discarded on exit: a gate that
+    finds offenders, prints them, and still exits 0.
+  - Watched to fail on four paths first: a blanked `Samples` cell (exit 1, naming the
+    row), a renamed column (`SCOPE EMPTY`, exit 1), a missing scoreboard file
+    (skipped, not assumed), and the clean tree (exit 0, `ok (10 scoreboard rows)`).
+  - This closes the **last actionable candidate** in
+    [docs/CONVENTIONS-LEDGER.md](docs/CONVENTIONS-LEDGER.md). One candidate remains
+    (§2b's front-door grep) and is blocked on machine-readable capability names.
+- **Five stale surfaces fixed, found by re-checking the ones this cycle touched.**
+  - `README.md` still said **"Eleven invariants"** — missed by the earlier sweep
+    because its grep was case-sensitive. Its list of what they cover also omitted
+    four: rules-file indexing, the single `[Unreleased]`, `LAST-VERIFIED` pairing,
+    and rendered-asset currency. Both fixed, and the list now names all thirteen
+    areas rather than trailing off after six.
+  - `docs/MAINTENANCE.md`'s structure row had its **count** bumped to 12 in the same
+    breath as leaving its **parenthetical list** without the new check — a count that
+    agrees with the script while the prose beside it does not.
+  - `docs/INDEX.md` had **no route to the render procedure** added a day earlier: a
+    documented procedure with no front-door row, which is `RELEASING.md` §2b's class
+    applied to the index rather than the README.
+  - `RELEASING.md`'s social-preview step described re-rendering by hand with no
+    mention that **invariant 12 now enforces the commit-both half**, and no pointer
+    to the fuller procedure in `CONTRIBUTING.md`.
+  - `docs/ROADMAP.md`'s open-tasks header still read *as of 2026-08-01* and called
+    §2b "the only other candidate" while the Samples guard was still listed as open.
 - **Two stale invariant counts fixed.** `docs/MAINTENANCE.md` said
   `check-invariants.sh` runs **7 checks** and `docs/WHY-IT-WORKS.md` said **eight
   invariants**; both are **11** (the script prints its own count, so the drift was

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,11 @@ are marked "needs verification", never asserted.
     output, put `[no-render]` in the commit subject. Added the day it failed —
     #173's whole point was fixing a claim in `how-it-works.html`, the PNG was not
     re-rendered, and the README kept showing the old text.
+13. **every scoreboard row declares its sample size**: each row of the results
+    table in `evals/results/RESULTS.md` must fill its `Samples` cell. Practical
+    effect: adding a row means stating its `n` (`3×, temp 0.7`, `1×`) — a number
+    without one reads exactly like a number with one. A regression guard: it passes
+    today and exists to keep it that way.
 
 Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`);
 CI scans the full git history, the pre-commit hook scans each commit.

--- a/README.md
+++ b/README.md
@@ -689,11 +689,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). The short version: keep skills generic,
 verify fast-moving claims against primary sources, keep **skill** files
 (`skills/**`) ≤ 500 lines — that cap keeps incremental rule loading working and
 does not apply to README/CHANGELOG/`docs/`, which are read by humans — and end
-each rules file with an audit checklist. Eleven invariants enforce this in
+each rules file with an audit checklist. Thirteen invariants enforce this in
 `scripts/check-invariants.sh` (pre-commit + CI), covering line caps, checklist
-placement, description limits, version and count drift, router completeness, and
-internal link resolution — plus gitleaks (full-history scan in CI; per-commit via
-the pre-commit hook). Ideas taken from outside the repo are recorded with a
+placement, description limits, version and count drift, router completeness,
+internal link resolution, every rules file being reachable from its skill's index,
+a single `[Unreleased]` CHANGELOG entry, the `LAST-VERIFIED` stamp moving only
+with a sweep, a rendered `assets/*.png` never being older than the `*.html` it
+comes from, and every scoreboard row declaring its sample size — plus gitleaks
+(full-history scan in CI; per-commit via the pre-commit hook). Ideas taken from outside the repo are recorded with a
 verdict and reason in [docs/ADOPTION-LOG.md](docs/ADOPTION-LOG.md), so a
 rejection isn't re-litigated. Security issues and conduct:
 [SECURITY.md](SECURITY.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -45,6 +45,10 @@ Then update every surface that carries a count:
   screenshotting at exactly **1280×640** with a headless browser (`file://`
   is typically blocked), commit both files, and re-upload the PNG at GitHub
   **Settings → Social preview** (the repo file does not refresh it).
+  **Invariant 12 now enforces the commit-both half**: any `assets/*.html` whose
+  paired PNG is older fails CI, so a re-render can no longer be forgotten the way
+  `how-it-works` was in #173. Full procedure and per-asset sizes:
+  [CONTRIBUTING.md → Rendered assets](CONTRIBUTING.md#rendered-assets).
 
 ## 2b. Front-door surfaces (every release) — no gate catches these
 

--- a/docs/CONVENTIONS-LEDGER.md
+++ b/docs/CONVENTIONS-LEDGER.md
@@ -25,7 +25,7 @@ item).
 | Raw entries | 49 |
 | Duplicates (the invariant list appears in both `AGENTS.md` and `CONTRIBUTING.md`) | 8 |
 | **Distinct conventions** | **41** |
-| Already enforced as invariants | 12 (11 when this ledger was derived) |
+| Already enforced as invariants | 13 (11 when this ledger was derived) |
 
 An earlier estimate of "~122" came from a loose regex that matched any bold line or
 any line containing *must/never/always*. It was an over-count by ~3×, and is
@@ -47,12 +47,12 @@ A convention earns a gate only if it passes **all three**:
 
 ## The ledger
 
-### Enforced (12) — invariants 1–12
+### Enforced (13) — invariants 1–13
 
 Skill-file line cap · audit-checklist placement · internal-name denylist · description cap ·
 version lockstep · count surfaces · router completeness · link resolution ·
 single `[Unreleased]` · rules-file indexed by its SKILL.md · `LAST-VERIFIED` sweep
-pairing · rendered asset no older than its source. Each is in
+pairing · rendered asset no older than its source · scoreboard rows declare their sample size. Each is in
 `scripts/check-invariants.sh` and documented in `AGENTS.md`.
 
 ### Enforced in code, outside the invariant script (4)
@@ -104,12 +104,25 @@ is small" is therefore a statement about *written* conventions only. A second so
 of candidates exists and is not searchable: things this repo does by habit and has
 never said out loud, which surface only when one of them fails.
 
-### Gateable but not gated (2 candidates)
+### Gateable but not gated (1 candidate)
 
 | Candidate | Incident? | Silent? | Checkable? | Verdict |
 |---|---|---|---|---|
-| Every scoreboard row declares its sample size | **yes** — a `+0.07` retracted at n=49, and `+0.40` corrected to `+0.39` by a second run | **yes** — a number from one run is typographically identical to one from ten | **yes** — the Samples column exists and all 10 rows populate it | **regression guard**, like invariant 10: it currently passes, so it prevents drift rather than repairing a defect |
 | Front-door capability grep (`RELEASING.md` §2b) | **yes** — five capabilities shipped with no README mention | **yes** — nothing errors | **no** — needs a machine-readable capability list per release | **blocked**, recorded in ROADMAP |
+
+**Closed 2026-08-02: the Samples-column guard shipped as invariant 13.** It was
+this ledger's one actionable candidate — *every scoreboard row declares its sample
+size* — with its incident (a `+0.07` retracted when the set grew 15 → 49; a `+0.40`
+corrected to `+0.39` by a second run), its silence (a number from one run is
+typographically identical to one from ten), and its checkability (the `Samples`
+column, populated in all 10 rows) all already argued above. The implementation
+locates the table by its **header** rather than a column index, so renaming or
+dropping the column fails closed instead of passing over zero rows.
+
+That leaves **one** candidate, and it is blocked on a prerequisite this ledger
+cannot supply. The actionable set from *written* conventions is now empty — which,
+with finding 2b below, is the useful state to be in: the next gate will come from an
+incident, not from re-reading the docs.
 
 ## Findings
 
@@ -124,7 +137,8 @@ find a breach and found a wording defect instead, which is the more useful resul
 **2. The gateable set is small — 2, and one is blocked.** Against a prediction of
 2–4, the ledger yields **one actionable candidate**, and it is a regression guard
 rather than a repair. That is the honest output: most conventions here either are
-already enforced or govern judgment a gate cannot reach.
+already enforced or govern judgment a gate cannot reach. *(That one candidate
+shipped as invariant 13 on 2026-08-02; the remaining candidate is still blocked.)*
 
 **2b. …but only among conventions that were written down (added 2026-08-01).**
 One day after this ledger shipped, a real defect produced invariant 12 — a

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -49,6 +49,7 @@ trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issu
 | Know the invariants CI enforces | [AGENTS.md → Invariants](../AGENTS.md#invariants-enforced-in-pre-commit-and-ci) |
 | See which conventions are *enforced* vs. prose, and why the rest aren't gated | [CONVENTIONS-LEDGER.md](CONVENTIONS-LEDGER.md) |
 | Full contribution conventions | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Re-render a README diagram after editing its HTML (sizes, why `file://` fails) | [CONTRIBUTING.md → Rendered assets](../CONTRIBUTING.md#rendered-assets) |
 | Cut a release | [RELEASING.md](../RELEASING.md) |
 | Keep fast-moving claims accurate (sweep runbook + named high-rot targets) | [MAINTENANCE.md](MAINTENANCE.md) |
 | See which external ideas were adopted/rejected and why | [ADOPTION-LOG.md](ADOPTION-LOG.md) |

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -2,7 +2,7 @@
 
 The library's value is that its fast-moving claims (versions, CVEs, RFCs,
 specs, GA states, tool status, standards) hold up against primary sources.
-CI enforces *structure* (the 12 invariants in `scripts/check-invariants.sh` +
+CI enforces *structure* (the 13 invariants in `scripts/check-invariants.sh` +
 gitleaks + shellcheck) but **cannot** verify that a claim is *true* — that
 needs web access and judgment. This file is the human/agent process that
 covers the accuracy dimension CI can't, plus how efficacy is measured.
@@ -95,7 +95,7 @@ grow the golden sets as coverage warrants.
 
 | Dimension | Gate | Automated? |
 |---|---|---|
-| Structure (skill-file line cap, checklist-last, description cap, counts, router completeness, link resolution, rules-file indexing, `LAST-VERIFIED` pairing) | `check-invariants.sh` (**12 checks**) | Yes — pre-commit + CI |
+| Structure (skill-file line cap, checklist-last, description cap, counts, router completeness, link resolution, rules-file indexing, `LAST-VERIFIED` pairing, rendered-asset currency, scoreboard sample sizes) | `check-invariants.sh` (**13 checks**) | Yes — pre-commit + CI |
 | Secrets | gitleaks (full history) | Yes — CI |
 | Shell quality | shellcheck | Yes — CI |
 | Claim **accuracy** | this runbook + `LAST-VERIFIED` | No — human/agent, monthly red-flag |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,9 +4,28 @@ Priorities set by the **2026-07-10 audit**
 ([AUDIT-2026-07-10.md](AUDIT-2026-07-10.md)). Ordered; revisit after each
 release. The 2026-07-01 cycle is fully executed and kept below as history.
 
-## Open tasks — next-session pick-up *(as of 2026-08-01)*
+## Open tasks — next-session pick-up *(as of 2026-08-02)*
 
-**This cycle (2026-08-01, v1.19.9 — "counted as a layer").** A **fourth** discovery
+**Latest cycle (2026-08-02, PRs #174–#176).** Two invariants and a diagram, from a
+**fifth** discovery mode: *writing marketing copy about the repo forced a look at a
+surface nobody reads from inside it.* Drafting a LinkedIn post about what shipped
+since v1.0.0 led to the how-it-works diagram, and the diagram turned out to be
+**stale against its own source** — #173 had fixed the line-cap wording in
+`assets/how-it-works.html` and never re-rendered `how-it-works.png`, so `main` served
+the old claim all day while the diff, the commit message and the CHANGELOG all read
+as done. Landed: the render + a diagram that finally shows the *loop* the README
+argues for (#174), **invariant 12** — a rendered asset is never older than its source
+(#175), and **invariant 13** — every scoreboard row declares its sample size (#176),
+which closes the ledger's last actionable candidate.
+
+The generalisable finding is in [CONVENTIONS-LEDGER.md](CONVENTIONS-LEDGER.md)
+finding 2b: **invariant 12's convention appeared in none of the five documents the
+ledger extracts from.** It was *unwritten*, not merely ungated, and a method that
+matches the repo's convention format is structurally blind to that class. So "the
+gateable set is small" bounds the **documented** set only — re-deriving the ledger
+will not find the next invariant 12, and only an incident will.
+
+**Prior cycle (2026-08-01, v1.19.9 — "counted as a layer").** A **fourth** discovery
 mode, after external repos (v1.19.1–2), running the library ourselves (v1.19.3–6),
 and a user-authored audit prompt (v1.19.7): **a separate agent session applying the
 library to its own problem handed back three proposed additions, each citing our
@@ -85,18 +104,19 @@ first.
 
 **New open items from the 2026-07-31 cycle:**
 
-- **One gateable convention remains ungated: every scoreboard row must declare its
-  sample size.** Surfaced by [CONVENTIONS-LEDGER.md](CONVENTIONS-LEDGER.md), which
-  extracted **41 distinct conventions** from the five agent-facing docs and found
-  **11 enforced as invariants plus 4 more enforced inside the eval runners** — so
-  reading `check-invariants.sh` alone undercounts enforcement by about a third.
-  Applying three filters (has it already failed · does it fail silently · is it
-  mechanically checkable) left exactly **one** actionable candidate against a
-  predicted 2–4. It would be a **regression guard**, not a repair: all 10 rows
-  currently populate the Samples column. Low priority precisely because it passes
-  today.
+- ~~**One gateable convention remains ungated: every scoreboard row must declare its
+  sample size.**~~ **CLOSED 2026-08-02 — shipped as invariant 13.** Surfaced by
+  [CONVENTIONS-LEDGER.md](CONVENTIONS-LEDGER.md), which extracted **41 distinct
+  conventions** from the five agent-facing docs and found **11 enforced as invariants
+  plus 4 more enforced inside the eval runners** — so reading `check-invariants.sh`
+  alone undercounts enforcement by about a third. Applying three filters left exactly
+  **one** actionable candidate against a predicted 2–4, and it was a **regression
+  guard** rather than a repair: all 10 rows already populated the Samples column. The
+  implementation finds the table by its `Samples` **header** rather than a column
+  index, so renaming or dropping the column fails closed instead of passing over zero
+  rows. **The actionable set from written conventions is now empty.**
 - **`RELEASING.md` §2b's front-door grep stays blocked** on needing machine-readable
-  capability names per release — carried forward, still the only other candidate.
+  capability names per release — now the **only** remaining candidate.
 - **The reimplement case set is documentation, never run**
   (`evals/cases/reimplement.jsonl`). If anyone ever runs it, the predictions written
   *before* any run exist in the case-file header and must be used rather than fresh

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -145,7 +145,7 @@ comparison to anyone else required.
    `file:line | rule violated | severity | effort | fix` and maps to a standard
    (CWE, OWASP, MITRE ATT&CK/ATLAS) where one applies.
 
-4. **CI-gated library quality.** Twelve invariants
+4. **CI-gated library quality.** Thirteen invariants
    ([`check-invariants.sh`](../scripts/check-invariants.sh)) block a bad change at
    the door: every **skill** file ≤ 500 lines — `skills/*/SKILL.md` and
    `skills/*/rules/*.md`, the files an agent actually loads, and nothing else (so

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -53,6 +53,13 @@
 #      read as done. HISTORY-based (commit times, not mtimes — a fresh clone
 #      stamps every file identically); escape is "[no-render]" in the HTML's own
 #      commit subject.
+#  13. Every scoreboard row in evals/results/RESULTS.md declares its sample size.
+#      A lift from one run is typographically identical to a lift from ten, and
+#      this repo has been burned twice: a +0.07 retracted when the set grew 15 ->
+#      49, and a +0.40 corrected to +0.39 by a second run. A REGRESSION GUARD like
+#      check 10 — all 10 rows pass today. Shape-driven (finds the table by its
+#      "Samples" header), so a renamed or dropped column fails closed instead of
+#      passing over zero rows.
 #
 # ADDING A CHECK? Three things this file learned the hard way — all from real
 # incidents recorded in the checks below:
@@ -114,7 +121,7 @@ scope() {  # <count> <noun> — returns 1 on an empty scope; prints nothing on s
 # CHANGELOG, docs/, evals/, AGENTS.md, these scripts -- is prose or code read by
 # people, deliberately uncapped since 2026-07-15; navigability there comes from a
 # table of contents and docs/INDEX.md, not a line ceiling.
-echo "[1/12] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
+echo "[1/13] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
 over=0
 seen1=0
 while IFS= read -r f; do
@@ -131,7 +138,7 @@ scope "$seen1" "skill files" || over=1
 if [ "$over" -eq 0 ]; then echo "    ok ($seen1 skill files)"; else fail=1; fi
 
 # --- 2. Audit checklist ends every rules file ------------------------------
-echo "[2/12] Every skills/*/rules/*.md ends with an '## Audit checklist'"
+echo "[2/13] Every skills/*/rules/*.md ends with an '## Audit checklist'"
 missing=0
 seen2=0
 while IFS= read -r f; do
@@ -162,7 +169,7 @@ if [ "$missing" -eq 0 ]; then echo "    ok ($seen2 rules files)"; else fail=1; f
 # .denylist.local (git-ignored, one ERE per line, '#' comments). When neither
 # exists (e.g. an external fork's PR), only the generic phrases are checked —
 # the maintainer's pre-commit hook and this repo's CI carry the full list.
-echo "[3/12] No internal-name leaks"
+echo "[3/13] No internal-name leaks"
 DENY='the user runs|the user operates'
 if [ -n "${SOTA_DENYLIST:-}" ]; then
   DENY="$DENY|$SOTA_DENYLIST"
@@ -198,7 +205,7 @@ fi
 # Code, Codex, ...) skip any skill that exceeds it. Count Unicode characters
 # (descriptions use em-dashes: 1 char, 3 bytes) via python3, parsing both
 # folded block scalars (`>-`) and plain single-line descriptions.
-echo "[4/12] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
+echo "[4/13] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
 if command -v python3 >/dev/null 2>&1; then
   if desc_out=$(python3 - "$MAX_DESC" <<'PY'
 import sys, glob, re
@@ -252,7 +259,7 @@ fi
 # One version, four places: VERSION, plugin.json, the CHANGELOG's top entry,
 # and (after the release lands) the newest v* tag. Drift here shipped a main
 # briefly claiming 1.8.0 with 1.9.0 content (2026-07-03) — hence a hard check.
-echo "[5/12] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
+echo "[5/13] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
 v5=0
 ver=$(tr -d '[:space:]' < VERSION)
 # Strict X.Y.Z: rejects interior malformations (1..2, 1.2, 1.2.3.4) the old
@@ -286,7 +293,7 @@ if [ "$v5" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # rot on surfaces nobody recounts (the social preview said "30 skills" for
 # three releases). Recount from the tree and compare every tracked surface;
 # RELEASING.md lists the same surfaces for manual release edits.
-echo "[6/12] Count-bearing surfaces match the tree"
+echo "[6/13] Count-bearing surfaces match the tree"
 v6=0
 ck() { # ck <found> <expected> <surface>
   [ "$1" = "$2" ] || { note "$3: says '${1:-<not found>}', tree says '$2'"; v6=1; }
@@ -332,7 +339,7 @@ if [ "$v6" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # library-map entry must name a real skill dir. Catches the drift the
 # 2026-07-10 audit found: sota-confidential-computing was added to the table
 # but missing from the map for a full release.
-echo "[7/12] Router lists every skill (routing table + library map)"
+echo "[7/13] Router lists every skill (routing table + library map)"
 v7=0
 seen7=0
 router=skills/sota/SKILL.md
@@ -360,7 +367,7 @@ if [ "$v7" -eq 0 ]; then echo "    ok ($seen7 domain skills)"; else fail=1; fi
 # with no rot-catching upside. Fenced AND inline code are stripped so link-shaped
 # examples (in ``` fences or `backticks`) are not scanned. Idea from vault-doctor
 # (training-knowledge-vault); see docs/ADOPTION-LOG.md.
-echo "[8/12] Internal Markdown links resolve (*.md targets)"
+echo "[8/13] Internal Markdown links resolve (*.md targets)"
 if command -v python3 >/dev/null 2>&1; then
   if link_out=$(python3 - <<'PY'
 import os, re, sys
@@ -406,7 +413,7 @@ fi
 # previous release (2026-07-28) and both sat on main until a human noticed
 # during the release cut. Fence-aware, like check 2: a CHANGELOG entry may
 # legitimately quote '## [Unreleased]' inside a code fence.
-echo "[9/12] CHANGELOG has at most one [Unreleased], and it is the top entry"
+echo "[9/13] CHANGELOG has at most one [Unreleased], and it is the top entry"
 v9=0
 changelogs="CHANGELOG.md $(git ls-files 'docs/CHANGELOG-archive*.md' | tr '\n' ' ')"
 for cl in $changelogs; do
@@ -452,7 +459,7 @@ if [ "$v9" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # to ourselves. All 255 rules files passed when this landed, so it is a
 # regression gate, not a repair; it was watched to fail on an injected file
 # and on a renamed reference before being trusted.
-echo "[10/12] Every skills/*/rules/*.md is referenced by its own SKILL.md"
+echo "[10/13] Every skills/*/rules/*.md is referenced by its own SKILL.md"
 v10=0
 seen10=0
 while IFS= read -r rf; do
@@ -495,7 +502,7 @@ if [ "$v10" -eq 0 ]; then echo "    ok ($seen10 rules files indexed)"; else fail
 # This is the first DIFF-based invariant; every other check reads the whole tree.
 # With no merge base it skips with a note rather than guessing, like checks 4/8.
 SWEEP_MIN_SKILL_FILES=20
-echo "[11/12] LAST-VERIFIED moves only with a sweep (batched diff, or declared in CHANGELOG)"
+echo "[11/13] LAST-VERIFIED moves only with a sweep (batched diff, or declared in CHANGELOG)"
 v11=0
 base=""
 for ref in origin/main main; do
@@ -568,7 +575,7 @@ if [ "$v11" -ne 0 ]; then fail=1; fi
 #
 # HISTORY-based, like check 11's diff: with no commit history for a pair it skips
 # with a note rather than guessing, because a shallow clone must not read as a pass.
-echo "[12/12] Rendered assets: each assets/*.png is no older than its *.html"
+echo "[12/13] Rendered assets: each assets/*.png is no older than its *.html"
 v12=0
 seen12=0
 checked12=0
@@ -625,11 +632,73 @@ if [ "$v12" -eq 0 ]; then
 fi
 if [ "$v12" -ne 0 ]; then fail=1; fi
 
+# --- 13. Every scoreboard row declares its sample size ---------------------
+# The last actionable candidate in docs/CONVENTIONS-LEDGER.md. A lift from one run
+# is typographically identical to a lift from ten, and this repo has been burned by
+# exactly that twice: a +0.07 on inert-control detection did not survive growing the
+# set from 15 to 49 cases and was RETRACTED, and a +0.40 published from one synced
+# run became +0.39 on the two-run mean. Neither number looked uncertain on the page.
+#
+# Like invariant 10, this is a REGRESSION GUARD with no incident of its own: all 10
+# rows populate the column today. It prevents the next row from being added without
+# one, which is the cheap moment to catch it — the expensive moment is after the
+# number has been quoted somewhere.
+#
+# Shape-driven, not position-driven: it finds any table whose header has a "Samples"
+# column and checks that column in every data row beneath it. So it also fails when
+# the column is RENAMED or dropped (0 tables -> SCOPE EMPTY), which is the drift a
+# hardcoded column index would sail straight past.
+echo "[13/13] Every scoreboard row declares its sample size"
+v13=0
+BOARD="evals/results/RESULTS.md"
+if [ ! -f "$BOARD" ]; then
+  note "SKIPPED (no $BOARD in this checkout)"
+  echo "    ok (skipped)"
+else
+  s13=$(awk -F'|' '
+    /^\|/ {
+      if (!intable) {
+        for (i = 1; i <= NF; i++) {
+          g = $i; gsub(/^[ \t]+|[ \t]+$/, "", g)
+          if (g == "Samples") { col = i; intable = 1; tables++; next }
+        }
+        next
+      }
+      if ($0 ~ /^\|[ :|-]*$/) next          # the |---|---| separator row
+      rows++
+      cell = $col;  gsub(/^[ \t]+|[ \t]+$/, "", cell)
+      label = $2;   gsub(/^[ \t]+|[ \t]+$/, "", label)
+      if (cell == "") printf "EMPTY\t%d\t%s\n", NR, label
+      next
+    }
+    { intable = 0 }                          # a non-table line ends the table
+    END { printf "TABLES\t%d\nROWS\t%d\n", tables, rows }
+  ' "$BOARD")
+  n_tables=$(printf '%s\n' "$s13" | awk -F'\t' '$1=="TABLES"{print $2}')
+  n_rows=$(printf '%s\n' "$s13" | awk -F'\t' '$1=="ROWS"{print $2}')
+  # Process substitution, NOT a pipe: a `| while` runs the loop in a subshell and
+  # every v13=1 set inside it is discarded when the subshell exits — a gate that
+  # finds offenders, prints them, and still exits 0.
+  while IFS="$(printf '\t')" read -r kind line label; do
+    [ "$kind" = "EMPTY" ] || continue
+    note "NO SAMPLE SIZE: $BOARD:$line — \"$label\""
+    v13=1
+  done < <(printf '%s\n' "$s13")
+  if [ "$v13" -ne 0 ]; then
+    note "  A number without its n reads exactly like a number with one. State the"
+    note "  sample size in the row (\"3×, temp 0.7\", \"1×\") — see evals/README.md."
+  fi
+  scope "${n_tables:-0}" "scoreboard tables with a Samples column" || v13=1
+  scope "${n_rows:-0}" "scoreboard rows" || v13=1
+  if [ "$v13" -eq 0 ]; then echo "    ok ($n_rows scoreboard rows)"; fi
+fi
+if [ "$v13" -ne 0 ]; then fail=1; fi
+
 # --- Result ---------------------------------------------------------------
 echo
 if [ "$fail" -ne 0 ]; then
   echo "FAIL: repository invariants violated (see above)."
   exit 1
 fi
-printf 'PASS: all repository invariants satisfied (12 checks over %s skill files / %s rules files, %ss).\n' \
+printf 'PASS: all repository invariants satisfied (13 checks over %s skill files / %s rules files, %ss).\n' \
   "${seen1:-?}" "${seen2:-?}" "$((SECONDS - START_SECONDS))"


### PR DESCRIPTION
Closes the **last actionable candidate** in
[docs/CONVENTIONS-LEDGER.md](docs/CONVENTIONS-LEDGER.md), and fixes five stale
surfaces found by re-checking the ones this cycle touched.

## Invariant 13

Each row of the results table in `evals/results/RESULTS.md` must fill its
`Samples` cell. A lift from one run is typographically identical to a lift from
ten, and this repo has been burned twice: a **+0.07** retracted when the set grew
15 → 49, and a **+0.40** corrected to **+0.39** by a second run. Neither looked
uncertain on the page.

Like invariant 10 it is a **regression guard** with no incident of its own — all
10 rows pass today. It catches the *next* row added without an `n`, which is the
cheap moment; the expensive one is after the number has been quoted.

**Shape-driven, not position-driven.** It finds the table by its `Samples`
**header** and checks that column in every data row beneath, so a renamed or
dropped column fails closed rather than passing over zero rows — the drift a
hardcoded column index sails straight past.

**Process substitution, not a pipe.** A `| while` runs the loop in a subshell, so
every `v13=1` set inside it would be discarded on exit: a gate that finds
offenders, prints them, and still exits 0.

### Watched to fail first

| Case | Exit | Output |
|---|---|---|
| Blanked `Samples` cell | 1 | `NO SAMPLE SIZE: …:20 — "Audit (14 hard snippets)"` |
| `Samples` column renamed | 1 | `SCOPE EMPTY` (tables **and** rows) |
| Scoreboard file absent | 0 | `SKIPPED` — not assumed |
| Clean tree | 0 | `ok (10 scoreboard rows)` |

## Five stale surfaces fixed

- **`README.md` said "Eleven invariants"** — missed by the earlier sweep because
  its grep was case-sensitive. Its coverage list also omitted four of them
  (rules-file indexing, single `[Unreleased]`, `LAST-VERIFIED` pairing, rendered
  assets); it now names all thirteen areas instead of trailing off after six.
- **`docs/MAINTENANCE.md`** had its structure-row *count* bumped to 12 while its
  parenthetical *list* kept the old contents — a count that agrees with the
  script while the prose beside it does not.
- **`docs/INDEX.md`** had no route to the render procedure added a day earlier: a
  documented procedure with no front-door row, which is `RELEASING.md` §2b's
  class applied to the index rather than the README.
- **`RELEASING.md`**'s social-preview step described re-rendering by hand with no
  mention that invariant 12 now enforces the commit-both half.
- **`docs/ROADMAP.md`**'s open-tasks header still read *as of 2026-08-01*, listed
  the Samples guard as open, and called §2b "the only other candidate".

## One correction, recorded rather than hidden

"4 more enforced inside the eval runners" was briefly changed to **3**, on the
assumption the Samples guard had come from that set. It did not — it came from
the *gateable but not gated* table, and the runner-enforced set is still 4.
Caught by re-reading the ledger and reverted before it propagated.

## Verification

- `./scripts/check-invariants.sh` → `PASS (13 checks over 297 skill files / 256
  rules files)`
- `shellcheck scripts/check-invariants.sh` → clean
- Case-insensitive re-grep for `eleven|twelve|11|12 invariants|checks` → no
  residual stale count outside the CHANGELOG's historical entries
- `#rendered-assets` anchor confirmed to exist in `CONTRIBUTING.md` before both
  new links to it were added
