### PR TITLE
feat(ci): invariant 14 — a release declares its front-door terms, and they resolve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ symlinks to it — edit only this file, never the symlinks.
 
 ## Invariants (enforced in pre-commit and CI)
 
-`scripts/check-invariants.sh` runs **13 checks** and fails the build on any of
+`scripts/check-invariants.sh` runs **14 checks** and fails the build on any of
 them. One line each below. The *rationale* — and the real incident behind every
 one — lives in the script's own header, at the point of use, and the practical
 "what this means for your PR" version is in
@@ -45,6 +45,7 @@ one — lives in the script's own header, at the point of use, and the practical
 | 11 | `LAST-VERIFIED` moves without a sweep. Escapes: a sweep-shaped diff (≥ 20 skill files) or naming it in the CHANGELOG. The only **diff-based** check; skips with a note when there's no merge base |
 | 12 | an `assets/*.png` is older than the `*.html` it renders — the README embeds the *image*, never the source, so an un-rendered fix reaches nobody. Escape: `[no-render]` in the commit subject |
 | 13 | a scoreboard row in `evals/results/RESULTS.md` leaves its `Samples` cell empty |
+| 14 | a **release** (VERSION changed) carries no `**Front door checked:**` line in its CHANGELOG section, or a declared term resolves in neither `README.md`/`docs/INDEX.md` nor the release's own entry |
 
 **Only instruction files are capped.** A file is capped if and only if an agent
 loads it *as instructions* — `skills/*/SKILL.md` and `skills/*/rules/*.md`, and
@@ -142,7 +143,7 @@ the setting. The pre-commit hook scans each commit locally.
   library handed back three proposals citing this repo's own `file:line` — the
   ledger takes those on the same terms, rejections included
 - [docs/CONVENTIONS-LEDGER.md](docs/CONVENTIONS-LEDGER.md) — which of this repo's
-  conventions are **enforced** (13 invariants + 4 more inside the eval runners) and
+  conventions are **enforced** (14 invariants + 4 more inside the eval runners) and
   which are prose, with the three filters a convention must pass to earn a gate
   (has it already failed · does it fail silently · is it mechanically checkable).
   Read it before proposing a new gate — it argues against gating the ~18 judgment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Invariant 14 — a release declares its front-door terms, and they resolve.**
+  Closes the last actionable candidate in
+  [docs/CONVENTIONS-LEDGER.md](docs/CONVENTIONS-LEDGER.md), which had it **blocked**
+  on *"needs a machine-readable capability list per release"*.
+  - **That objection was right, and is still right: discovery cannot be gated.**
+    Deciding what counts as a capability is judgement. What *can* be gated is the
+    **declaration** — the same move invariant 11 makes for `LAST-VERIFIED`, where
+    the escape is a claim that must be *true*. A release adds
+    `**Front door checked:** term · term` to its CHANGELOG section and the gate
+    proves every term resolves in `README.md`/`docs/INDEX.md` **and** appears in
+    that release's own entry — so a filler word cannot buy a pass.
+  - **Fires only when `VERSION` changes**, so it adds nothing to an ordinary PR.
+    The problem it fixes is release-time: invariant 6 fails on a wrong *number* in
+    the README, and nothing failed on a *capability* that never got a sentence —
+    five shipped across v1.17.0–v1.19.7 with zero README hits.
+  - **Watched to fail on five paths**: ordinary PR (skips, no ceremony), release
+    with no declaration (fails, naming the required line), a term in no front door
+    (fails, naming the term), a term absent from the release's own entry (fails),
+    and a valid release (passes, `ok (2 terms declared, all resolve)`).
+  - **The fail-watch found a real bug rather than confirming behaviour.** The first
+    cut read the *topmost* `## [` section, which is `[Unreleased]` when one still
+    sits above the new entry — so it reported "no declaration" for a release that
+    had one. It now selects the section matching `VERSION`. Case C failing for the
+    wrong reason is what exposed it.
+
 ### Changed
 
 - **One decision table now settles every size question.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,11 @@ are marked "needs verification", never asserted.
     effect: adding a row means stating its `n` (`3×, temp 0.7`, `1×`) — a number
     without one reads exactly like a number with one. A regression guard: it passes
     today and exists to keep it that way.
