### PR TITLE
docs: one decision table for every size limit that governs the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **One decision table now settles every size question.**
+  `docs/CONTEXT-MANAGEMENT.md` gains *Size limits: what to actually do* — all ten
+  limits that govern this library, each marked **hard** or **recommendation**,
+  each with its verified source and a standing decision. Written because this
+  cycle produced findings across four documents and the useful form of that is one
+  table, not four narratives. The load-bearing entries: `description` is at
+  **1024/1024** with no slack, the router is at **500/500 lines** with no slack,
+  long `rules/*.md` are **correct by design**, and the router's 2× token overrun is
+  **accepted rather than restructured** — trimming it would break
+  `ROUTER_BUILD_SHA` and invalidate comparability with every historical +0.39 run,
+  while the compaction truncation it causes is self-healing on the next invocation.
 - **Tested whether long rules files need a table of contents. They don't — so the
   242-file sweep is off the table.** Anthropic's skill-authoring guidance says
   reference files over 100 lines should carry a TOC *"even when previewing with

--- a/docs/CONTEXT-MANAGEMENT.md
+++ b/docs/CONTEXT-MANAGEMENT.md
@@ -46,6 +46,43 @@ Fight the attention shape; don't out-muscle it with volume.
    an endpoint has no rate limiting or TLS moves the invariant out of "attention"
    entirely. ([README → Enforcing the gates](../README.md#enforcing-the-gates).)
 
+## Size limits: what to actually do (settled 2026-08-02)
+
+Every size number that governs this library, verified against three official sources
+(`agentskills.io/specification`, the `platform.claude.com` Agent Skills reference and
+its best-practices page, and the Claude Code memory/skills docs), with the standing
+decision for each. **Nothing here is a guess; where a number is a heuristic it says so.**
+
+| Limit | Kind | Us | Do |
+|---|---|---|---|
+| `name` ≤ 64 chars | **hard** | fine | nothing — gated (inv. 4) |
+| `description` ≤ 1024 chars | **hard** | router at **1024/1024** | **watch it** — no slack; any new domain in the description means trimming another |
+| no XML tags in `name`/`description` | **hard** | fixed 2026-08-02 | nothing — gated (inv. 4) |
+| no reserved words (`anthropic`, `claude`) in `name` | **hard** | fine | nothing — gated (inv. 4) |
+| `description` + `when_to_use` ≤ 1,536 in the listing | **hard** truncation | 1024, no `when_to_use` | nothing — 512 spare |
+| `SKILL.md` < 500 lines | recommendation | router at **500/500** | nothing — gated (inv. 1), but **no slack: the next router addition must trim first** |
+| `SKILL.md` body < 5,000 tokens | recommendation | router ≈ **9,945** (2×) | **accept, don't restructure** — see below |
+| `rules/*.md` length | **no budget** — stage-3 resources | 162 over 200 lines | nothing — **long is correct by design**; the spec says move detail *into* these |
+| TOC for reference files > 100 lines | recommendation | 242 without one | **skip** — tested, no retrieval benefit at 4× our longest file |
+| first 5,000 tokens kept on compaction re-attach | **hard** truncation | router loses ~half | **accept** — a later invocation reloads it in full |
+
+**Why the router stays as it is.** It is the one file exceeding a documented
+recommendation, and the temptation is to restructure it into the spec's "high-level
+guide with references" pattern. Three reasons not to, in order of weight:
+
+1. **It would invalidate the flagship number.** `ROUTER_BUILD_SHA` pins the BUILD
+   section that `run-completeness.py` mirrors; moving those steps into a referenced
+   file breaks comparability with every historical **+0.39** run.
+2. **The compaction truncation is self-healing.** It applies to the copy *carried
+   forward* past a summary. A subsequent invocation reads `SKILL.md` again in full —
+   and defense 5, the per-prompt routing directive, is what prompts that re-invocation.
+   (Inferred from the documented behaviour; not separately observed.)
+3. **The overrun costs context, not correctness.** Nothing truncates at load; all
+   three sources agree there is no hard size cap.
+
+Revisit only when the router must **grow** — it is at 500/500 lines, so growth forces
+a trim regardless, and that is the moment to do both at once.
+
 ## Do long rules files need a table of contents? Tested — no (pilot, 2026-08-02)
 
 Anthropic's skill-authoring guidance says: *"For reference files longer than 100


### PR DESCRIPTION
This cycle produced size findings across **four** official documents. The useful form of that is one table, not four narratives.

`docs/CONTEXT-MANAGEMENT.md` gains **Size limits: what to actually do** — all ten limits, each marked **hard** or **recommendation**, each with its verified source and a standing decision.

## The load-bearing entries

- `description` is at **1024/1024** — no slack; any new domain means trimming another
- `SKILL.md` is at **500/500 lines** — the next router addition must trim first
- long `rules/*.md` are **correct by design**; the spec says move detail *into* them
- the TOC recommendation is **skipped** — tested (#184) and shown to buy nothing here
- the router's 2× token overrun is **accepted, not restructured**

## Why the router stays

1. **It would invalidate the flagship number.** `ROUTER_BUILD_SHA` pins the BUILD section `run-completeness.py` mirrors; moving those steps breaks comparability with every historical **+0.39** run.
2. **The compaction truncation is self-healing** — it applies to the copy carried past a summary; a later invocation reloads `SKILL.md` in full. (Inferred from documented behaviour, labelled as such.)
3. **The overrun costs context, not correctness** — all three sources agree there is no hard size cap.

Revisit when the router must **grow**: it has no line slack either, so growth forces a trim regardless.
