### PR TITLE
docs: the minor-vs-patch rule now matches 31 releases of practice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,10 +189,14 @@ pre-commit hook scans each commit locally.
   substring; assert a scripted edit landed; pin anything hand-mirrored from the
   library). Read it before changing anything under `evals/` — four harness changes in
   one day silently measured nothing while still printing plausible numbers
-- [docs/VERIFY-SETUP.md](docs/VERIFY-SETUP.md) — the **read-only setup check**: a
-  paste-in prompt that reports whether the library reaches a repo, whether its
-  agent file is *true*, and whether its gates are real rather than merely
-  configured. `init-gates.sh` sets a repo up; this is what checks the result
+- **The read-only setup check, in two halves** — `init-gates.sh` sets a repo up;
+  these check the result, because "configured" and "working" render identically.
+  `scripts/verify-setup.sh` does the mechanical half (skills reachable, hook
+  installed vs merely configured, licence under any name, whether CI has ever
+  *executed* and ever *rejected* — `--runs N` widens that sample);
+  [docs/VERIFY-SETUP.md](docs/VERIFY-SETUP.md) is the paste-in prompt for the half
+  a script cannot do — whether the agent file's content is meaningful and whether
+  its claims are still *true*
 - [docs/ADOPTION-LOG.md](docs/ADOPTION-LOG.md) — the **external-idea intake
   ledger**: every idea evaluated from an outside repo, paper, or review with a
   verdict and reason (adopted / rejected / deferred / superseded). A rejection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`RELEASING.md`'s minor-vs-patch rule now matches 31 releases of practice.** It
+  said *"adding a skill is a **minor** bump; fixes to existing content are a
+  **patch**"* — whose first half is exceptionless and whose second half misleads,
+  because it reads as *no new skill → patch*. Measured with `git ls-tree` across
+  every tag: **6** skill-adding releases, **all 6 minor** (so a skill is
+  *sufficient*), but **15 of 21 minors added no skill at all** (so it is never
+  *necessary*). The rule that actually separates them, spot-checked against six
+  releases: **minor when the library gains a new surface someone can *use*** — a
+  skill, a script or command, a hook, a cross-tool integration (v1.9.0's
+  `AGENTS.md` support), or a new eval instrument (v1.13.0, v1.14.0, v1.17.0,
+  v1.18.0); **patch when the change lives inside surfaces that already exist** —
+  rule text, docs, intakes, and, on the evidence, **a new CI invariant on its
+  own**: invariants 8, 9 and 11 each shipped in a *patch*. Invariants 12 and 13
+  rode a minor because that release also added two scripts and a hook. Tie-breaker
+  recorded for the next cut: does a reader of the release notes gain something new
+  to run? Found while cutting v1.20.0, where the old line would have argued for a
+  patch.
+- **`AGENTS.md` and `docs/INDEX.md` describe the setup check as the two halves it
+  now is.** Both still framed it as a paste-in prompt, which had been true for four
+  days: `scripts/verify-setup.sh` answers the mechanical half in a second and tells
+  the agent which checks are left. Both now say to run the script first.
+
 ## [1.20.0] - 2026-08-02
 
 **The reported-but-never-read release.** Every change here traces to the same

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,37 @@
 # Releasing
 
