### PR TITLE
feat: close three open roadmap items (setup check, scan scope, runner timing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,5 +95,37 @@ jobs:
           tar -xzf "$TARBALL" gitleaks
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
           gitleaks version
-      - name: Scan (full git history)
-        run: gitleaks git --config .gitleaks.toml --redact --verbose .
+      - name: Scan (full git history) + assert the scan's scope
+        # gitleaks PRINTS its denominator ("179 commits scanned") and nothing ever
+        # read it. Measured 2026-08-02: in a --depth 1 clone of this repo it scans
+        # 1 of 179 commits, prints "no leaks found", and exits 0 — a green secret
+        # scan over 0.5% of history. `fetch-depth: 0` above is the only thing
+        # preventing that, and a gate whose correctness rests on a setting nobody
+        # asserts is `sota-code-security` rules/11 §2.2.
+        #
+        # The scope is asserted from the SHALLOW FLAG, not from a commit count.
+        # Counts cannot do it: `git rev-list --count HEAD` truncates to 1 in the
+        # same clone, so it degrades alongside the scan it would be checking. The
+        # three numbers do not agree either (measured here: rev-list HEAD 175,
+        # rev-list --all 181, gitleaks 179 — gitleaks walks refs beyond HEAD), so
+        # any equality test would be flaky, and a flaky gate gets disabled.
+        run: |
+          set -euo pipefail
+          if [ "$(git rev-parse --is-shallow-repository)" != "false" ]; then
+            echo "::error::Shallow checkout — gitleaks cannot scan full history. Restore fetch-depth: 0."
+            exit 1
+          fi
+          # Log outside the worktree: a file written into the repo root would be
+          # committable by accident and in scope for the next scan.
+          LOG="${RUNNER_TEMP:-/tmp}/gitleaks.log"
+          gitleaks git --config .gitleaks.toml --redact --verbose . 2>&1 | tee "$LOG"
+          scanned=$(grep -oE '[0-9]+ commits scanned' "$LOG" | grep -oE '^[0-9]+' || true)
+          if [ -z "$scanned" ]; then
+            echo "::error::gitleaks printed no 'N commits scanned' line — output format changed, so the scope is no longer verified."
+            exit 1
+          fi
+          if [ "$scanned" -lt 2 ]; then
+            echo "::error::gitleaks scanned only ${scanned} commit(s) on a non-shallow checkout."
+            exit 1
+          fi
+          echo "gitleaks scope OK: ${scanned} commits scanned, non-shallow checkout."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`scripts/verify-setup.sh` — the deterministic half of
+  [docs/VERIFY-SETUP.md](docs/VERIFY-SETUP.md)**, open since the 2026-07-28 cycle.
+  14 checks, strictly **read-only**, exit 1 on any FAIL: skills reachability and
+  whether the *router* is among them, the three always-on routing layers reported
+  separately, profile symlinks resolving, a licence under *any* name, which gate
+  mechanisms exist, whether a hook is **installed** rather than merely configured,
+  and — from real run conclusions — whether CI has ever *executed* and ever
+  *rejected* anything. `--runs N` widens the run-history sample.
+  - The read-only claim is **verified, not asserted**: hashing the file tree and
+    `git status` before and after a full run shows both unchanged.
+  - The three checks a script cannot do (agent-file content, whether its claims
+    are still *true*, the routing dry-run) print as `N/A — judgement check` with a
+    pointer to the prompt, so the split is visible where you run it rather than
+    only in the doc.
+  - **Writing it found a bug in itself.** Check 8 used `git grep`, which reads only
+    **tracked** files — so an untracked `.pre-commit-config.yaml` configuring
+    gitleaks was reported as *no secret scanning*. That is a false FAIL on exactly
+    the case the doc names first ("on a repo you just scaffolded"), and it was found
+    by running the fail path, not by reading the code. Now plain `grep`.
+  - **It also validated its own UNVERIFIED vocabulary.** On this repo check 10b
+    (*has CI ever rejected anything?*) reads UNVERIFIED at the default 60-run
+    sample — 60/60 success — and turns up **1 failure at 200**. "Not in the last 60"
+    really is not "never"; the sample size is printed for that reason.
+- **`evals/_elapsed.py` — the eval runners report their wall time.** All 13 now
+  print `[<runner> elapsed 12.3s]`, closing the runner half of the duration item.
+  Registered with `atexit` so the line survives the `sys.exit(...)` several runners
+  use on an empty corpus — the fast-exit case most worth timing — and written to
+  **stderr** so a runner whose stdout is piped or parsed is not handed an extra
+  line. **Printed, never gated**: these call a remote API whose latency is not ours,
+  and a flaky gate gets disabled. Verified end-to-end on the two `--selftest` paths
+  CI runs without an API key, plus `py_compile` across all of `evals/`.
+
+### Fixed
+
+- **The secret scan reported a denominator nobody read.** `gitleaks` prints
+  `179 commits scanned`, and the roadmap had carried *"still unexamined: what
+  gitleaks reports as its scope"* since 2026-07-30. Examined: in a `--depth 1`
+  clone of this repo it scans **1 of 179 commits**, prints `no leaks found`, and
+  **exits 0** — a green secret scan over 0.5% of history, where `fetch-depth: 0`
+  is the only thing preventing it and nothing asserts that. CI now asserts the
+  scope.
+  - The assertion keys on `git rev-parse --is-shallow-repository`, **not** on a
+    commit count. `git rev-list --count HEAD` truncates to 1 in the same clone, so
+    it degrades alongside the scan it would be checking; and the three available
+    numbers disagree anyway (measured: rev-list HEAD **175**, rev-list --all
+    **181**, gitleaks **179** — gitleaks walks refs beyond HEAD), so any equality
+    test would be flaky, and a flaky gate gets disabled.
+  - It also fails when gitleaks prints **no** `N commits scanned` line: an output
+    format we can no longer parse means the scope is no longer verified, which must
+    not read as a pass.
+  - Watched to fail on four paths: shallow clone (exit 1), unparsable output (exit
+    1), a degenerate 1-commit count on a non-shallow tree (exit 1), and the real
+    repo (exit 0, `179 commits scanned`).
+
 ### Changed
 
 - **The 500-line cap is stated as *instruction-files-only* everywhere it appears.**

--- a/README.md
+++ b/README.md
@@ -523,10 +523,22 @@ couldn't).
 **Then check it actually took.** `init-gates.sh` sets things up; nothing
 verifies the result, and "configured" and "working" render identically — a
 config file with no installed hook is not a control, and a CI job whose every
-run is *skipped* is a gate on paper. [docs/VERIFY-SETUP.md](docs/VERIFY-SETUP.md)
-is a read-only prompt you paste into an agent: it reports whether the library,
-this repo's context, and its gates are in place, changes nothing, and marks
-anything it could not observe as UNVERIFIED rather than passing it.
+run is *skipped* is a gate on paper.
+
+```sh
+/path/to/SOTA-skills/scripts/verify-setup.sh     # read-only; --runs N widens the CI sample
+```
+
+It reports skills reachability, the routing hook, the profile symlink, a licence
+under *any* name, which gates exist, whether a hook is **installed** rather than
+merely configured, and — from real run conclusions — whether CI has ever
+*executed* and ever *rejected* anything. It changes nothing and exits 1 on any
+FAIL. Anything it could not observe is marked **UNVERIFIED**, never passed: on
+this repo the reject-history check reads UNVERIFIED at the default sample and
+turns up a real rejection at `--runs 200`, which is why the sample size is
+printed. [docs/VERIFY-SETUP.md](docs/VERIFY-SETUP.md) carries the other half — a
+paste-in prompt for the judgement calls a script can't make: whether the agent
+file's content is meaningful and whether its claims are still *true*.
 
 Add `--docs-gate` to also install a pre-commit hook that **blocks a commit which
 changes code but updates no docs** (README/CHANGELOG/`docs/`/`*.md`) — so docs

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -50,6 +50,7 @@ trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issu
 | See which conventions are *enforced* vs. prose, and why the rest aren't gated | [CONVENTIONS-LEDGER.md](CONVENTIONS-LEDGER.md) |
 | Full contribution conventions | [CONTRIBUTING.md](../CONTRIBUTING.md) |
 | Re-render a README diagram after editing its HTML (sizes, why `file://` fails) | [CONTRIBUTING.md → Rendered assets](../CONTRIBUTING.md#rendered-assets) |
+| Check a repo's setup is real, not just configured | `scripts/verify-setup.sh` (deterministic) + [VERIFY-SETUP.md](VERIFY-SETUP.md) (the judgement half) |
 | Cut a release | [RELEASING.md](../RELEASING.md) |
 | Keep fast-moving claims accurate (sweep runbook + named high-rot targets) | [MAINTENANCE.md](MAINTENANCE.md) |
 | See which external ideas were adopted/rejected and why | [ADOPTION-LOG.md](ADOPTION-LOG.md) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -173,15 +173,31 @@ first.
   it, watched to fail by simulating
   an early return (`only 17 ran, expected at least 25`). One suspicion was
   **REFUTED** and recorded: CI's `shellcheck scripts/*.sh` fails loudly on an
-  unmatched glob in bash (exit 2), so there was nothing to fix. Still unexamined:
-  what gitleaks reports as its scope over the full history.
+  unmatched glob in bash (exit 2), so there was nothing to fix. ~~Still unexamined:
+  what gitleaks reports as its scope over the full history.~~ **Examined
+  2026-08-02 — it reports a denominator and nobody read it.** gitleaks prints
+  `179 commits scanned`; measured in a `--depth 1` clone of this repo it scans
+  **1 of 179**, prints `no leaks found`, and **exits 0** — a green secret scan over
+  0.5% of history, with `fetch-depth: 0` the only thing preventing it and nothing
+  asserting that. CI now asserts the scope. The assertion keys on
+  `git rev-parse --is-shallow-repository`, **not** on a commit count, for a reason
+  worth keeping: `git rev-list --count HEAD` truncates to 1 in the same clone, so
+  it degrades alongside the scan it would be checking — and the three available
+  numbers disagree anyway (rev-list HEAD 175, rev-list --all 181, gitleaks 179),
+  so any equality test would be flaky. It also fails if gitleaks stops printing the
+  line at all, since an unparsable output means the scope is no longer verified.
 - ~~**Duration is not recorded for any of our automation.**~~ **Partly done
   2026-07-30.** `check-invariants.sh` prints wall time with its denominators
   (`10 checks over 297 skill files / 256 rules files, 10s`). Deliberately printed
   and **not gated** — a duration threshold in CI is flaky under runner variance,
-  and a flaky gate gets disabled. Still open: the eval runners and CI steps print
-  no duration, and there is no recorded baseline to compare a future run against,
-  so "it got 30× faster" is visible only to a human reading two logs.
+  and a flaky gate gets disabled. **The runner half is done 2026-08-02**: all 13
+  runners now print `[<runner> elapsed 12.3s]` via `evals/_elapsed.py`, registered
+  with `atexit` so the line survives the `sys.exit(...)` several of them use on an
+  empty corpus — the fast-exit case most worth timing. To **stderr**, so a runner
+  whose stdout is piped or parsed is not handed an extra line. Printed, never
+  gated: these call a remote API whose latency is not ours. **Still open**: no
+  recorded baseline to compare a future run against, so "it got 30× faster" is
+  still visible only to a human reading two logs.
 - ~~**The dead-path eval has never been run against a live agent.**~~ **Run
   2026-07-30 — and the hypothesis was wrong.** Six local sub-agents, 3 per arm:
   **both arms 1.000/1.000, +0.00**. The pre-registered prediction ("a bare agent
@@ -269,12 +285,22 @@ first.
   upstream. Still true that **no skill file carries a version**, deliberately:
   a version string inside a skill is one more surface to bump every release, and
   `VERSION` is already the invariant-5-guarded source of truth.
-- **`scripts/verify-setup.sh`** — the deterministic half of VERIFY-SETUP.md (does
-  a gate exist, is the hook installed, has this workflow ever run non-skipped,
-  licence present under any name). A script does that better than a prompt, per
-  the library's own "push invariants into deterministic gates". The prompt keeps
-  the half a script cannot do: judging whether an agent file's *content* is
-  meaningful and its claims true.
+- ~~**`scripts/verify-setup.sh`** — the deterministic half of VERIFY-SETUP.md.~~
+  **DONE 2026-08-02.** 14 checks, strictly read-only (verified by hashing the file
+  tree and `git status` before/after), exits 1 on any FAIL, `--runs N` widens the
+  CI-history sample. The prompt keeps the half a script cannot do: whether an agent
+  file's *content* is meaningful (4) and whether its claims are still true (5b),
+  plus the routing dry-run (11) — each now labelled `N/A — judgement check` in the
+  script's own output so the split is visible where you run it.
+  - **Writing it found a bug in itself.** Check 8 used `git grep`, which reads only
+    **tracked** files, so an untracked `.pre-commit-config.yaml` configuring
+    gitleaks was reported as *no secret scanning* — a false FAIL on precisely the
+    case the doc names first ("on a repo you just scaffolded"). Found by running
+    the fail path, not by reading the code. Now plain `grep`.
+  - **And it validated its own UNVERIFIED vocabulary.** On this repo, check 10b
+    (*has CI ever rejected anything?*) reads UNVERIFIED at the default 60-run
+    sample — 60/60 success — and turns up **1 failure at 200**. "Not in the last
+    60" really is not "never", and that is why `--runs` exists.
 - **`gh-sota` extension — considered and deferred, with reason.** gh requires the
   repo to be named `gh-*` with a root executable of the same name (verified in
   `gh extension --help`, 2.96.0), so it cannot live in this repo; it would need a

--- a/docs/VERIFY-SETUP.md
+++ b/docs/VERIFY-SETUP.md
@@ -1,9 +1,26 @@
 # Verifying a repo's setup — the read-only check
 
 `scripts/init-gates.sh` and `scripts/gen-agents-md.sh` **set things up**.
-Nothing checks the result. This is that check: a prompt you paste into a coding
-agent that reports whether the library, this repo's own context, and its gates
-are actually in place — and changes nothing.
+Nothing checks the result. This is that check, in two halves that answer
+different questions — run both:
+
+```sh
+/path/to/SOTA-skills/scripts/verify-setup.sh          # deterministic half
+/path/to/SOTA-skills/scripts/verify-setup.sh --runs 200   # widen the CI-history sample
+```
+
+**`scripts/verify-setup.sh`** does everything mechanical and does it identically
+every time: are the skills reachable, is the routing hook installed, does the
+profile symlink resolve, is there a licence under *any* name, which gate
+mechanisms exist, is a hook actually **installed** rather than merely configured,
+and — from real run conclusions — has CI ever *executed* and ever *rejected*
+anything. It is strictly read-only and exits 1 if any check FAILs.
+
+**The prompt below** does the half a script cannot: whether the agent file's
+content is *meaningful* (check 4), whether its factual claims are still *true*
+(check 5b — where agent files actually rot), and the routing dry-run (check 11).
+Run the script first; it answers a dozen checks in a second and tells the agent
+which ones are left.
 
 It exists because "configured" and "working" are different states that render
 identically. A `.pre-commit-config.yaml` with no installed hook is a file, not a

--- a/evals/_elapsed.py
+++ b/evals/_elapsed.py
@@ -1,0 +1,38 @@
+"""Wall-time reporting for the eval runners.
+
+Every runner used to finish without saying how long it took, so "this got 30x
+faster" — or 30x slower — was visible only to a human diffing two logs. The
+invariant script has printed its duration alongside its denominators since
+2026-07-30 (`sota-code-security` rules/11 SS2.1: a step that reports "nothing
+found" far faster than its claimed work allows did not do the work). The runners
+did not.
+
+PRINTED, NEVER GATED, and to **stderr**. Two deliberate choices:
+
+- No threshold. These runners call a remote API whose latency is not ours; a
+  duration gate would be flaky, and a flaky gate gets disabled, which is how a
+  control becomes inert.
+- stderr, so a runner whose stdout is piped into a report or parsed by another
+  tool is not silently given an extra line to choke on.
+
+Registered via atexit so the line still prints when a runner ends through
+`sys.exit(...)` -- which several of them do on an empty corpus, and which is
+exactly the fast-exit case worth timing.
+
+This module is NOT a measuring instrument: nothing scores it and no published
+number depends on it. It reports; it never decides.
+"""
+
+import atexit
+import sys
+import time
+
+
+def report_on_exit(label):
+    """Print '[label elapsed 12.3s]' to stderr when the process exits."""
+    started = time.time()
+
+    def _emit():
+        print(f"[{label} elapsed {time.time() - started:.1f}s]", file=sys.stderr)
+
+    atexit.register(_emit)

--- a/evals/judge-live-build.py
+++ b/evals/judge-live-build.py
@@ -105,4 +105,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("judge-live-build")
     main()

--- a/evals/run-adjudication.py
+++ b/evals/run-adjudication.py
@@ -166,4 +166,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-adjudication")
     main()

--- a/evals/run-build-safe.py
+++ b/evals/run-build-safe.py
@@ -208,4 +208,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-build-safe")
     main()

--- a/evals/run-clean.py
+++ b/evals/run-clean.py
@@ -274,4 +274,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-clean")
     main()

--- a/evals/run-competitors.py
+++ b/evals/run-competitors.py
@@ -167,4 +167,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-competitors")
     main()

--- a/evals/run-completeness.py
+++ b/evals/run-completeness.py
@@ -250,4 +250,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-completeness")
     main()

--- a/evals/run-dead-path.py
+++ b/evals/run-dead-path.py
@@ -230,4 +230,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-dead-path")
     main()

--- a/evals/run-decay.py
+++ b/evals/run-decay.py
@@ -194,4 +194,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-decay")
     main()

--- a/evals/run-desc-routing.py
+++ b/evals/run-desc-routing.py
@@ -154,4 +154,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-desc-routing")
     main()

--- a/evals/run-reimplement.py
+++ b/evals/run-reimplement.py
@@ -299,4 +299,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-reimplement")
     main()

--- a/evals/run-repo-audit.py
+++ b/evals/run-repo-audit.py
@@ -175,4 +175,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-repo-audit")
     main()

--- a/evals/run-silent-open.py
+++ b/evals/run-silent-open.py
@@ -143,4 +143,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-silent-open")
     main()

--- a/evals/run-unscoped-audit.py
+++ b/evals/run-unscoped-audit.py
@@ -174,4 +174,6 @@ def main():
 
 
 if __name__ == "__main__":
+    from _elapsed import report_on_exit
+    report_on_exit("run-unscoped-audit")
     main()

--- a/scripts/verify-setup.sh
+++ b/scripts/verify-setup.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+#
+# verify-setup.sh — the DETERMINISTIC half of docs/VERIFY-SETUP.md.
+#
+# init-gates.sh and gen-agents-md.sh SET THINGS UP. This reports whether the
+# result is real. "Configured" and "working" render identically: a
+# .pre-commit-config.yaml with no installed hook is a file, not a control; a CI
+# workflow whose every run is "skipped" is a gate on paper.
+#
+# STRICTLY READ-ONLY. It creates, modifies and deletes nothing — run it on a repo
+# you do not trust yet. Every check reports what it OBSERVED; anything it could
+# not actually run is UNVERIFIED with the reason, never a pass.
+#
+# WHAT STAYS IN THE PROMPT (docs/VERIFY-SETUP.md), because a script cannot do it:
+#   - check 4's content judgement: does the agent file carry real build/test
+#     commands, deviations and traps, or does it restate generic best practice?
+#   - check 5b: are the agent file's factual CLAIMS still true? (Commands
+#     existing is checkable; "pinned to 3.11" still being accurate is not.)
+#   - check 11: the routing dry-run.
+# This script does the rest — existence, resolution, installation state, and run
+# history — which it does better than a prompt, and identically every time.
+#
+# Exit code: 1 if any check FAILed, else 0. UNVERIFIED does NOT fail the run —
+# it means nobody watched the thing work, which is unknown, not broken. Do not
+# read a 0 as "the setup is good" when the report carries UNVERIFIED rows.
+#
+# Portable to macOS bash 3.2 (no associative arrays, no mapfile).
+set -euo pipefail
+
+RUN_SAMPLE=60
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --runs) RUN_SAMPLE="${2:?--runs needs a number}"; shift 2 ;;
+    -h|--help)
+      echo "usage: verify-setup.sh [--runs N]   # N = CI runs to sample for check 10 (default 60)"
+      exit 0 ;;
+    *) echo "unknown argument: $1 (try --help)" >&2; exit 2 ;;
+  esac
+done
+case "$RUN_SAMPLE" in
+  ''|*[!0-9]*) echo "--runs must be a positive integer, got: $RUN_SAMPLE" >&2; exit 2 ;;
+esac
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+CLAUDE_HOME="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+
+n_pass=0; n_fail=0; n_partial=0; n_unver=0; n_na=0
+
+row() {  # <status> <check> <evidence>
+  case "$1" in
+    PASS)       n_pass=$((n_pass + 1)) ;;
+    FAIL)       n_fail=$((n_fail + 1)) ;;
+    PARTIAL)    n_partial=$((n_partial + 1)) ;;
+    UNVERIFIED) n_unver=$((n_unver + 1)) ;;
+    N/A)        n_na=$((n_na + 1)) ;;
+  esac
+  printf '%-11s %-34s %s\n' "$1" "$2" "$3"
+}
+
+section() { printf '\n== %s\n' "$1"; }
+
+echo "SOTA setup verification (read-only) — $REPO_ROOT"
+
+# --- A. Is the library reaching this directory? ---------------------------
+section "A. Library reach"
+
+# Probe every install path, not one: personal, project, and plugin.
+skill_dirs=""
+for d in "$CLAUDE_HOME/skills" ".claude/skills" "$CLAUDE_HOME/plugins"; do
+  [ -d "$d" ] && skill_dirs="$skill_dirs $d"
+done
+n_sota=0
+router_seen=0
+for d in $skill_dirs; do
+  # -L: a symlinked skill dir is the recommended install, so follow links.
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    n_sota=$((n_sota + 1))
+    case "$(basename "$s")" in sota) router_seen=1 ;; esac
+  done <<EOF
+$(find -L "$d" -maxdepth 3 -type d -name 'sota' -o -maxdepth 3 -type d -name 'sota-*' 2>/dev/null || true)
+EOF
+done
+if [ -z "$skill_dirs" ]; then
+  row "FAIL" "1. sota skills reachable" "no skills dir found (looked in $CLAUDE_HOME/skills, .claude/skills, $CLAUDE_HOME/plugins)"
+elif [ "$n_sota" -eq 0 ]; then
+  row "FAIL" "1. sota skills reachable" "skills dir(s) exist but contain no sota* skill:$skill_dirs"
+elif [ "$router_seen" -eq 0 ]; then
+  row "PARTIAL" "1. sota skills reachable" "$n_sota sota* skills, but the 'sota' ROUTER is not among them — routing is what loads the rest"
+else
+  row "PASS" "1. sota skills reachable" "$n_sota sota* skills incl. the router, in:$skill_dirs"
+fi
+
+# Always-on routing is THREE layers; report which of them are actually present.
+directive=0; hook=0
+[ -f "$CLAUDE_HOME/CLAUDE.md" ] && grep -qi 'sota' "$CLAUDE_HOME/CLAUDE.md" 2>/dev/null && directive=1
+if [ -f "$CLAUDE_HOME/settings.json" ]; then
+  # Substring test, not a JSON parse: the hook may be a shell one-liner, a script
+  # path, or a wrapper, and any of those is a working injection.
+  if tr -d '\n' < "$CLAUDE_HOME/settings.json" | grep -qi 'UserPromptSubmit' \
+     && grep -qi 'sota' "$CLAUDE_HOME/settings.json"; then
+    hook=1
+  fi
+fi
+if [ "$directive" -eq 1 ] && [ "$hook" -eq 1 ]; then
+  row "PASS" "2. always-on routing" "CLAUDE.md directive + UserPromptSubmit hook mentioning sota"
+elif [ "$directive" -eq 1 ]; then
+  row "PARTIAL" "2. always-on routing" "CLAUDE.md directive only — routing depends on the model reading it, not on per-prompt injection"
+elif [ "$hook" -eq 1 ]; then
+  row "PARTIAL" "2. always-on routing" "UserPromptSubmit hook only — no global directive in $CLAUDE_HOME/CLAUDE.md"
+else
+  row "FAIL" "2. always-on routing" "neither a sota directive in CLAUDE.md nor a UserPromptSubmit hook — routing depends on how each prompt is phrased"
+fi
+
+# Profile: report the FILENAME only. Its contents are the user's stack.
+prof_found=0; prof_dangling=""
+for p in "$CLAUDE_HOME"/profiles/*.md; do
+  [ -e "$p" ] || [ -L "$p" ] || continue
+  if [ -e "$p" ]; then prof_found=$((prof_found + 1)); else prof_dangling="$prof_dangling $(basename "$p")"; fi
+done
+if [ -n "$prof_dangling" ]; then
+  row "FAIL" "3. stack profile" "dangling symlink(s):$prof_dangling"
+elif [ "$prof_found" -gt 0 ]; then
+  row "PASS" "3. stack profile" "$prof_found profile(s) resolve in $CLAUDE_HOME/profiles (names not read)"
+else
+  row "N/A" "3. stack profile" "none present — optional; the skills' own defaults apply"
+fi
+
+# --- B. Is this repo's own context in place? ------------------------------
+section "B. Repo context"
+
+agent_file=""
+for f in AGENTS.md CLAUDE.md GEMINI.md; do
+  [ -e "$f" ] && { agent_file="$f"; break; }
+done
+if [ -z "$agent_file" ]; then
+  row "FAIL" "4. agent file present" "no AGENTS.md / CLAUDE.md / GEMINI.md"
+else
+  link_note=""
+  for f in AGENTS.md CLAUDE.md GEMINI.md; do
+    if [ -L "$f" ]; then
+      if [ -e "$f" ]; then link_note="$link_note $f->$(readlink "$f")"
+      else row "FAIL" "4. agent file present" "$f is a DANGLING symlink"; link_note=" DANGLING"; fi
+    fi
+  done
+  case "$link_note" in
+    *DANGLING*) : ;;
+    *) row "PASS" "4. agent file present" "$agent_file$link_note — CONTENT not judged here, see docs/VERIFY-SETUP.md checks 4-5" ;;
+  esac
+fi
+
+# 5a: the commands an agent file names should exist. Only the presence of a task
+# runner is mechanical; whether a NAMED command resolves is check 5a in the
+# prompt, and whether its CLAIMS are true is 5b, which no script can do.
+row "N/A" "5. agent file is TRUE" "judgement check — run the prompt in docs/VERIFY-SETUP.md (5a commands resolve, 5b claims still accurate)"
+
+# Capabilities, not one implementation's filename.
+lic=$(ls LICENSE* COPYING* COPYRIGHT* 2>/dev/null | head -1 || true)
+[ -n "$lic" ] && row "PASS" "6a. licence" "$lic" || row "FAIL" "6a. licence" "no LICENSE*/COPYING*/COPYRIGHT* — nobody may legally reuse this"
+[ -f .gitignore ] && row "PASS" "6b. .gitignore" "present" || row "FAIL" "6b. .gitignore" "absent"
+rdm=$(ls README* 2>/dev/null | head -1 || true)
+[ -n "$rdm" ] && row "PASS" "6c. README" "$rdm" || row "FAIL" "6c. README" "absent"
+
+# --- C. Are the gates real, or just configured? ---------------------------
+section "C. Gates"
+
+gates=""
+[ -f .pre-commit-config.yaml ] && gates="$gates pre-commit"
+[ -d .husky ] && gates="$gates husky"
+{ [ -f lefthook.yml ] || [ -f lefthook.yaml ] || [ -f .lefthook.yml ]; } && gates="$gates lefthook"
+n_wf=0
+if [ -d .github/workflows ]; then
+  n_wf=$(find .github/workflows -maxdepth 1 -name '*.yml' -o -maxdepth 1 -name '*.yaml' 2>/dev/null | wc -l | tr -d ' ')
+  [ "$n_wf" -gt 0 ] && gates="$gates ci(${n_wf}-workflow)"
+fi
+if [ -n "$gates" ]; then
+  row "PASS" "7. gate mechanisms found" "$(echo "$gates" | sed 's/^ //')"
+else
+  row "FAIL" "7. gate mechanisms found" "no pre-commit / husky / lefthook / CI workflows — nothing gates this repo"
+fi
+
+# Secret scanning: search the gate configs, do not infer from a filename.
+# Plain grep, NOT `git grep`: git grep reads only TRACKED files, and the primary
+# use case for this script is a repo you just scaffolded, whose configs are still
+# untracked. Measured 2026-08-02 — an untracked .pre-commit-config.yaml
+# configuring gitleaks was reported as "no secret scanning", a false FAIL on
+# exactly the repo the check exists for.
+scan_paths=""
+for p in .pre-commit-config.yaml .github .husky lefthook.yml lefthook.yaml .lefthook.yml; do
+  [ -e "$p" ] && scan_paths="$scan_paths $p"
+done
+scan_hits=""
+if [ -n "$scan_paths" ]; then
+  for pat in gitleaks trufflehog detect-secrets ggshield gitguardian; do
+    # shellcheck disable=SC2086  # word splitting is how the path list is passed
+    if grep -r -l -i -- "$pat" $scan_paths >/dev/null 2>&1; then
+      scan_hits="$scan_hits $pat"
+    fi
+  done
+fi
+if [ -n "$scan_hits" ]; then
+  row "PASS" "8. secret scanning configured" "$(echo "$scan_hits" | sed 's/^ //') referenced in a gate config"
+else
+  row "FAIL" "8. secret scanning configured" "no gitleaks/trufflehog/detect-secrets/ggshield in any gate config"
+fi
+
+# INSTALLED vs merely configured — three distinct states, not two.
+hookspath=$(git config --get core.hooksPath 2>/dev/null || true)
+hookdir="${hookspath:-.git/hooks}"
+installed=0
+if [ -d "$hookdir" ]; then
+  installed=$(find "$hookdir" -maxdepth 1 -type f ! -name '*.sample' 2>/dev/null | wc -l | tr -d ' ')
+fi
+if [ "$installed" -gt 0 ]; then
+  row "PASS" "9. hooks installed" "$installed non-sample hook(s) in $hookdir"
+elif [ -n "$gates" ] && echo "$gates" | grep -q 'pre-commit\|husky\|lefthook'; then
+  row "FAIL" "9. hooks installed" "a hook manager is CONFIGURED but $hookdir holds no non-sample hook — that is a file, not a control (run its install step)"
+else
+  row "N/A" "9. hooks installed" "no local hook manager configured"
+fi
+
+# Has each workflow ever EXECUTED, and ever REJECTED anything?
+if [ "$n_wf" -eq 0 ]; then
+  row "N/A" "10. CI run history" "no workflows to have a history"
+elif ! command -v gh >/dev/null 2>&1; then
+  row "UNVERIFIED" "10. CI run history" "gh not installed — cannot read real run conclusions; a green badge is not evidence"
+elif ! gh auth status >/dev/null 2>&1; then
+  row "UNVERIFIED" "10. CI run history" "gh not authenticated — run 'gh auth login'"
+else
+  # gh's own jq (-q), not a hand-rolled grep over the JSON: a miscounting parser
+  # is the failure this repo keeps finding in its own instruments.
+  runs=$(gh run list --limit "$RUN_SAMPLE" --json conclusion -q '.[].conclusion' 2>/dev/null || true)
+  if [ -z "$runs" ]; then
+    row "UNVERIFIED" "10. CI run history" "gh returned no runs (none yet, or no access); sample size 0"
+  else
+    n_runs=$(printf '%s\n' "$runs" | grep -c . || true)
+    n_exec=$(printf '%s\n' "$runs" | grep -cE '^(success|failure)$' || true)
+    n_rej=$(printf '%s\n' "$runs" | grep -c '^failure$' || true)
+    if [ "$n_exec" -eq 0 ]; then
+      row "FAIL" "10a. CI has executed" "$n_runs run(s) sampled, NONE concluded success/failure — an all-skipped history is a control on paper (rules/10 §2.13)"
+    else
+      row "PASS" "10a. CI has executed" "$n_exec of $n_runs sampled run(s) actually concluded"
+    fi
+    if [ "$n_rej" -gt 0 ]; then
+      row "PASS" "10b. CI has rejected" "$n_rej failure(s) in $n_runs sampled — observed doing its job"
+    else
+      row "UNVERIFIED" "10b. CI has rejected" "no failures in $n_runs sampled run(s) — that is not 'never'. Widen with --runs N (this repo: 0 failures in 60, 1 in 200)"
+    fi
+  fi
+fi
+
+# --- E. Can the findings be acted on? -------------------------------------
+section "E. Actionability"
+
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  origin=$(git remote get-url origin 2>/dev/null || true)
+  if [ -n "$origin" ]; then
+    row "PASS" "12. remote" "origin: $origin (fork-vs-upstream: check push access before promising a fix)"
+  else
+    row "PARTIAL" "12. remote" "a git repo with no 'origin' — fixes cannot be pushed anywhere"
+  fi
+else
+  row "N/A" "12. remote" "not a git repository"
+fi
+
+# --- Result ---------------------------------------------------------------
+printf '\n%s\n' "PASS $n_pass · FAIL $n_fail · PARTIAL $n_partial · UNVERIFIED $n_unver · N/A $n_na"
+if [ "$n_unver" -gt 0 ]; then
+  echo "UNVERIFIED is not a soft PASS: nobody watched those work. Treat them as unknown."
+fi
+cat <<'EOF'
+Not covered here (a script cannot): whether the agent file's content is
+meaningful, and whether its factual claims are still true. Run the prompt in
+docs/VERIFY-SETUP.md for those, plus the one check nothing read-only can do —
+whether the secret gate actually REJECTS a commit.
+EOF
+[ "$n_fail" -eq 0 ]


