### PR TITLE
feat: occasional update reminder (no network), and cancel the gh-sota idea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`scripts/update-reminder.sh` — an occasional update nudge that makes no
+  network request.** Closes the *push* half of the update-notification item, open
+  since the 2026-07-28 cycle: symlinked skills update the moment you `git pull`,
+  but nothing ever told you to pull, and the plugin's first-run notice is
+  marker-guarded to fire once ever, so it is onboarding rather than a version
+  channel.
+  - **The phone-home question was dissolved, not answered.** The roadmap had this
+    blocked on "a `SessionStart` version check reaches passive users but phones
+    home — a deliberate privacy decision, not to be built without an explicit
+    call." The resolution is that the *benefit* — reminding you updates exist —
+    never needed the network. The hook cannot tell whether a new version exists,
+    only how long since it last spoke. A real check from every session start would
+    turn a documentation library into something that reports when and how often you
+    work; you run the check instead, and it is one command.
+  - **Verified, not asserted**: run under a `PATH` seeded with `curl`/`wget`/`git`/
+    `nc`/`ssh` stubs that report any invocation, it makes **zero** attempts. The
+    only external commands it uses are `find`, `tr`, `mkdir`, `printf`, `dirname`
+    and `pwd`.
+  - Silent on first run (a fresh install is current by definition), then at most one
+    message every `SOTA_UPDATE_REMINDER_DAYS` days (default 14, `0` disables). TTL
+    from the state file's **mtime** via `find -mtime` rather than date arithmetic,
+    because GNU `date -d` and BSD/macOS `date -v` disagree.
+  - **Fails open on every path**, because a `SessionStart` hook that errors degrades
+    the session it is attached to: unwritable data dir, missing `VERSION`, and
+    garbage in the interval env var were each tested and each exit 0.
+  - Reaches **both** install paths — the plugin via `hooks/hooks.json`, clone
+    installs via a new `setup_update_reminder` in `install.sh`. The installer path
+    was tested against a `settings.json` already holding the user's *own*
+    `SessionStart` hook: that hook and an unrelated `theme` key survive untouched,
+    and a second run adds nothing (idempotent).
 - **`scripts/verify-setup.sh` — the deterministic half of
   [docs/VERIFY-SETUP.md](docs/VERIFY-SETUP.md)**, open since the 2026-07-28 cycle.
   14 checks, strictly **read-only**, exit 1 on any FAIL: skills reachability and
@@ -40,6 +70,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line. **Printed, never gated**: these call a remote API whose latency is not ours,
   and a flaky gate gets disabled. Verified end-to-end on the two `--selftest` paths
   CI runs without an API key, plus `py_compile` across all of `evals/`.
+
+### Removed
+
+- **The `gh-sota` extension idea is cancelled, not deferred.** Its one real benefit
+  was update notification, now delivered directly by the `SessionStart` reminder
+  above — without a second repo, a shim, or a CLI nobody would invoke for a library
+  used *inside* an agent session. The original blocker stands and is kept in the
+  roadmap for why the shape never worked (gh requires a `gh-*` repo with a matching
+  root executable, so it could not live here). Closed rather than left deferred: a
+  deferred item whose rationale has died is indistinguishable, on a list, from a
+  live one.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,15 @@ starts "with a random delay of up to ten minutes", and the running session keeps
 versions it loaded at launch, so a refresh lands on `/reload-plugins` or your next
 launch — never mid-turn. Run `/plugin update` when you want a known-current library.
 
+**An occasional nudge, with no telemetry.** Nothing pushes updates on either path,
+so a `SessionStart` hook mentions — at most once every **14 days** — that your copy
+has been sitting for a while, and how to check. **It makes no network request.** It
+cannot tell whether a new version exists, only how long since it last spoke: the
+useful part was the reminder, and a real check from every session start would turn a
+documentation library into something that reports when and how often you work. You
+run the check. Installed by `install.sh` (clone) and by the plugin's own hook; silence
+it with `SOTA_UPDATE_REMINDER_DAYS=0`, or set your own interval in days.
+
 **Which version am I on?** `scripts/install.sh --version` reports the release, the
 checkout (`git describe`), whether your remote is ahead as of the last fetch, and
 whether the skills are symlinked (update live) or a pinned `--copy` snapshot. Quote

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -271,11 +271,21 @@ first.
   It now reads `VERSION` before and after the pull and prints the delta
   (`1.19.7 → 1.20.0 — see CHANGELOG.md`), and `--version` reports the release,
   checkout, upstream state as of the last fetch, and whether the install is
