### PR TITLE
feat(evals): a duration baseline, not just a printed duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ __pycache__/
 
 # Local secrets (OPENROUTER_API_KEY etc.) — never commit
 .env
+
+# Eval duration ledger — machine-local by design (a duration is only
+# comparable on the same machine/network); see evals/_elapsed.py.
+evals/results/durations.tsv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The eval runners now have a duration baseline, not just a printed duration.**
+  Closes the open half of the duration item: every run appends to a git-ignored
+  `evals/results/durations.tsv`, and the next run of the same runner prints the delta
+  — `[run-completeness elapsed 12.3s over 7 cases | previous 380.0s — 30.9x faster
+  (total)  <-- CHECK THIS: a large swing usually means the work changed, not the
+  speed]`.
+  - **Printing alone was never enough.** `sota-code-security` rules/11 §2.1's tell —
+    a step that finishes far faster than its claimed work allows did not do the work
+    — is a **comparison**, and there was nothing to compare against. It was
+    *"visible only to a human reading two logs"*; it is now in the log you are
+    already reading.
+  - **A duration without a denominator is the same defect in time form.** "12s" says
+    nothing; "12s over 7 cases" does. **7 of 12 runners** declare one via
+    `note_work(len(cases), "cases")`; the other five have no single `cases = load…`
+    line to hook, so their rows record `-` and print `[no denominator — bare seconds,
+    weak evidence]` rather than being quietly compared. Differing corpus sizes are
+    compared **per case**, and the line says which basis it used.
+  - **The ledger is git-ignored, and that is correctness rather than convenience**: a
+    duration is only comparable on the same machine and network, so committing one
+    would invite exactly the cross-machine comparison it cannot support — and would
+    dirty the tree on every local run.
+  - **Printed, never gated**, consistent with `check-invariants.sh`'s own wall-time
+    decision: these call a remote API whose latency is not ours, and a flaky gate
+    gets disabled. **Fails open on every path** — corrupt ledger, unwritable
+    location, and absent ledger were each tested by breaking them.
+  - **The CI half of the item needed nothing built.** The GitHub API already returns
+    `started_at`/`completed_at` per *step* (verified 2026-08-03:
+    `Check invariants 21:48:18 → 21:48:20`), so per-step duration is already
+    observable. Recorded rather than reimplemented.
+  - Verified end-to-end on the two `--selftest` paths CI runs without an API key —
+    both still PASS, with correct denominators (dead-path **4**, reimplement **10**,
+    matching their real case counts) — plus `py_compile` across `evals/` and
+    `test_scoring.py` still green at 38 checks.
+
 - **Invariant 14 — a release declares its front-door terms, and they resolve.**
   Closes the last actionable candidate in
   [docs/CONVENTIONS-LEDGER.md](docs/CONVENTIONS-LEDGER.md), which had it **blocked**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -224,7 +224,16 @@ first.
   numbers disagree anyway (rev-list HEAD 175, rev-list --all 181, gitleaks 179),
   so any equality test would be flaky. It also fails if gitleaks stops printing the
   line at all, since an unparsable output means the scope is no longer verified.
-- ~~**Duration is not recorded for any of our automation.**~~ **Partly done
+- ~~**Duration is not recorded for any of our automation.**~~ **DONE 2026-08-03.**
+  The remaining half — no recorded baseline — is closed: `_elapsed.py` appends every
+  run to a git-ignored `evals/results/durations.tsv` and the next run of the same
+  runner prints the delta, flagging a swing of ≥ 5×. §2.1's tell is a *comparison*,
+  so printing alone never sufficed. Denominators matter as much as the seconds
+  ("12s over 7 cases", not "12s"): **7 of 12 runners declare one**, the rest record
+  `-` and are labelled weak evidence rather than silently compared. The ledger is
+  machine-local by design — a duration is only comparable on the same machine and
+  network. **The CI half needed nothing**: the GitHub API already exposes
+  `started_at`/`completed_at` per step (verified). Original entry: **Partly done
   2026-07-30.** `check-invariants.sh` prints wall time with its denominators
   (`10 checks over 297 skill files / 256 rules files, 10s`). Deliberately printed
   and **not gated** — a duration threshold in CI is flaky under runner variance,

--- a/evals/README.md
+++ b/evals/README.md
@@ -265,6 +265,30 @@ that measures the library. So:
 - **Assert the corpus is non-empty, and that a filter removed something.** Every
   loader and every ablation aborts rather than returning silently-empty context. Both
   failure modes print a plausible `+0.00`.