### PR DESCRIPTION
Three items that were genuinely open, each validated by running it rather than
reading it.

## 1. `scripts/verify-setup.sh` — the deterministic half of VERIFY-SETUP.md

Open since the 2026-07-28 cycle. 14 checks, **strictly read-only**, exit 1 on any
FAIL: skills reachability *and whether the router is among them*, the three
always-on routing layers reported separately, profile symlinks resolving, a
licence under **any** name, which gate mechanisms exist, whether a hook is
**installed** rather than merely configured, and — from real run conclusions —
whether CI has ever *executed* and ever *rejected* anything. `--runs N` widens
the sample.

The read-only claim is **verified, not asserted**: hashing the file tree and
`git status` before and after a full run shows both unchanged.

The three checks a script cannot do (agent-file content, whether its claims are
still *true*, the routing dry-run) print as `N/A — judgement check` with a
pointer to the prompt, so the split is visible where you run it.

**Writing it found a bug in itself.** Check 8 used `git grep`, which reads only
**tracked** files — so an untracked `.pre-commit-config.yaml` configuring
gitleaks was reported as *no secret scanning*. A false FAIL on exactly the case
the doc names first ("on a repo you just scaffolded"), found by running the fail
path rather than reading the code.

**And it validated its own UNVERIFIED vocabulary.** On this repo, *has CI ever
rejected anything?* reads UNVERIFIED at the default 60-run sample (60/60 success)
and turns up **1 failure at 200**. "Not in the last 60" really is not "never".