-  symlinked or a pinned `--copy` snapshot. What remains open is the *push* half:
-  nothing tells a passive user to pull in the first place. A `SessionStart`
-  version check would reach passive users but **phones home**; that is a
-  deliberate privacy decision, needs a TTL cache and must fail open, and is not
-  to be built without an explicit call.
+  symlinked or a pinned `--copy` snapshot. ~~What remains open is the *push*
+  half.~~ **DONE 2026-08-02 — and the phone-home question was dissolved rather
+  than answered.** `scripts/update-reminder.sh` runs on `SessionStart` and, at
+  most once every 14 days, tells the user their install is getting old and how to
+  check. **It makes no network request** — it cannot know whether a new version
+  exists, only how long since it last spoke. That is the point: the benefit was
+  *reminding you updates exist*, which needs no telemetry, and a real check from
+  every session start would turn a documentation library into something that
+  reports when and how often you work. The check stays manual and is one command
+  (`install.sh --update`). TTL from the state file's mtime (`find -mtime`, because
+  GNU `date -d` and BSD `date -v` disagree), silent on first run, opt-out with
+  `SOTA_UPDATE_REMINDER_DAYS=0`, and **fails open on every path** — unwritable
+  data dir, missing `VERSION`, garbage in the env. Reaches **both** install paths:
+  the plugin via `hooks/hooks.json`, clone installs via `install.sh`'s routing
+  setup (which is what the original item was actually about).
 - ~~**Nothing reports which version is in use.**~~ **Done 2026-07-30** —
   `scripts/install.sh --version` reports it (release from `VERSION`, `git
   describe`, upstream-ahead count as of the last fetch, symlink-vs-snapshot
@@ -301,7 +311,13 @@ first.
     (*has CI ever rejected anything?*) reads UNVERIFIED at the default 60-run
     sample — 60/60 success — and turns up **1 failure at 200**. "Not in the last
     60" really is not "never", and that is why `--runs` exists.
-- **`gh-sota` extension — considered and deferred, with reason.** gh requires the
+- ~~**`gh-sota` extension — considered and deferred, with reason.**~~ **CANCELLED
+  2026-08-02, not deferred.** Its one real benefit was update notification, and
+  that is now delivered directly by the SessionStart reminder below — without a
+  second repo, a shim, or a CLI nobody would invoke. Closing it rather than
+  leaving it "deferred" forever: a deferred item with a dead rationale is
+  indistinguishable from a live one on a list. Original reasoning, kept because it
+  is still why the shape never worked: gh requires the
   repo to be named `gh-*` with a root executable of the same name (verified in
   `gh extension --help`, 2.96.0), so it cannot live in this repo; it would need a
   thin shim repo delegating to `scripts/`. Its headline benefit does not

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/plugin-notice.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/update-reminder.sh\""
           }
         ]
       }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -218,6 +218,40 @@ setup_claude_md() {
   return 0
 }
 