-How to cut a SOTA-skills release. Adding a skill is a **minor** bump (the
-library only ever adds); fixes to existing content are a **patch**. Everything
-lands through a PR — `main` is protected for everyone, including admins (see
-[AGENTS.md](AGENTS.md)).
+How to cut a SOTA-skills release. Everything lands through a PR — `main` is
+protected for everyone, including admins (see [AGENTS.md](AGENTS.md)).
+
+## Minor or patch?
+
+One line used to say *"adding a skill is a minor bump; fixes to existing content
+are a patch."* The first half is exceptionless. The second half misled at the
+v1.20.0 cut, because it reads as *no new skill → patch*, and that is not what this
+repo has ever done. Measured across all 31 releases (`git ls-tree` per tag):
+
+| | |
+|---|---|
+| Skill-adding releases | **6**, and **all 6 were minor** — the rule holds in that direction |
+| Minor bumps | **21** — so **15 of 21 added no skill at all** |
+| Patch bumps | **10**, none of which added a skill |
+
+So a new skill is **sufficient** for a minor and never **necessary**. What actually
+separates the 15 no-skill minors from the 10 patches, spot-checked against six of
+them (v1.9.0, v1.13.0, v1.14.0, v1.17.0, v1.18.0, v1.20.0):
+
+- **Minor — the library gains a new surface someone can *use*.** A skill, a script
+  or command (`v1.20.0`: `verify-setup.sh`, `update-reminder.sh`), a hook, a
+  cross-tool integration (`v1.9.0`: `AGENTS.md` support), or a new eval instrument
+  or harness (`v1.13.0`, `v1.14.0`, `v1.17.0`, `v1.18.0`).
+- **Patch — the change lives inside surfaces that already exist.** Rule text,
+  doc fixes, corrections, an intake, and — on the evidence — **a new CI invariant on
+  its own**: invariants 8, 9 and 11 each shipped in a patch (`v1.19.1`, `v1.19.5`,
+  `v1.19.9`). Invariants 12 and 13 rode a minor because that release also added two
+  scripts and a hook, not because they were invariants.
+
+When it is genuinely unclear, ask whether a *reader of the release notes gains
+something new to run*. If not, it is a patch.
 
 ## 1. Version-bearing files (every release)
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -12,7 +12,7 @@ trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issu
 | Understand how a prompt gets routed to skills | [README → How it works](../README.md#how-it-works); [`skills/sota/SKILL.md`](../skills/sota/SKILL.md) |
 | See example prompts (build & audit) | [README → Using it](../README.md#using-it) |
 | Enforce the rules as git hooks | [README → Enforcing the gates](../README.md#enforcing-the-gates) |
-| **Verify a repo is actually set up** (read-only check: library reaching it, agent file true, gates real not just configured) | [**VERIFY-SETUP.md**](VERIFY-SETUP.md) |
+| **Verify a repo is actually set up** (read-only: library reaching it, gates real not just configured, agent file *true*) | Run `scripts/verify-setup.sh` first (mechanical half), then [**VERIFY-SETUP.md**](VERIFY-SETUP.md) for the judgement half |
 | Use it with Codex / Gemini / other AGENTS.md agents | [README → Other AI agents](../README.md#other-ai-agents-codex-copilot-gemini-) |
 
 ## Keep the model applying the rules (context / "forgetting")


### PR DESCRIPTION
`RELEASING.md` said *"adding a skill is a **minor** bump; fixes to existing
content are a **patch**."* The first half is exceptionless. The second half
misleads, because it reads as *no new skill → patch* — and that is not what this
repo has ever done. It would have argued for a **patch** at the v1.20.0 cut.

## Measured, with `git ls-tree` across every tag

| | | |
|---|---|---|
| Skill-adding releases | **6** | all 6 were **minor** — a skill is *sufficient* |
| Minor bumps | **21** | **15 added no skill at all** — never *necessary* |
| Patch bumps | **10** | none added a skill |

## The line that actually separates them

Spot-checked against six releases (v1.9.0, v1.13.0, v1.14.0, v1.17.0, v1.18.0,
v1.20.0):

- **Minor — the library gains a new surface someone can *use*.** A skill; a script
  or command (v1.20.0: `verify-setup.sh`, `update-reminder.sh`); a hook; a
  cross-tool integration (v1.9.0's `AGENTS.md` support); a new eval instrument
  (v1.13.0, v1.14.0, v1.17.0, v1.18.0).
- **Patch — the change lives inside surfaces that already exist.** Rule text, doc
  fixes, intakes, and — on the evidence — **a new CI invariant on its own**.

That last point is the counter-intuitive one, so it was verified by reading the
CHANGELOG entries rather than assumed:

```text
invariant 8  -> 1.19.1  (PATCH)
invariant 9  -> 1.19.5  (PATCH)
invariant 11 -> 1.19.9  (PATCH)
invariant 12 -> 1.20.0  (MINOR)
invariant 13 -> 1.20.0  (MINOR)
```

12 and 13 rode a minor because that release *also* added two scripts and a hook —
not because they were invariants.

**Tie-breaker recorded for the next cut:** does a reader of the release notes gain
something new to run? If not, it is a patch.

## Also: two surfaces this week made stale

`AGENTS.md` and `docs/INDEX.md` both still described the setup check as a
paste-in prompt — true until four days ago. `scripts/verify-setup.sh` now answers
the mechanical half in a second and reports which checks are left to judgement.
Both now say to run the script first.

## Verification

- `./scripts/check-invariants.sh` → `PASS (13 checks)`
- Every number above re-derived from `git ls-tree` per tag, not from memory
- The first version of the invariant-8/9/11 check was a **broken awk range** that
  reported `0 mentions` for all three; the range self-terminated because the start
  line also matched the end pattern. Re-run correctly before any of it was written
  down.
