### PR TITLE
docs: test whether long rules files need a table of contents — they don't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Tested whether long rules files need a table of contents. They don't — so the
+  242-file sweep is off the table.** Anthropic's skill-authoring guidance says
+  reference files over 100 lines should carry a TOC *"even when previewing with
+  partial reads"*; **242 of this repo's rules files exceed 100 lines and none has
+  one**. Rather than assume, the *mechanism* was tested: four arms, one agent each,
+  an unguessable canary constant so a hit proves retrieval and not prior knowledge,
+  the prompt silent about position/length/TOCs, and the arm kept out of every path
+  (opaque workspace IDs — two agents in an earlier study read their arm from a
+  directory name).
+  - Control (434 lines, canary at 99% depth, no TOC): **found**. With a TOC:
+    **found**. Stress at **1,719 lines / 92 KB**, 4× the repo's longest rules file:
+    **found**, with the agent reporting the canary's exact line range.
+  - **The positive control is what makes it readable**: moving the canary to 1%
+    depth changed nothing, so there was no depth effect for a TOC to correct. Every
+    agent read the file whole — two said so unprompted. The TOC's only measurable
+    effect was **+183 tokens** of context.
+  - **Limits stated rather than implied**: *n* = 1 per arm, a pilot, deliberately
+    **not** on the scoreboard. It covers the `Read`-tool path on a directly named
+    file; the guidance's own trigger is *nested* references, which this library does
+    not have — `SKILL.md → rules/NN.md` is already the "one level deep" structure the
+    same guidance prescribes.
+
 ### Fixed
 
 - **A skill description violated a documented constraint, found by applying this