+# A SessionStart hook that occasionally reminds the user updates exist. It makes
+# NO network request — see scripts/update-reminder.sh for why that is a design
+# choice and not a gap. This is the clone-install half of the update story:
+# symlinked skills update the moment you `git pull`, but nothing ever told you to
+# pull, and the plugin's first-run notice fires once ever so it is onboarding,
+# not a version channel.
+setup_update_reminder() {
+  local s="$HOME/.claude/settings.json" tmp cmd
+  cmd="\"$REPO/scripts/update-reminder.sh\""
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "jq not found — skipping update-reminder hook"; return
+  fi
+  if [ -f "$s" ] && jq -e --arg sig "update-reminder.sh" \
+      '[.hooks.SessionStart[]?.hooks[]?.command // ""] | any(contains($sig))' "$s" >/dev/null 2>&1; then
+    log "sota update-reminder hook already present — up to date"; return
+  fi
+  ask_yn "Add a SessionStart hook that reminds you to check for updates every ~14 days (no network calls)?" y || return
+  tmp="$(mktemp)"
+  if [ -e "$s" ]; then
+    backup "$s"
+    if jq --arg c "$cmd" '.hooks.SessionStart = ((.hooks.SessionStart // []) + [{hooks:[{type:"command",command:$c}]}])' "$s" >"$tmp" 2>/dev/null; then
+      cat "$tmp" >"$s"   # cat (not mv) so a symlinked settings.json keeps its link
+      log "added SessionStart update-reminder hook (silence it with SOTA_UPDATE_REMINDER_DAYS=0)"
+    else
+      warn "could not parse $s as JSON — left unchanged"
+    fi
+  else
+    mkdir -p "$(dirname "$s")"
+    jq -n --arg c "$cmd" '{hooks:{SessionStart:[{hooks:[{type:"command",command:$c}]}]}}' >"$s"
+    log "created ~/.claude/settings.json with the update-reminder hook"
+  fi
+  rm -f "$tmp"
+}
+
 setup_hook() {
   local s="$HOME/.claude/settings.json" tmp
   if ! command -v jq >/dev/null 2>&1; then
@@ -306,6 +340,7 @@ maybe_setup_routing() {
   # and the final instructions (2026-07-10 audit Q-MED-4).
   setup_claude_md || true
   setup_hook || true
+  setup_update_reminder || true
   return 0
 }
 

--- a/scripts/update-reminder.sh
+++ b/scripts/update-reminder.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# update-reminder.sh — an occasional nudge to check for a newer SOTA-skills.
+#
+# THIS SCRIPT MAKES NO NETWORK REQUEST. It does not contact GitHub, this repo, or
+# anything else; it cannot know whether a new version exists. All it knows is how
+# long it has been since it last said anything, and which version is installed
+# locally (read from the VERSION file next to it).
+#
+# That is a deliberate design choice, not a limitation to fix later. A real
+# version check has to phone home from every session start, which turns a
+# documentation library into something that reports when and how often you work.
+# The whole benefit here — reminding you that updates exist — needs none of that.
+# If you want the actual check, YOU run it, and it is one command:
+#
+#     scripts/install.sh --update      # pulls, then prints the version delta
+#
+# Behaviour: silent on first run (a fresh install is current by definition, and
+# the plugin's first-run notice is already speaking), then at most one line every
+# SOTA_UPDATE_REMINDER_DAYS days (default 14).
+#
+# Opt out completely:
+#     export SOTA_UPDATE_REMINDER_DAYS=0
+#
+# FAILS OPEN, ALWAYS. This runs on SessionStart; a hook that errors degrades the
+# session it is attached to. Every step is guarded and the script exits 0 no
+# matter what — an un-writable data dir, a missing VERSION, a read-only home.
+# The worst outcome is silence, which is also the correct outcome most days.
+set -uo pipefail
+
+# --- opt-out and interval -------------------------------------------------
+days="${SOTA_UPDATE_REMINDER_DAYS:-14}"
+case "$days" in
+  ''|*[!0-9]*) days=14 ;;   # garbage in the env must not break a session
+esac
+[ "$days" -eq 0 ] && exit 0
+
+# --- where we remember the last nudge -------------------------------------
+data="${CLAUDE_PLUGIN_DATA:-${HOME}/.claude/sota-skills-data}"
+stamp="${data}/.update-reminder-last"
+
+mkdir -p "$data" 2>/dev/null || exit 0
+
+# First run: record the moment and say nothing. A just-installed copy is current,
+# and the plugin's first-run notice is already using this turn.
+if [ ! -e "$stamp" ]; then
+  : > "$stamp" 2>/dev/null || true
+  exit 0
+fi
+
+# Older than the interval? `find -mtime` rather than date arithmetic: `date -d`
+# (GNU) and `date -v` (BSD/macOS) disagree, and this has to run on both.
+due=$(find "$stamp" -maxdepth 0 -mtime +"$days" 2>/dev/null) || exit 0
+[ -n "$due" ] || exit 0
+
+# --- what we can say without asking anyone --------------------------------
+here=$(unset CDPATH; cd -- "$(dirname -- "$0")/.." 2>/dev/null && pwd) || exit 0
+version=""
+[ -r "$here/VERSION" ] && version=$(tr -d '[:space:]' < "$here/VERSION" 2>/dev/null)
+
+: > "$stamp" 2>/dev/null || true   # reset the clock even if the message is thin
+
+printf '[sota-skills: occasional update reminder. Relay this to the user in one line, then continue with their request.]\n'
+if [ -n "$version" ]; then
+  printf 'SOTA-skills %s has been installed here for over %s days. No update check was made (this library never phones home).\n' "$version" "$days"
+else
+  printf 'SOTA-skills has been installed here for over %s days. No update check was made (this library never phones home).\n' "$days"
+fi
+printf 'If they want to check for a newer release: run `scripts/install.sh --update`, or browse https://github.com/martinholovsky/SOTA-skills/releases\n'
+printf 'To silence this: export SOTA_UPDATE_REMINDER_DAYS=0 (or set it to a different number of days).\n'
+exit 0