## 2. The secret scan reported a denominator nobody read

`gitleaks` prints `179 commits scanned`, and the roadmap had carried *"still
unexamined: what gitleaks reports as its scope"* since 2026-07-30.

Examined — in a `--depth 1` clone of this repo:

```text
1 commits scanned.          (of 179)
no leaks found
exit 0
```

A green secret scan over **0.5% of history**, with `fetch-depth: 0` the only
thing preventing it and nothing asserting that.

CI now asserts the scope from `git rev-parse --is-shallow-repository`, **not**
from a commit count — and the reason is worth keeping: `git rev-list --count
HEAD` truncates to 1 in the same clone, so it *degrades alongside the scan it
would be checking*. The three available numbers disagree anyway (measured:
rev-list HEAD **175**, rev-list --all **181**, gitleaks **179**), so any equality
test would be flaky, and a flaky gate gets disabled. It also fails when gitleaks
prints no `N commits scanned` line at all: output we cannot parse means the scope
is no longer verified, which must not read as a pass.

Watched to fail on four paths: shallow clone · unparsable output · degenerate
1-commit count on a non-shallow tree · the real repo (pass).

## 3. `evals/_elapsed.py` — the runners report wall time

All 13 print `[<runner> elapsed 12.3s]`. Registered with `atexit` so the line
survives the `sys.exit(...)` several runners use on an empty corpus — the
fast-exit case most worth timing — and written to **stderr** so a runner whose
stdout is piped or parsed is not handed an extra line. **Printed, never gated**:
these call a remote API whose latency is not ours.

Verified on the two `--selftest` paths CI runs without an API key, plus
`py_compile` across all of `evals/`. **Still open and said so**: no recorded
baseline to compare a future run against.

## Not built, per the roadmap's own recorded verdicts

The SessionStart version check (phones home — *"not to be built without an
explicit call"*), `gh-sota` (deferred with reason), another audit-recall
instrument, the build-safe rebuild, relocating the other 18 judgment conventions,
and §2b's gate (still blocked on machine-readable capability names).

## Verification

- `./scripts/check-invariants.sh` → `PASS (13 checks)`
- `shellcheck -S warning scripts/*.sh` → clean, including the new script
- The workflow YAML parses (all 3 jobs intact) and the **shell CI will actually
  execute**, extracted from the parsed YAML, shellchecks clean
- `python3 -m py_compile evals/*.py` → all compile; both `--selftest` runners
  still PASS