--- a/docs/CONTEXT-MANAGEMENT.md
+++ b/docs/CONTEXT-MANAGEMENT.md
@@ -46,6 +46,48 @@ Fight the attention shape; don't out-muscle it with volume.
    an endpoint has no rate limiting or TLS moves the invariant out of "attention"
    entirely. ([README → Enforcing the gates](../README.md#enforcing-the-gates).)
 
+## Do long rules files need a table of contents? Tested — no (pilot, 2026-08-02)
+
+Anthropic's skill-authoring guidance says: *"For reference files longer than 100
+lines, include a table of contents at the top. This ensures Claude can see the full
+scope of available information **even when previewing with partial reads**."* **242 of
+this repo's rules files exceed 100 lines and none carries a TOC**, so the question is
+whether that costs anything.
+
+It was tested rather than assumed, because the claim rests on a *mechanism* — partial
+reads — that may simply not occur here. Four arms, one agent each, an unguessable
+canary constant (`PROBE_QUARANTINE_RUNS = 17`) planted so a correct answer proves
+retrieval rather than prior knowledge. The prompt never mentions position, length or
+tables of contents, and **the arm is not encoded in any path** (opaque workspace IDs),
+because two agents in an earlier study read their arm out of a directory name.
+
+| Arm | File | Canary depth | TOC | Canary found | Tool calls |
+|---|---|---|---|---|---|
+| A control | 434 lines | 99% | no | **yes** | 1 |
+| B treatment | 446 lines | 99% | **yes** | **yes** | 1 |
+| C positive control | 434 lines | **1%** | no | **yes** | 1 |
+| D stress | **1,719 lines / 92 KB** | 99% | no | **yes** | 2 |
+
+**The positive control is what makes this readable.** Arm C moved the canary to the
+top; it scored identically to A, so there was no depth effect for a TOC to correct.
+The agents read the files whole — two said so unprompted ("read the file in full
+(434/446 lines)"), and arm D's agent reported the canary's exact line range in a
+1,719-line file. Arm B's only measurable effect was **+183 tokens** of context for the
+TOC itself.
+
+**Conclusion: the 242-file TOC sweep is not justified**, and would be pure added
+context cost at these lengths.
+
+**Limits, stated because they bound the claim.** *n* = 1 per arm — a pilot, not a
+result, and not on the scoreboard. It exercises one path: the `Read` tool in a Claude
+Code sub-agent on a **directly named** file. The guidance's own stated trigger is
+different — *"Claude may partially read files when they're referenced **from other
+referenced files**"* — i.e. nested references. That condition is untested here, and it
+does not arise in this library anyway, because `SKILL.md → rules/NN.md` is already the
+**one level deep** structure the same guidance prescribes. Finally, the canary sat
+after the `## Audit checklist` heading, which two agents flagged as anomalous; that
+salience may have aided detection.
+
 ## The 500-line cap is a proxy, and a loose one (measured 2026-08-02)
 
 The Agent Skills specification states the budget in **tokens**, not lines:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -117,6 +117,16 @@ first.
   rows. **The actionable set from written conventions is now empty.**
 - **`RELEASING.md` §2b's front-door grep stays blocked** on needing machine-readable
   capability names per release.
+- **CLOSED 2026-08-02: long rules files do NOT need a table of contents.** The
+  skill-authoring guidance recommends one for reference files over 100 lines
+  *"even when previewing with partial reads"*, and 242 of ours qualify with none.
+  Tested with a planted canary across four arms (control / TOC / positive control /
+  4× stress at 1,719 lines): **every arm retrieved it, every agent read the file
+  whole, and the positive control showed no depth effect for a TOC to correct**.
+  The sweep is not justified. *n*=1 per arm — a pilot, not on the scoreboard; it
+  covers direct `Read` calls, while the guidance's stated trigger is *nested*
+  references, which this library does not use. Detail:
+  [CONTEXT-MANAGEMENT.md](CONTEXT-MANAGEMENT.md).
 - **NEW 2026-08-02: the router is 2× the spec's token budget, and invariant 1 cannot
   see it.** The Agent Skills spec states the budget in **tokens** — *"Instructions
   (< 5000 tokens recommended)"* — and enforces nothing; invariant 1 checks the


### PR DESCRIPTION
Anthropic's skill-authoring guidance says reference files over 100 lines should
carry a TOC *"even when previewing with partial reads"*. **242 of this repo's rules
files exceed 100 lines and none has one** — so before running a 242-file sweep, the
question was whether it buys anything.

Tested rather than assumed, because the claim rests on a **mechanism** (partial
reads) that may simply not occur here.

## Design

An unguessable canary constant (`PROBE_QUARANTINE_RUNS = 17`) so a hit proves
*retrieval*, not prior knowledge. The prompt never mentions position, length, or
tables of contents. **The arm is not encoded in any path** — opaque workspace IDs,
because two agents in an earlier study read their arm out of a directory name.

| Arm | File | Canary depth | TOC | Found | Tool calls |
|---|---|---|---|---|---|
| control | 434 lines | 99% | no | **yes** | 1 |
| treatment | 446 lines | 99% | **yes** | **yes** | 1 |
| **positive control** | 434 lines | **1%** | no | **yes** | 1 |
| stress | **1,719 lines / 92 KB** | 99% | no | **yes** | 2 |

## Result

**The positive control is what makes this readable.** Moving the canary to 1% depth
changed nothing, so there was no depth effect for a TOC to correct. Every agent read
the file whole — two said so unprompted, and the stress arm's agent reported the
canary's exact line range in a file 4× the repo's longest. The TOC's only measurable
effect was **+183 tokens** of context.

**The sweep is not justified.**

## Limits, stated rather than implied

- **n = 1 per arm.** A pilot. Deliberately **not** on the scoreboard, and no
  `Samples` row claimed.
- Covers **one path**: the `Read` tool on a **directly named** file. The guidance's
  own trigger is different — *"Claude may partially read files when they're
  referenced **from other referenced files**"*. That condition is untested, and does
  not arise here anyway: `SKILL.md → rules/NN.md` is already the "one level deep"
  structure the same guidance prescribes.
- The canary sat after the `## Audit checklist` heading, which two agents flagged as
  anomalous; that salience may have aided detection.

## Verification

- `./scripts/check-invariants.sh` → `PASS (13 checks)`