### PR DESCRIPTION
Closes the **push** half of the update-notification item, open since the
2026-07-28 cycle: symlinked skills update the moment you `git pull`, but nothing
ever told you to pull, and the plugin's first-run notice is marker-guarded to
fire *once ever*, so it is onboarding rather than a version channel.

## The phone-home question was dissolved, not answered

The roadmap had this blocked on: *"a `SessionStart` version check reaches passive
users but **phones home** — a deliberate privacy decision, not to be built
without an explicit call."*

The resolution is that the *benefit* — reminding you updates exist — never needed
the network. The hook **cannot tell whether a new version exists**, only how long
since it last spoke. A real check from every session start would turn a
documentation library into something that reports when and how often you work.
The check stays manual and is one command (`install.sh --update`).

**Verified, not asserted.** Run under a `PATH` seeded with `curl`/`wget`/`git`/
`nc`/`ssh` stubs that loudly report any invocation, it makes **zero** attempts.
The only external commands it uses are `find`, `tr`, `mkdir`, `printf`,
`dirname`, `pwd`.

## Behaviour

- **Silent on first run** — a fresh install is current by definition — then at
  most one message every `SOTA_UPDATE_REMINDER_DAYS` days (default 14, `0`
  disables).
- TTL from the state file's **mtime** via `find -mtime`, not date arithmetic:
  GNU `date -d` and BSD/macOS `date -v` disagree and this runs on both.
- **Fails open on every path**, because a `SessionStart` hook that errors
  degrades the session it is attached to. Unwritable data dir, missing `VERSION`,
  and garbage in the interval env var were each tested and each exit 0.

| Case | Result |
|---|---|
| First run | silent, exit 0 |
| Same day | silent, exit 0 |
| Stamp aged 20d | nudges once, resets the clock |
| Immediately after | silent again |
| `SOTA_UPDATE_REMINDER_DAYS=0` | silent (opt-out) |
| `=banana` | falls back to 14d, does not break the session |
| `=30` with a 20d stamp | silent (not due) |
| Unwritable data dir | silent, exit 0 |

## Reaches both install paths

The plugin via `hooks/hooks.json`; **clone installs** via a new
`setup_update_reminder` in `install.sh` — which is what the original roadmap item
was actually about. Tested against a `settings.json` already holding the user's
**own** `SessionStart` hook: that hook and an unrelated `theme` key survive
untouched, and a second run adds nothing (idempotent).

## `gh-sota` is cancelled, not deferred

Its one real benefit was update notification, now delivered directly — without a
second repo, a shim, or a CLI nobody would invoke for a library used *inside* an
agent session. The original blocker stands and is kept in the roadmap for why the
shape never worked (gh requires a `gh-*` repo with a matching root executable).
Closed rather than left deferred: a deferred item whose rationale has died is
indistinguishable, on a list, from a live one.

## Note

**Invariant 3 caught my own first draft** — the roadmap wording "the user runs
the check" is a reader-assumption phrase the library bans. Rephrased.

## Verification

- `./scripts/check-invariants.sh` → `PASS (13 checks)`
- `shellcheck -S warning scripts/*.sh` → clean
- `hooks/hooks.json` parses; both SessionStart commands present
