### PR TITLE
fix(skills): remove an XML tag from sota-dotnet's description; gate it in invariant 4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ one — lives in the script's own header, at the point of use, and the practical
 | 1 | a **skill** file (`skills/*/SKILL.md`, `skills/*/rules/*.md`) exceeds **500 lines** |
 | 2 | a `skills/*/rules/*.md` doesn't end with `## Audit checklist` |
 | 3 | an internal-name denylist hits (the library must stay generic) |
-| 4 | a `SKILL.md` `description` exceeds **1024 chars** (spec cap — loaders silently skip it) or is unquoted YAML containing `: ` |
+| 4 | a `SKILL.md` `description` exceeds **1024 chars** (spec cap — loaders silently skip it), is unquoted YAML containing `: `, or either `name`/`description` contains an **XML tag**; also a reserved word (`anthropic`, `claude`) in `name` |
 | 5 | `VERSION`, `plugin.json` and the CHANGELOG top entry disagree, or a tag is ahead of `VERSION` |
 | 6 | a count-bearing surface drifts from a recount of `skills/` (the social-preview pill and README alt are **"N+" floors**) |
 | 7 | a skill is missing from the router's routing table **or** its library map |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A skill description violated a documented constraint, found by applying this
+  repo's own absence-claim rule to itself.** `sota-dotnet`'s `description` contained
+  `Span<T>/Memory<T>` — C# generics, but `<T>` is also a well-formed XML start tag,
+  and Anthropic's Agent Skills reference states that `name` and `description`
+  *"Cannot contain XML tags"*. Rewritten as "Span and Memory" (965 → 963 chars).
+  - **How it surfaced is the point.** The claim under test was *"there is no hard
+    size cap for skills"* — an **absence claim**, and `skills/sota/rules/01` §5/§7
+    require a widened search **plus a second independent method**, because a narrow
+    search and a true absence are indistinguishable. The first source
+    (`agentskills.io/specification`) does not mention XML tags at all. Only the
+    second (`platform.claude.com` Agent Skills reference) carries that constraint —
+    and a reserved-word rule for `name` (`anthropic`, `claude`) that the spec page
+    also omits. One source would have missed both.
+  - The absence claim itself **held**, and the second source states it more
+    strongly than the first: *"No practical limit on bundled content… There's no
+    context penalty for bundled content that isn't used."*
+- **Invariant 4 now checks both new constraints** — an XML tag in `name` or
+  `description`, and a reserved word in `name`. Watched to fail on the real defect
+  (`XML TAG in description ['<T>', '<T>']`), on a synthetic `claude-golang` name
+  (`RESERVED WORD 'claude'`), and to pass on the clean tree. It stays inside
+  invariant 4 rather than becoming invariant 14: same file, same parse, same
+  failure mode — a description a loader silently mangles or rejects.
+
 ### Changed
 
 - **`AGENTS.md` is back under the platform's 200-line target** (234 → **170**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,10 @@ are marked "needs verification", never asserted.
 4. any `skills/*/SKILL.md` `description` over **1024 characters** (the Agent
    Skills cap) or written as an unquoted inline scalar containing `: ` —
    invalid YAML that makes loaders skip the skill; use `description: >-`.
+   Also rejected: an **XML tag** in `name` or `description`, and a reserved
+   word (`anthropic`, `claude`) in `name` — both stated in Anthropic's Agent
+   Skills reference. `sota-dotnet` carried `Span<T>/Memory<T>`, a well-formed
+   XML start tag, until 2026-08-02.
    (Check 4 needs `python3`, and is skipped with a warning if it is absent
    locally — CI always enforces it.)
 5. **version drift**: `VERSION`, `plugin.json`, and the CHANGELOG top entry

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -235,6 +235,22 @@ def get_desc(text):
                 err = "unquoted ':' in inline description (invalid YAML — use 'description: >-')"
             return rest.strip('\'"'), err        # plain / quoted single line
     return None, None
+def get_name(text):
+    m = re.match(r'---\n(.*?)\n---', text, re.S)
+    if not m:
+        return None
+    n = re.search(r'^name:\s*(.+)$', m.group(1), re.M)
+    return n.group(1).strip().strip('\'"') if n else None
+
+# Anthropic's Agent Skills reference states two constraints the agentskills.io
+# spec page does not: `name` and `description` "Cannot contain XML tags", and
+# `name` "Cannot contain reserved words: anthropic, claude". Found 2026-08-02 by
+# re-verifying an ABSENCE claim ("there is no size cap") against a SECOND
+# independent source, exactly as skills/sota/rules/01 sections 5 and 7 require --
+# and the second source is the only one that carries these. sota-dotnet's
+# description held `Span<T>/Memory<T>`, which is a well-formed XML start tag.
+XML_TAG = re.compile(r'<[A-Za-z/][^>]*>')
+RESERVED = ('anthropic', 'claude')
 for f in sorted(glob.glob('skills/*/SKILL.md')):
     d, err = get_desc(open(f, encoding='utf-8').read())
     if not d:
