### PR TITLE
docs: validate the skills size limits against the spec — no byte cap, but a token budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   material to separate files"*, which is invariant 1 exactly, with `rules/*.md`
   being those separate files. **162 of 256 rules files exceed 200 lines and that is
   correct by design**; splitting them would work against the documented model.
+- **Validated against the Agent Skills spec: there is no byte cap for skills, but
+  the 500-line cap is a loose proxy for the one budget that exists.** Prompted by
+  the observation that `MEMORY.md`'s hard cap is *"200 lines **or** 25KB, whichever
+  comes first"* — so a few long lines can exhaust it well under 200 lines. Checked
+  whether the same shape applies to skills:
+  - **It does not, as a hard cap.** The spec's only hard limits are on frontmatter
+    (`name` ≤ 64, `description` ≤ **1024** — which confirms invariant 4 — and
+    `compatibility` ≤ 500). Of the body it says outright: *"There are no format
+    restrictions."* Nothing truncates a skill at load. And the 200-line/25KB rule is
+    scoped in the memory docs to `MEMORY.md` alone: *"This limit applies only to
+    `MEMORY.md`. CLAUDE.md files are loaded in full regardless of length."*
+  - **But the budget it stands in for is stated in tokens, not lines**:
+    *"Instructions (< 5000 tokens recommended)"*. Measured across this repo's **297**
+    skill files, line density varies **3.3×** (38–127 bytes/line, median 57), so a
+    500-line file lands anywhere between **~4,750 and ~15,870 tokens** — the median
+    density already puts it 42% over. **12 files exceed ~5,000 tokens and 11 of them
+    pass invariant 1 comfortably** (`sota-mobile/rules/07-swift-language.md`: 254
+    lines, half the cap, ~6,737 tokens).
+  - **Exactly one file breaches the recommendation where it applies** — the
+    `SKILL.md` body: `skills/sota/SKILL.md` at **~10,211 tokens**, 2× the budget,
+    at 500/500 lines with no slack. `rules/*.md` are stage-3 resources, for which
+    the spec gives no number.
+  - **Logged, not gated.** A byte-or-token check passes all three ledger filters but
+    would fail on `main` today, and the only fix is trimming a router with no line
+    slack — a design decision. Recorded in `docs/ROADMAP.md` with the explicit
+    caveat that `bytes/4` is a heuristic and a real tokenizer should be used before
+    acting on any specific number.
 - **`docs/CONTEXT-MANAGEMENT.md` records a platform behaviour none of the six
   defenses covers.** Auto-compaction *"re-attaches the most recent invocation of
   each skill after the summary, keeping the **first 5,000 tokens of each**"*, with a