+- **Every runner records its duration, and compares against its own last run.**
+  `_elapsed.py` prints `[run-x elapsed 12.3s over 7 cases | previous 380.1s — 30.9x
+  faster (total)]` to **stderr** on exit, and appends the row to
+  `evals/results/durations.tsv`. `rules/11` §2.1's tell — a step that finishes far
+  faster than its claimed work allows did not do the work — is a *comparison*, so
+  printing alone was not enough; the previous run has to be there to compare to.
+  A swing of ≥ 5× is flagged in the text with *"a large swing usually means the work
+  changed, not the speed"*.
+  - **A duration without a denominator is the same defect in time form.** "12s" says
+    nothing; "12s over 7 cases" does. Runners call `note_work(len(cases), "cases")`;
+    **7 of 12 do** — the other five have no single `cases = load…` line to hook, and
+    their rows record `-` and print `[no denominator — bare seconds, weak evidence]`
+    rather than being quietly compared. Add the call when you next touch one.
+  - Corpus sizes differing between runs are compared **per case**, and the line says
+    `(per case)` so the basis is never ambiguous.
+  - **The ledger is git-ignored, and that is correctness, not convenience**: a
+    duration is only comparable on the same machine and network, so committing one
+    would invite exactly the cross-machine comparison it cannot support.
+  - **Printed, never gated**, and it **fails open on every path** — a missing,
+    unreadable or corrupt ledger, or an unwritable location, must never break a run.
+    All three were tested by breaking them.
+  - **CI steps needed nothing**: the GitHub API already returns `started_at`/
+    `completed_at` per *step* (verified 2026-08-03), so per-step duration is already
+    observable there.
 - **Bound what the instrument reads, and read the denominator it prints.** A scorer
   reported `851 .py files` for a ten-module service — it was walking a vendored
   virtualenv, third-party packages, the build's own `assert user.has(permission)`

--- a/evals/_elapsed.py
+++ b/evals/_elapsed.py
@@ -1,17 +1,33 @@
-"""Wall-time reporting for the eval runners.
+"""Wall-time reporting and a local duration baseline for the eval runners.
 
 Every runner used to finish without saying how long it took, so "this got 30x