+14. **a release declares its front-door terms**: only fires when `VERSION`
+    changes, so an ordinary PR is unaffected. Practical effect: a release PR adds
+    `**Front door checked:** term · term` to its CHANGELOG section, and each term
+    must appear in `README.md` or `docs/INDEX.md` **and** in that release's own
+    entry. See [RELEASING.md](RELEASING.md) §2b for why.
 
 Secrets are scanned separately by **gitleaks** (config in `.gitleaks.toml`);
 CI scans the full git history, the pre-commit hook scans each commit.

--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). The short version: keep skills generic,
 verify fast-moving claims against primary sources, keep **skill** files
 (`skills/**`) ≤ 500 lines — that cap keeps incremental rule loading working and
 does not apply to README/CHANGELOG/`docs/`, which are read by humans — and end
-each rules file with an audit checklist. Thirteen invariants enforce this in
+each rules file with an audit checklist. Fourteen invariants enforce this in
 `scripts/check-invariants.sh` (pre-commit + CI), covering line caps, checklist
 placement, description limits, version and count drift, router completeness,
 internal link resolution, every rules file being reachable from its skill's index,

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -78,10 +78,10 @@ Then update every surface that carries a count:
   `how-it-works` was in #173. Full procedure and per-asset sizes:
   [CONTRIBUTING.md → Rendered assets](CONTRIBUTING.md#rendered-assets).
 
-## 2b. Front-door surfaces (every release) — no gate catches these
+## 2b. Front-door surfaces (every release) — now gated by invariant 14
 
-Invariant 6 fails the build on a wrong **number** in the README. **Nothing** fails
-on a capability that never got a sentence anywhere a reader looks. That gap is not
+Invariant 6 fails the build on a wrong **number** in the README. Until 2026-08-02
+**nothing** failed on a capability that never got a sentence anywhere a reader looks. That gap is not
 hypothetical: at the v1.19.7 cut, grepping `main` returned **0 hits** in `README.md`
 for `adversarial`, `refut`, `decision ledger`, `inert`, `no-op`, and `ADOPTION-LOG` —
 five capabilities shipped across v1.17.0–v1.19.7 with no front-door mention, and
@@ -96,9 +96,22 @@ grep -ic '<distinctive term>' README.md docs/INDEX.md
 Zero hits is a **documentation finding**, not a polish item — fix it in the release
 PR. `README.md` is the front door and is where a rule-level capability earns its
 sentence; `docs/INDEX.md` indexes *documents*, so a new rule inside an existing file
-usually belongs in the README's class list rather than as an INDEX row. It has now
-read zero at **two consecutive cuts** (v1.19.7, v1.19.9), which is the argument for
-the gate this section still lacks, not evidence the habit is taking. Two habits that go with it: say where a capability is *not* backed by a measured
+usually belongs in the README's class list rather than as an INDEX row. It read zero at **three consecutive cuts**
+(v1.19.7, v1.19.9, v1.20.0) — which was the argument for a gate, not evidence the
+habit was taking.
+
+**Invariant 14 now enforces the verification.** Add to the new version's CHANGELOG
+section:
+
+```text
+**Front door checked:** verify-setup · update-reminder · commits scanned
+```
+
+Every term must appear in `README.md` or `docs/INDEX.md` **and** in that release's own
+CHANGELOG entry, so a filler word cannot buy a pass. The check fires **only** when
+`VERSION` changes, so ordinary PRs are unaffected. It gates the *verification*, not
+the *discovery* — deciding what counts as a capability is still yours, and the grep
+above is still how you find them. Two habits that go with it: say where a capability is *not* backed by a measured
 number rather than letting the reader assume, and re-read the long-lived prose while
 you are there (that cut found "keep every file ≤ 500 lines" in both README and
 CONTRIBUTING, a cap that has been skill-files-only since PR #100).
@@ -151,5 +164,7 @@ skills.
       library map
 - [ ] **Front-door grep done (§2b)** — every capability this release added has a
       mention in README/`docs/INDEX.md`, and anything unbacked by a measured number
-      says so
+      says so. Then record it: **invariant 14 fails the build** unless the new
+      CHANGELOG section carries `**Front door checked:** term · term` and every term
+      resolves
 - [ ] GitHub Settings social-preview re-upload — only if the PNG changed

--- a/docs/CONVENTIONS-LEDGER.md
+++ b/docs/CONVENTIONS-LEDGER.md
@@ -25,7 +25,7 @@ item).
 | Raw entries | 49 |
 | Duplicates (the invariant list appears in both `AGENTS.md` and `CONTRIBUTING.md`) | 8 |
 | **Distinct conventions** | **41** |
-| Already enforced as invariants | 13 (11 when this ledger was derived) |
+| Already enforced as invariants | 14 (11 when this ledger was derived) |
 
 An earlier estimate of "~122" came from a loose regex that matched any bold line or
 any line containing *must/never/always*. It was an over-count by ~3×, and is
@@ -47,7 +47,7 @@ A convention earns a gate only if it passes **all three**:
 
 ## The ledger
 
-### Enforced (13) — invariants 1–13
+### Enforced (14) — invariants 1–14
 
 Skill-file line cap · audit-checklist placement · internal-name denylist · description cap ·
 version lockstep · count surfaces · router completeness · link resolution ·
@@ -104,11 +104,23 @@ is small" is therefore a statement about *written* conventions only. A second so
 of candidates exists and is not searchable: things this repo does by habit and has
 never said out loud, which surface only when one of them fails.
 
-### Gateable but not gated (1 candidate)
+### Gateable but not gated (0 candidates)
 
 | Candidate | Incident? | Silent? | Checkable? | Verdict |
 |---|---|---|---|---|
-| Front-door capability grep (`RELEASING.md` §2b) | **yes** — five capabilities shipped with no README mention | **yes** — nothing errors | **no** — needs a machine-readable capability list per release | **blocked**, recorded in ROADMAP |
+| Front-door capability grep (`RELEASING.md` §2b) | **yes** — five capabilities shipped with no README mention | **yes** — nothing errors | ~~**no**~~ → **yes** | **GATED 2026-08-02 as invariant 14** |
+
+**How the block came off.** This sat blocked on *"needs a machine-readable
+capability list per release"* — true, and still true: **discovery cannot be
+gated**, because "what counts as a capability" is judgement. What can be gated is
+the **declaration**, which is the same move invariant 11 makes for `LAST-VERIFIED`:
+the escape is a claim that must be *true*. A release states its front-door terms
+and the gate proves each one resolves — in `README.md`/`docs/INDEX.md` **and** in
+the release's own entry, so a filler word cannot buy a pass. The residual risk is a
+deliberately gamed declaration, which is a different failure from the oversight
+this fixes.
+
+**The actionable set from written conventions is now empty.**
 
 **Closed 2026-08-02: the Samples-column guard shipped as invariant 13.** It was
 this ledger's one actionable candidate — *every scoreboard row declares its sample

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -2,7 +2,7 @@
 
 The library's value is that its fast-moving claims (versions, CVEs, RFCs,
 specs, GA states, tool status, standards) hold up against primary sources.