--- a/docs/CONTEXT-MANAGEMENT.md
+++ b/docs/CONTEXT-MANAGEMENT.md
@@ -46,6 +46,51 @@ Fight the attention shape; don't out-muscle it with volume.
    an endpoint has no rate limiting or TLS moves the invariant out of "attention"
    entirely. ([README → Enforcing the gates](../README.md#enforcing-the-gates).)
 
+## The 500-line cap is a proxy, and a loose one (measured 2026-08-02)
+
+The Agent Skills specification states the budget in **tokens**, not lines:
+
+> **Progressive disclosure** — 1. Metadata (~100 tokens): `name` and `description`
+> loaded at startup for all skills. 2. **Instructions (< 5000 tokens recommended)**:
+> the full `SKILL.md` body is loaded when the skill is activated. 3. Resources (as
+> needed).
+>
+> Keep your main `SKILL.md` under 500 lines.
+
+Invariant 1 enforces the *line* half because lines are trivially checkable. But
+lines predict tokens only as well as line length allows, and across this repo's
+**297** skill files line density varies **3.3×** — 38 to 127 bytes per line, median
+57. So, by a `bytes/4` estimate:
+
+| A 500-line file at… | ≈ tokens | vs. the 5,000 recommendation |
+|---|---|---|
+| the sparsest observed density | ~4,750 | within budget |
+| the **median** density | ~7,118 | **42% over** |
+| the densest observed density | ~15,870 | **3× over** |
+
+**12 of 297 files already exceed ~5,000 tokens, and 11 of them pass invariant 1
+comfortably** — `sota-mobile/rules/07-swift-language.md` is 254 lines, half the cap,
+and ~6,737 tokens. A line cap cannot see that.
+
+Two things keep this from being urgent. The 5,000-token figure applies to the
+`SKILL.md` **body** (stage 2); for `rules/*.md`, which are stage-3 resources, the
+spec gives no number, only *"keep individual reference files focused — agents load
+these on demand, so smaller files mean less use of context."* And exactly **one**
+file breaches the recommendation where it actually applies: `skills/sota/SKILL.md`,
+the router, at **~10,211 tokens — 2× the budget** while sitting at exactly 500/500
+lines.
+
+There is no hard cap anywhere here. The spec's only hard limits are on frontmatter
+(`name` ≤ 64, `description` ≤ 1024 — invariant 4 — `compatibility` ≤ 500), and of the
+body it says outright: *"There are no format restrictions."* Nothing truncates a
+skill at load. What a token overrun costs is context, and — see below — survival
+across compaction.
+
+**Not gated, deliberately.** A byte-or-token check passes all three
+[CONVENTIONS-LEDGER](CONVENTIONS-LEDGER.md) filters, but it would fail on `main`
+today, and the only fix is trimming a router that has no line slack left. That is a
+design decision, not a mechanical one; it is logged in [ROADMAP.md](ROADMAP.md).
+
 ## A platform behaviour the six defenses do not cover (recorded 2026-08-02)
 
 Auto-compaction **truncates a re-attached skill**. Per the Claude Code skills
@@ -55,9 +100,14 @@ tokens of each**"*, and re-attached skills *"share a combined budget of 25,000
 tokens"*, filled from the most recently invoked — so older skills can be dropped
 entirely after a long session.
 
-That interacts with this library in a way none of the six defenses addresses,
-because they all fight *attention*, and this is *deletion*. A rough `bytes/4`
-estimate of what exceeds the per-skill 5,000-token cut:
+**That 5,000 is the same 5,000 as above, and the match is not a coincidence**: a
+`SKILL.md` written to the spec's recommended instruction budget survives a
+compaction intact, and one written past it is silently cut in half. The budget is
+sized to the format.
+
+This interacts with the library in a way none of the six defenses addresses, because
+they all fight *attention* and this is *deletion*. A rough `bytes/4` estimate of what
+exceeds the per-skill 5,000-token cut:
 
 | File | ~tokens |
 |---|---|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -116,7 +116,27 @@ first.
   index, so renaming or dropping the column fails closed instead of passing over zero
   rows. **The actionable set from written conventions is now empty.**
 - **`RELEASING.md` §2b's front-door grep stays blocked** on needing machine-readable
-  capability names per release — now the **only** remaining candidate.
+  capability names per release.
+- **NEW 2026-08-02: the router is 2× the spec's token budget, and invariant 1 cannot
+  see it.** The Agent Skills spec states the budget in **tokens** — *"Instructions
+  (< 5000 tokens recommended)"* — and enforces nothing; invariant 1 checks the
+  *line* half because lines are cheap to count. Measured across 297 skill files,
+  line density varies **3.3×** (38–127 bytes/line), so a 500-line file lands
+  anywhere between ~4,750 and ~15,870 tokens. **12 files already exceed ~5,000
+  tokens and 11 of them pass invariant 1 comfortably.** Exactly one breaches the
+  recommendation where it applies (the `SKILL.md` body): `skills/sota/SKILL.md` at
+  **~10,211 tokens**, at 500/500 lines with no slack. It matters twice over —
+  context cost, and Claude Code's compaction keeps only *"the first 5,000 tokens"*
+  of a re-attached skill, so half the router would not survive a summarization.
+  - A byte-or-token check passes all three ledger filters but **would fail on `main`
+    today**, and the only fix is trimming the router — a design decision, not a
+    mechanical one. The pre-existing trim candidates are recorded below (the
+    per-domain pass ordering in AUDIT step 3, the duplicated severity glossary in
+    step 6).
+  - **Unverified in practice**: `bytes/4` is a heuristic and the real tokenizer will
+    differ. Measure with a real tokenizer before acting on any specific number.
+  - Detail and the measurement table:
+    [CONTEXT-MANAGEMENT.md](CONTEXT-MANAGEMENT.md).
 - **The reimplement case set is documentation, never run**
   (`evals/cases/reimplement.jsonl`). If anyone ever runs it, the predictions written
   *before* any run exist in the case-file header and must be used rather than fresh


### PR DESCRIPTION
Prompted by a sharp observation: `MEMORY.md`'s hard cap is *"200 lines **or** 25KB,
whichever comes first"*, so a handful of long lines can exhaust it well under 200
lines. Does the same shape apply to skills?

## It does not, as a hard cap

The [Agent Skills spec](https://agentskills.io/specification)'s only hard limits are
on frontmatter:

| Field | Limit |
|---|---|
| `name` | 64 chars |
| `description` | **1024 chars** — confirms invariant 4 |
| `compatibility` | 500 chars |
| **body** | *"There are no format restrictions."* |

Nothing truncates a skill at load. And the 200-line/25KB rule is scoped in the
[memory docs](https://code.claude.com/docs/en/memory) to one file: *"This limit
applies only to `MEMORY.md`. CLAUDE.md files are loaded in full regardless of
length."*

## But the budget it stands in for is stated in tokens, not lines

> **Progressive disclosure** — … 2. **Instructions (< 5000 tokens recommended)**:
> the full `SKILL.md` body is loaded when the skill is activated.

Invariant 1 checks the *line* half because lines are cheap to count. Across this
repo's **297** skill files, line density varies **3.3×** (38–127 bytes/line, median
57), so by a `bytes/4` estimate:

| A 500-line file at… | ≈ tokens | vs. 5,000 |
|---|---|---|
| sparsest density | ~4,750 | within budget |
| **median** density | ~7,118 | **42% over** |
| densest density | ~15,870 | **3× over** |

**12 files already exceed ~5,000 tokens and 11 of them pass invariant 1
comfortably** — `sota-mobile/rules/07-swift-language.md` is 254 lines, *half* the
cap, and ~6,737 tokens. A line cap cannot see that.

**Exactly one file breaches the recommendation where it applies** (the `SKILL.md`
body): `skills/sota/SKILL.md` at **~10,211 tokens**, 2× the budget, at 500/500 lines
with no slack. `rules/*.md` are stage-3 resources, for which the spec gives no
number — only *"keep individual reference files focused."*

## The two 5,000s are the same number

The spec recommends `SKILL.md` instructions stay **< 5,000 tokens**; Claude Code's
compaction keeps *"the first 5,000 tokens"* of each re-attached skill. Not a
coincidence — a skill written to the budget survives a compaction intact, and one
past it is silently cut in half.

## Logged, not gated

A byte-or-token check passes all three [CONVENTIONS-LEDGER](docs/CONVENTIONS-LEDGER.md)
filters, but it **would fail on `main` today**, and the only fix is trimming a router
that has no line slack left. That is a design decision, not a mechanical one, so it
goes to the roadmap with the pre-existing trim candidates — and with an explicit
caveat that `bytes/4` is a heuristic and a real tokenizer should be used before
acting on any specific number.

## Verification

- `./scripts/check-invariants.sh` → `PASS (13 checks)`
- Every limit above quoted from the spec and the Claude Code docs, not from memory
- Density spread and the 12 over-budget files computed from the tree