@@ -243,6 +259,17 @@ for f in sorted(glob.glob('skills/*/SKILL.md')):
         print(f"{err}: {f}"); bad = 1
     if len(d) > cap:
         print(f"OVER {cap} ({len(d)} chars): {f}"); bad = 1
+    hits = XML_TAG.findall(d)
+    if hits:
+        print(f"XML TAG in description {hits[:3]} (spec: descriptions cannot contain XML tags): {f}")
+        bad = 1
+    n = get_name(open(f, encoding='utf-8').read())
+    if n:
+        if XML_TAG.search(n):
+            print(f"XML TAG in name: {f}"); bad = 1
+        for w in RESERVED:
+            if w in n.lower():
+                print(f"RESERVED WORD '{w}' in name '{n}': {f}"); bad = 1
 sys.exit(1 if bad else 0)
 PY
   ); then

--- a/skills/sota-dotnet/SKILL.md
+++ b/skills/sota-dotnet/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   concurrency (ConfigureAwait, channels, cancellation, TPL), security (OWASP
   .NET, deserialization — BinaryFormatter removed in .NET 9, EF/Dapper SQL
   injection, ASP.NET Core auth, Data Protection, crypto), performance (GC,
-  Span<T>/Memory<T>, BenchmarkDotNet, Native AOT), and build/tooling/CI (dotnet
+  Span and Memory, BenchmarkDotNet, Native AOT), and build/tooling/CI (dotnet
   CLI, NuGet lockfiles & supply chain, Roslyn analyzers, nullable). Trigger
   keywords - C#, .NET, dotnet, ASP.NET Core, async, await, Task, record,
   nullable reference types, Span, EF Core, Dapper, LINQ, NuGet, Roslyn analyzer,


### PR DESCRIPTION
`sota-dotnet`'s `description` contained **`Span<T>/Memory<T>`**. Those are C#
generics — but `<T>` is also a well-formed XML start tag, and Anthropic's Agent
Skills reference states that `name` and `description` *"Cannot contain XML tags"*.
Rewritten as "Span and Memory" (965 → 963 chars).

## How it surfaced is the point

The claim under test was *"there is no hard size cap for skills"* — an **absence
claim**. This repo's own audit methodology (`skills/sota/rules/01` §5, §7) requires
a widened search **plus a second independent method** for exactly those, because a
narrow search and a true absence produce identical output.

| Source | XML-tag rule? | Reserved-word rule? |
|---|---|---|
| `agentskills.io/specification` | **not mentioned** | **not mentioned** |
| `platform.claude.com` Agent Skills reference | *"Cannot contain XML tags"* | *"Cannot contain reserved words: anthropic, claude"* |

**A single source would have missed both.** The rule that caught this is one the
library teaches, applied to itself.

The absence claim itself **held**, and the second source states it more strongly
than the first: *"No practical limit on bundled content… There's no context penalty
for bundled content that isn't used."*

## The gate

Invariant 4 now checks both constraints. It stays **inside invariant 4** rather than
becoming invariant 14 — same file, same parse, same failure mode: a description a
loader silently mangles or rejects.

Watched to fail first, in a throwaway worktree:

```text
real defect restored     exit 1   XML TAG in description ['<T>', '<T>']: skills/sota-dotnet/SKILL.md
synthetic claude-golang  exit 1   RESERVED WORD 'claude' in name 'claude-golang'
clean tree               exit 0   ok
```

## Scope note

The constraint is stated on the page governing the API and claude.ai upload paths;
Claude Code is filesystem-based and tolerates it today, which is why this never
surfaced as a visible failure. The risk is a user zipping the library and uploading
it, or a stricter validator later — a silently mangled `description` degrades
routing for that skill, which is the same silent-failure shape invariant 4 already
exists to prevent.

## Verification

- `./scripts/check-invariants.sh` → `PASS (13 checks)`
- `shellcheck -S warning scripts/check-invariants.sh` → clean
- All 41 skills re-scanned: 0 reserved words in names, 0 XML tags in names, 0
  remaining XML tags in descriptions
- Docs updated in the same change: invariant 4 row in `AGENTS.md`, invariant 4
  entry in `CONTRIBUTING.md`