-faster" — or 30x slower — was visible only to a human diffing two logs. The
+faster" -- or 30x slower -- was visible only to a human diffing two logs. The
 invariant script has printed its duration alongside its denominators since
 2026-07-30 (`sota-code-security` rules/11 SS2.1: a step that reports "nothing
 found" far faster than its claimed work allows did not do the work). The runners
 did not.
 
+Printing alone was not enough. SS2.1's tell is a COMPARISON -- "far faster than
+its claimed work allows" needs something to compare against -- so each run is
+appended to a local ledger and the next run of the same runner prints the delta.
+The regression becomes visible in the log you are already reading.
+
+DURATION WITHOUT A DENOMINATOR IS THE SAME DEFECT IN TIME FORM. "12s" says
+nothing; "12s over 7 cases" does. Runners call note_work(n, unit) once they know
+their corpus size, and a run recorded without one is printed as `no denominator`
+rather than being quietly compared as bare seconds.
+
+THE LEDGER IS DELIBERATELY GIT-IGNORED, and that is correctness, not a
+compromise: a duration is only comparable on the same machine and network.
+Committing one would invite exactly the cross-machine comparison it cannot
+support, and would dirty the tree on every local run.
+
 PRINTED, NEVER GATED, and to **stderr**. Two deliberate choices:
 
-- No threshold. These runners call a remote API whose latency is not ours; a
-  duration gate would be flaky, and a flaky gate gets disabled, which is how a
-  control becomes inert.
+- No threshold fails a build. These runners call a remote API whose latency is
+  not ours; a duration gate would be flaky, and a flaky gate gets disabled, which
+  is how a control becomes inert. A large swing is flagged in the text, and a
+  human decides.
 - stderr, so a runner whose stdout is piped into a report or parsed by another
   tool is not silently given an extra line to choke on.
 
@@ -19,20 +35,104 @@ Registered via atexit so the line still prints when a runner ends through
 `sys.exit(...)` -- which several of them do on an empty corpus, and which is
 exactly the fast-exit case worth timing.
 
+FAILS OPEN ON EVERY PATH. A missing, unreadable, or corrupt ledger must never
+break a run: this module reports, it never decides.
+
 This module is NOT a measuring instrument: nothing scores it and no published
-number depends on it. It reports; it never decides.
+number depends on it.
 """
 
 import atexit
+import os
 import sys
 import time
 
+# Ratio at which a change is worth a human's attention. Not a threshold that
+# fails anything -- SS2.1 is about the 30x speedup that means the work stopped
+# happening, and 5x is comfortably outside ordinary API-latency noise.
+NOTABLE_RATIO = 5.0
+
+LEDGER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "results", "durations.tsv")
+
+_work = {"n": None, "unit": "items"}
+
+
+def note_work(n, unit="cases"):
+    """Declare the denominator for this run: how many items it processed."""
+    try:
+        _work["n"] = int(n)
+        _work["unit"] = str(unit)
+    except Exception:
+        pass
+
+
+def _previous(label):
+    """Most recent prior row for this label, or None. Never raises."""
+    try:
+        with open(LEDGER, encoding="utf-8") as fh:
+            rows = [r.rstrip("\n").split("\t") for r in fh if r.strip()]
+    except Exception:
+        return None
+    for row in reversed(rows):
+        if len(row) >= 5 and row[1] == label:
+            try:
+                return {"elapsed": float(row[2]),
+                        "n": int(row[3]) if row[3] != "-" else None,
+                        "unit": row[4]}
+            except Exception:
+                continue
+    return None
+
+
+def _append(label, elapsed):
+    try:
+        os.makedirs(os.path.dirname(LEDGER), exist_ok=True)
+        stamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
+        n = _work["n"] if _work["n"] is not None else "-"
+        with open(LEDGER, "a", encoding="utf-8") as fh:
+            fh.write(f"{stamp}\t{label}\t{elapsed:.1f}\t{n}\t{_work['unit']}\n")
+    except Exception:
+        pass
+
+
+def _compare(prev, elapsed):
+    """Human-readable delta against the previous run, or why there isn't one."""
+    if prev is None:
+        return "no baseline yet — this run becomes it"
+    now_n, prev_n = _work["n"], prev["n"]
+    if now_n and prev_n and now_n != prev_n:
+        # Different corpus sizes: compare per item, and say so.
+        a, b = elapsed / now_n, prev["elapsed"] / prev_n
+        basis = f"per {_work['unit'][:-1] if _work['unit'].endswith('s') else _work['unit']}"
+    else:
+        a, b = elapsed, prev["elapsed"]
+        basis = "total"
+    if a <= 0 or b <= 0:
+        return f"previous {prev['elapsed']:.1f}s (no usable ratio)"
+    ratio, faster = (b / a, True) if a < b else (a / b, False)
+    word = "faster" if faster else "slower"
+    line = f"previous {prev['elapsed']:.1f}s — {ratio:.1f}x {word} ({basis})"
+    if ratio >= NOTABLE_RATIO:
+        line += "  <-- CHECK THIS: a large swing usually means the work changed, not the speed"
+    if now_n is None or prev_n is None:
+        line += "  [no denominator — bare seconds, weak evidence]"
+    return line
+
 
 def report_on_exit(label):
-    """Print '[label elapsed 12.3s]' to stderr when the process exits."""
+    """Print '[label elapsed 12.3s ...]' to stderr when the process exits."""
     started = time.time()
+    prev = _previous(label)
 
     def _emit():
-        print(f"[{label} elapsed {time.time() - started:.1f}s]", file=sys.stderr)
+        elapsed = time.time() - started
+        n = _work["n"]
+        size = f" over {n} {_work['unit']}" if n is not None else ""
+        try:
+            print(f"[{label} elapsed {elapsed:.1f}s{size} | {_compare(prev, elapsed)}]",
+                  file=sys.stderr)
+        except Exception:
+            pass
+        _append(label, elapsed)
 
     atexit.register(_emit)

--- a/evals/run-build-safe.py
+++ b/evals/run-build-safe.py
@@ -188,6 +188,8 @@ def main():
     ap.add_argument("--selftest", action="store_true")
     a = ap.parse_args()
     cases = load_cases(a.cases)
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     if a.selftest:
         sys.exit(selftest(cases))
     if not a.build:

--- a/evals/run-clean.py
+++ b/evals/run-clean.py
@@ -243,6 +243,8 @@ def main():
               "use --temp 0.7 for real variance.\n")
     key = load_env_key()
     cases = load_cases(a.cases)
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     kind = cases[0].get("kind", "audit")
     abl = f"  ABLATED(-{ABLATE_FILE})" if a.ablate else ""
     print(f"model={a.model}  kind={kind}  cases={len(cases)}  samples={a.samples}  "

--- a/evals/run-completeness.py
+++ b/evals/run-completeness.py
@@ -211,6 +211,8 @@ def main():
               "use --temp 0.7 for real variance.\n")
     k = key()
     cases = load_cases()
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     print(f"build={a.build_model}  judge={a.judge_model}  cases={len(cases)}  "
           f"samples={a.samples}  temp={a.temp}  (clean API, blind judge)\n")
     results, tot_wo, tot_wl = {}, 0.0, 0.0