-CI enforces *structure* (the 13 invariants in `scripts/check-invariants.sh` +
+CI enforces *structure* (the 14 invariants in `scripts/check-invariants.sh` +
 gitleaks + shellcheck) but **cannot** verify that a claim is *true* — that
 needs web access and judgment. This file is the human/agent process that
 covers the accuracy dimension CI can't, plus how efficacy is measured.
@@ -95,7 +95,7 @@ grow the golden sets as coverage warrants.
 
 | Dimension | Gate | Automated? |
 |---|---|---|
-| Structure (skill-file line cap, checklist-last, description cap, counts, router completeness, link resolution, rules-file indexing, `LAST-VERIFIED` pairing, rendered-asset currency, scoreboard sample sizes) | `check-invariants.sh` (**13 checks**) | Yes — pre-commit + CI |
+| Structure (skill-file line cap, checklist-last, description cap, counts, router completeness, link resolution, rules-file indexing, `LAST-VERIFIED` pairing, rendered-asset currency, scoreboard sample sizes, release front-door terms) | `check-invariants.sh` (**14 checks**) | Yes — pre-commit + CI |
 | Secrets | gitleaks (full history) | Yes — CI |
 | Shell quality | shellcheck | Yes — CI |
 | Claim **accuracy** | this runbook + `LAST-VERIFIED` | No — human/agent, monthly red-flag |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -115,8 +115,16 @@ first.
   implementation finds the table by its `Samples` **header** rather than a column
   index, so renaming or dropping the column fails closed instead of passing over zero
   rows. **The actionable set from written conventions is now empty.**
-- **`RELEASING.md` §2b's front-door grep stays blocked** on needing machine-readable
-  capability names per release.
+- ~~**`RELEASING.md` §2b's front-door grep stays blocked**~~ **CLOSED 2026-08-02 —
+  shipped as invariant 14.** It was blocked on *"needs a machine-readable capability
+  list per release"*, which was true and still is: **discovery cannot be gated**,
+  because what counts as a capability is judgement. What *can* be gated is the
+  **declaration** — the same move invariant 11 makes for `LAST-VERIFIED`. A release
+  states its front-door terms and the gate proves each resolves, in
+  `README.md`/`docs/INDEX.md` **and** in the release's own entry. Fires only when
+  `VERSION` changes, so ordinary PRs are untouched. **The actionable set from
+  written conventions is now empty** — the next gate will come from an incident,
+  not from re-reading the docs.
 - **CLOSED 2026-08-02: long rules files do NOT need a table of contents.** The
   skill-authoring guidance recommends one for reference files over 100 lines
   *"even when previewing with partial reads"*, and 242 of ours qualify with none.

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -145,7 +145,7 @@ comparison to anyone else required.
    `file:line | rule violated | severity | effort | fix` and maps to a standard
    (CWE, OWASP, MITRE ATT&CK/ATLAS) where one applies.
 
-4. **CI-gated library quality.** Thirteen invariants
+4. **CI-gated library quality.** Fourteen invariants
    ([`check-invariants.sh`](../scripts/check-invariants.sh)) block a bad change at
    the door: every **skill** file ≤ 500 lines — `skills/*/SKILL.md` and
    `skills/*/rules/*.md`, the files an agent actually loads, and nothing else (so

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -60,6 +60,14 @@
 #      check 10 — all 10 rows pass today. Shape-driven (finds the table by its
 #      "Samples" header), so a renamed or dropped column fails closed instead of
 #      passing over zero rows.
+#  14. A release declares its front-door terms, and they resolve. Invariant 6 fails
+#      on a wrong NUMBER in the README; nothing failed on a CAPABILITY that never
+#      got a sentence anywhere a reader looks -- five shipped across v1.17.0-v1.19.7
+#      with zero README hits. Discovery ("what counts as a capability") is judgement
+#      and cannot be gated; DECLARATION can, so a release must carry
+#      "**Front door checked:** a · b" in its CHANGELOG section, and every term must
+#      resolve in README.md or docs/INDEX.md AND appear in that release's own entry.
+#      DIFF-based, release commits only — silent on an ordinary PR.
 #
 # ADDING A CHECK? Three things this file learned the hard way — all from real
 # incidents recorded in the checks below:
@@ -121,7 +129,7 @@ scope() {  # <count> <noun> — returns 1 on an empty scope; prints nothing on s
 # CHANGELOG, docs/, evals/, AGENTS.md, these scripts -- is prose or code read by
 # people, deliberately uncapped since 2026-07-15; navigability there comes from a
 # table of contents and docs/INDEX.md, not a line ceiling.
-echo "[1/13] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
+echo "[1/14] Skill Markdown (skills/**) <= ${MAX_LINES} lines"
 over=0
 seen1=0
 while IFS= read -r f; do
@@ -138,7 +146,7 @@ scope "$seen1" "skill files" || over=1
 if [ "$over" -eq 0 ]; then echo "    ok ($seen1 skill files)"; else fail=1; fi
 
 # --- 2. Audit checklist ends every rules file ------------------------------
-echo "[2/13] Every skills/*/rules/*.md ends with an '## Audit checklist'"
+echo "[2/14] Every skills/*/rules/*.md ends with an '## Audit checklist'"
 missing=0
 seen2=0
 while IFS= read -r f; do
@@ -169,7 +177,7 @@ if [ "$missing" -eq 0 ]; then echo "    ok ($seen2 rules files)"; else fail=1; f
 # .denylist.local (git-ignored, one ERE per line, '#' comments). When neither
 # exists (e.g. an external fork's PR), only the generic phrases are checked —
 # the maintainer's pre-commit hook and this repo's CI carry the full list.
-echo "[3/13] No internal-name leaks"
+echo "[3/14] No internal-name leaks"
 DENY='the user runs|the user operates'
 if [ -n "${SOTA_DENYLIST:-}" ]; then
   DENY="$DENY|$SOTA_DENYLIST"
@@ -205,7 +213,7 @@ fi
 # Code, Codex, ...) skip any skill that exceeds it. Count Unicode characters
 # (descriptions use em-dashes: 1 char, 3 bytes) via python3, parsing both
 # folded block scalars (`>-`) and plain single-line descriptions.
-echo "[4/13] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
+echo "[4/14] Every skills/*/SKILL.md description <= ${MAX_DESC} characters"
 if command -v python3 >/dev/null 2>&1; then
   if desc_out=$(python3 - "$MAX_DESC" <<'PY'
 import sys, glob, re
@@ -286,7 +294,7 @@ fi
 # One version, four places: VERSION, plugin.json, the CHANGELOG's top entry,
 # and (after the release lands) the newest v* tag. Drift here shipped a main
 # briefly claiming 1.8.0 with 1.9.0 content (2026-07-03) — hence a hard check.
-echo "[5/13] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
+echo "[5/14] Version lockstep (VERSION == plugin.json == CHANGELOG top; tag not ahead)"
 v5=0
 ver=$(tr -d '[:space:]' < VERSION)
 # Strict X.Y.Z: rejects interior malformations (1..2, 1.2, 1.2.3.4) the old
@@ -320,7 +328,7 @@ if [ "$v5" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # rot on surfaces nobody recounts (the social preview said "30 skills" for
 # three releases). Recount from the tree and compare every tracked surface;
 # RELEASING.md lists the same surfaces for manual release edits.
-echo "[6/13] Count-bearing surfaces match the tree"
+echo "[6/14] Count-bearing surfaces match the tree"
 v6=0
 ck() { # ck <found> <expected> <surface>
   [ "$1" = "$2" ] || { note "$3: says '${1:-<not found>}', tree says '$2'"; v6=1; }
@@ -366,7 +374,7 @@ if [ "$v6" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # library-map entry must name a real skill dir. Catches the drift the
 # 2026-07-10 audit found: sota-confidential-computing was added to the table
 # but missing from the map for a full release.
-echo "[7/13] Router lists every skill (routing table + library map)"
+echo "[7/14] Router lists every skill (routing table + library map)"
 v7=0
 seen7=0
 router=skills/sota/SKILL.md
@@ -394,7 +402,7 @@ if [ "$v7" -eq 0 ]; then echo "    ok ($seen7 domain skills)"; else fail=1; fi
 # with no rot-catching upside. Fenced AND inline code are stripped so link-shaped
 # examples (in ``` fences or `backticks`) are not scanned. Idea from vault-doctor
 # (training-knowledge-vault); see docs/ADOPTION-LOG.md.
-echo "[8/13] Internal Markdown links resolve (*.md targets)"
+echo "[8/14] Internal Markdown links resolve (*.md targets)"
 if command -v python3 >/dev/null 2>&1; then
   if link_out=$(python3 - <<'PY'
 import os, re, sys
@@ -440,7 +448,7 @@ fi
 # previous release (2026-07-28) and both sat on main until a human noticed
 # during the release cut. Fence-aware, like check 2: a CHANGELOG entry may
 # legitimately quote '## [Unreleased]' inside a code fence.
-echo "[9/13] CHANGELOG has at most one [Unreleased], and it is the top entry"
+echo "[9/14] CHANGELOG has at most one [Unreleased], and it is the top entry"
 v9=0
 changelogs="CHANGELOG.md $(git ls-files 'docs/CHANGELOG-archive*.md' | tr '\n' ' ')"
 for cl in $changelogs; do
@@ -486,7 +494,7 @@ if [ "$v9" -eq 0 ]; then echo "    ok"; else fail=1; fi
 # to ourselves. All 255 rules files passed when this landed, so it is a
 # regression gate, not a repair; it was watched to fail on an injected file
 # and on a renamed reference before being trusted.
-echo "[10/13] Every skills/*/rules/*.md is referenced by its own SKILL.md"
+echo "[10/14] Every skills/*/rules/*.md is referenced by its own SKILL.md"
 v10=0
 seen10=0
 while IFS= read -r rf; do
@@ -529,7 +537,7 @@ if [ "$v10" -eq 0 ]; then echo "    ok ($seen10 rules files indexed)"; else fail
 # This is the first DIFF-based invariant; every other check reads the whole tree.
 # With no merge base it skips with a note rather than guessing, like checks 4/8.
 SWEEP_MIN_SKILL_FILES=20
-echo "[11/13] LAST-VERIFIED moves only with a sweep (batched diff, or declared in CHANGELOG)"
+echo "[11/14] LAST-VERIFIED moves only with a sweep (batched diff, or declared in CHANGELOG)"
 v11=0
 base=""
 for ref in origin/main main; do
@@ -602,7 +610,7 @@ if [ "$v11" -ne 0 ]; then fail=1; fi
 #
 # HISTORY-based, like check 11's diff: with no commit history for a pair it skips
 # with a note rather than guessing, because a shallow clone must not read as a pass.
-echo "[12/13] Rendered assets: each assets/*.png is no older than its *.html"
+echo "[12/14] Rendered assets: each assets/*.png is no older than its *.html"
 v12=0
 seen12=0
 checked12=0
@@ -675,7 +683,7 @@ if [ "$v12" -ne 0 ]; then fail=1; fi
 # column and checks that column in every data row beneath it. So it also fails when
 # the column is RENAMED or dropped (0 tables -> SCOPE EMPTY), which is the drift a
 # hardcoded column index would sail straight past.
-echo "[13/13] Every scoreboard row declares its sample size"
+echo "[13/14] Every scoreboard row declares its sample size"
 v13=0
 BOARD="evals/results/RESULTS.md"
 if [ ! -f "$BOARD" ]; then
@@ -721,11 +729,94 @@ else
 fi
 if [ "$v13" -ne 0 ]; then fail=1; fi
 
+# --- 14. A release declares its front-door terms, and they resolve ---------
+# Invariant 6 fails on a wrong NUMBER in the README. Nothing failed on a
+# capability that never got a sentence anywhere a reader looks: at the v1.19.7 cut,
+# `adversarial`, `refut`, `decision ledger`, `inert`, `no-op` and `ADOPTION-LOG` all
+# returned ZERO hits in README.md — five capabilities shipped across three releases
+# with no front-door mention. RELEASING.md section 2b has prescribed the grep since,
+# and it has caught something at THREE consecutive cuts, which is the argument for a
+# gate rather than evidence the habit sticks.
+#
+# DISCOVERY IS NOT MECHANIZABLE -- "what counts as a capability" is judgement, which
+# is why this candidate sat blocked in docs/CONVENTIONS-LEDGER.md. DECLARATION IS.
+# So this gates the verification, not the discovery, exactly as invariant 11 gates
+# LAST-VERIFIED with escapes that are declarations which must be TRUE.
+#
+# Only fires on a RELEASE commit (VERSION changed against the merge base), so it adds
+# nothing to an ordinary PR. On a release it requires, in the new version's CHANGELOG
+# section, a line of the form:
+#
+#     **Front door checked:** term one · term two · term three
+#
+# and then verifies every term BOTH ways: it must appear in README.md or
+# docs/INDEX.md (the front door is real), AND in that release's own CHANGELOG section
+# (you cannot pass by declaring a filler word that was never part of the release).
+# A missing line on a release commit fails closed.
+echo "[14/14] A release declares its front-door terms, and they resolve"
+v14=0
+base14=""
+for ref in origin/main main; do
+  if git rev-parse --verify -q "$ref" >/dev/null 2>&1; then
+    base14=$(git merge-base HEAD "$ref" 2>/dev/null || true)
+    [ -n "$base14" ] && break
+  fi
+done
+if [ -z "$base14" ] || [ "$base14" = "$(git rev-parse HEAD)" ]; then
+  note "SKIPPED (no merge base to diff against, or nothing ahead of it)"
+  echo "    ok (skipped)"
+elif ! git diff --name-only "$base14"...HEAD | grep -qx 'VERSION'; then
+  echo "    ok (not a release commit — VERSION unchanged)"
+else
+  # The release section is the one matching VERSION -- NOT the topmost '## ['
+  # heading. Keying on the top heading read [Unreleased] instead when one still sat
+  # above the new entry, and reported "no declaration" for a release that had one.
+  # Found by watching case C fail for the wrong reason.
+  ver=$(tr -d '[:space:]' < VERSION)
+  sec=$(awk -v v="## [$ver]" 'index($0,v)==1{f=1;print;next} f&&/^## \[/{exit} f{print}' CHANGELOG.md)
+  if [ -z "$sec" ]; then
+    note "VERSION is $ver but CHANGELOG.md has no '## [$ver]' section to check"
+    v14=1
+    sec=""
+  fi
+  decl=$(printf '%s\n' "$sec" | grep -i '\*\*Front door checked:\*\*' || true)
+  if [ -z "$decl" ]; then
+    note "VERSION changed but this release declares no front-door check."
+    note "  Add to the new CHANGELOG section (RELEASING.md section 2b):"
+    note "    **Front door checked:** <term> · <term>"
+    note "  Each term must appear in README.md or docs/INDEX.md, and in this section."
+    v14=1
+  else
+    terms=$(printf '%s\n' "$decl" | sed 's/.*\*\*[Ff]ront door checked:\*\*//' \
+      | tr '·,;' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//; s/^[`*]*//; s/[`*.]*$//' \
+      | grep -v '^$' || true)
+    n_terms=0
+    while IFS= read -r t; do
+      [ -n "$t" ] || continue
+      n_terms=$((n_terms + 1))
+      if ! grep -qi -- "$t" README.md docs/INDEX.md 2>/dev/null; then
+        note "NO FRONT DOOR: \"$t\" appears in neither README.md nor docs/INDEX.md"
+        v14=1
+      fi
+      # Guard against declaring a word that was never part of this release.
+      if ! printf '%s\n' "$sec" | grep -v '\*\*[Ff]ront door checked:\*\*' | grep -qi -- "$t"; then
+        note "NOT IN THIS RELEASE: \"$t\" is declared but absent from the release's own entry"
+        v14=1
+      fi
+    done <<EOF
+$terms
+EOF
+    scope "$n_terms" "declared front-door terms" || v14=1
+    if [ "$v14" -eq 0 ]; then echo "    ok ($n_terms terms declared, all resolve)"; fi
+  fi
+fi
+if [ "$v14" -ne 0 ]; then fail=1; fi
+
 # --- Result ---------------------------------------------------------------
 echo
 if [ "$fail" -ne 0 ]; then
   echo "FAIL: repository invariants violated (see above)."
   exit 1
 fi
-printf 'PASS: all repository invariants satisfied (13 checks over %s skill files / %s rules files, %ss).\n' \
+printf 'PASS: all repository invariants satisfied (14 checks over %s skill files / %s rules files, %ss).\n' \
   "${seen1:-?}" "${seen2:-?}" "$((SECONDS - START_SECONDS))"


### PR DESCRIPTION
Closes the **last actionable candidate** in
[docs/CONVENTIONS-LEDGER.md](docs/CONVENTIONS-LEDGER.md), which had it **blocked** on
*"needs a machine-readable capability list per release."*

## That objection was right, and still is

**Discovery cannot be gated** — deciding what counts as a capability is judgement.
What *can* be gated is the **declaration**, which is the same move invariant 11 makes
for `LAST-VERIFIED`: the escape is a claim that must be **true**.

A release adds one line to its CHANGELOG section:

```text
**Front door checked:** verify-setup · update-reminder · commits scanned
```

and the gate proves every term resolves in `README.md`/`docs/INDEX.md` **and** appears
in that release's own entry — so a filler word cannot buy a pass.

**Fires only when `VERSION` changes**, so it adds nothing to an ordinary PR. The
problem is release-time: invariant 6 fails on a wrong *number* in the README, and
nothing failed on a *capability* that never got a sentence. Five shipped across
v1.17.0–v1.19.7 with zero README hits, and §2b's manual grep has now caught something
at **three consecutive cuts** (v1.19.7, v1.19.9, v1.20.0) — the argument for a gate,
not evidence the habit sticks.

## Watched to fail on five paths

| Case | Result |
|---|---|
| Ordinary PR (`VERSION` untouched) | **skip** — no ceremony |
| Release, no declaration | exit 1 — names the required line |
| Declared term in no front door | exit 1 — `NO FRONT DOOR: "widget-inspector"` |
| Declared term absent from the entry | exit 1 — `NOT IN THIS RELEASE: "verify-setup"` |
| Valid release | exit 0 — `ok (2 terms declared, all resolve)` |

**The fail-watch found a real bug rather than confirming behaviour.** The first cut
read the *topmost* `## [` section — which is `[Unreleased]` when one still sits above
the new entry — so it reported "no declaration" for a release that had one. It now
selects the section matching `VERSION`. Case C failing *for the wrong reason* is what
exposed it.

## Two process notes, recorded because they cost time

- A **stale worktree registration** made a test run against the real repo and commit
  test data to the branch. Caught immediately and reset; every later step asserts it
  is inside the worktree before touching anything.
- A **scripted header edit silently did not apply** — caught by re-reading the file
  rather than trusting the script's success message, which is the repo's own *"assert
  a scripted edit landed"* convention.

## Docs updated in the same change

`RELEASING.md` §2b (no longer *"no gate catches these"*, and its stale *"two
consecutive cuts"* corrected to three), the pre-tag checklist, `AGENTS.md` table +
count, `CONTRIBUTING.md` list, `CONVENTIONS-LEDGER` (candidates **1 → 0**, with why
the block came off), `docs/ROADMAP.md`, and the 13 → 14 counts in
README/MAINTENANCE/WHY-IT-WORKS.

## Verification

- `./scripts/check-invariants.sh` → `PASS (14 checks)`
- `shellcheck -S warning scripts/*.sh` → clean
- Case-insensitive sweep for `13 invariants|13 checks|thirteen|no gate catches these|two consecutive cuts` → **no stale claim outside the CHANGELOG's historical entries**
- `AGENTS.md` still **171 lines**, under the 200 target