--- a/evals/run-dead-path.py
+++ b/evals/run-dead-path.py
@@ -211,6 +211,8 @@ def main():
     args = ap.parse_args()
 
     cases = load_cases(args.cases)
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     if args.selftest:
         sys.exit(selftest(cases))
     if not args.report:

--- a/evals/run-reimplement.py
+++ b/evals/run-reimplement.py
@@ -277,6 +277,8 @@ def main():
     args = ap.parse_args()
 
     cases = load_cases(args.cases)
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     if args.selftest:
         sys.exit(selftest(cases))
     if args.print_prompt:

--- a/evals/run-repo-audit.py
+++ b/evals/run-repo-audit.py
@@ -144,6 +144,8 @@ def main():
               "use --temp 0.7 for real variance.\n")
     k = key()
     cases = load_cases()
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     repo = repo_text()
     print(f"model={a.model}  planted_defects={len(cases)}  samples={a.samples}  "
           f"temp={a.temp}  (clean API run, no sota config)\n")

--- a/evals/run-unscoped-audit.py
+++ b/evals/run-unscoped-audit.py
@@ -155,6 +155,8 @@ def main():
     ap.add_argument("--selftest", action="store_true")
     a = ap.parse_args()
     cases = load_cases(a.cases)
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     if a.selftest:
         sys.exit(selftest(cases))
     if not a.report:


### PR DESCRIPTION
Closes the open half of the duration roadmap item. Every run appends to a
git-ignored `evals/results/durations.tsv`, and the next run of the same runner prints
the delta:

```text
[run-completeness elapsed 12.3s over 7 cases | previous 380.0s — 30.9x faster (total)
 <-- CHECK THIS: a large swing usually means the work changed, not the speed]
```

## Printing alone was never enough

`rules/11` §2.1's tell — *a step that finishes far faster than its claimed work allows
did not do the work* — is a **comparison**, and there was nothing to compare against.
The roadmap put it exactly right: *"visible only to a human reading two logs."* It is
now in the log you are already reading.

## A duration without a denominator is the same defect in time form

"12s" says nothing; **"12s over 7 cases"** does. **7 of 12** runners declare one via
`note_work(len(cases), "cases")`. The other five have no single `cases = load…` line
to hook, so their rows record `-` and print `[no denominator — bare seconds, weak
evidence]` rather than being quietly compared. Differing corpus sizes are compared
**per case**, and the line names the basis it used.

## The ledger is git-ignored, and that is correctness

A duration is only comparable on the same machine and network. Committing one would
invite exactly the cross-machine comparison it cannot support — and dirty the tree on
every local run.

## Validated

| Path | Result |
|---|---|
| First run | `no baseline yet — this run becomes it` |
| 31× faster, same corpus | `30.9x faster (total)` **+ flag** |
| Different corpus size | normalised, `(per case)` |
| No denominator | recorded as `-` |
| No-denominator comparison | `[no denominator — bare seconds, weak evidence]` |
| Corrupt ledger / unwritable path / absent ledger | **fails open**, run unaffected |

Plus both `--selftest` runners still PASS with correct denominators (dead-path **4**,
reimplement **10**, matching their real case counts), `py_compile` across `evals/`,
and `test_scoring.py` green at 38 checks.

## The CI half needed nothing built

The GitHub API already returns `started_at`/`completed_at` per **step** — verified:
`Check invariants 21:48:18 → 21:48:20`. Recorded rather than reimplemented.

## One process note

The first scripted wiring pass **dropped the leading indent** from each matched line
and broke `run-build-safe.py`. `py_compile` caught it, all seven files were restored,
and the regex fixed to re-emit the captured indent — the repo's own *"assert a
scripted edit landed"* convention doing its job.
