### PR TITLE
Three rules from an external ledger implementation's own failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**Three rules from a 1-star repo that documented its own failures.** An intake pass over
+[spanchain](https://github.com/ghostfactory-art/spanchain) (Elixir hash-chained audit
+ledger for agent runs) found six of its lessons already in `sota-code-security/rules/04`
+§8 — independently arrived at on both sides — and three that were not. Full intake with
+verdicts, rejections and the verification notes: [docs/ADOPTION-LOG.md](docs/ADOPTION-LOG.md)
+2026-08-11.
+
+### Added
+
+- **`sota-code-security/rules/04` §8 — a partitioned chain must chain its partitions.**
+  Ledgers get segmented for ordinary reasons (fixed-size epochs to bound an index, daily
+  partitions, rotated files) and the obvious implementation starts each segment with
+  `prev_hash = NULL`. Deleting a whole **interior** segment then verifies clean on both
+  sides of the hole. §8 previously enumerated two deletion geometries, tail and
+  whole-stream; the rule now names three and says which a chain walk can and cannot
+  catch. Audit checklist asks for the fixture: one whole interior segment removed.
+- **`sota-code-security/rules/12` §3 — a fourth form of "the guard that is an instance of
+  what it guards".** The segment bug lived in the *verifier*, which reset its carried
+  hash at each boundary: predicate right, traversal right, blind to the removal of a
+  whole chunk. Also a new axis for §3's per-target rule — for a guard that walks a
+  sequence the population includes the **seams** (first chunk, last chunk, interior chunk
+  removed, empty chunk), and three of those four survive any amount of single-record
+  mutation.
+- **`sota-code-security/rules/04` §8 — canonicalization fails in two directions, and
+  "canonical" must name a spec.** The library said "canonical, unambiguous encoding" in
+  three places and never said how to get one; a reader complying with `sort_keys=True`
+  has a single-language encoder with unpinned float and escaping behaviour, which
+  contradicts the same section's requirement that verification run off the storing
+  system. Now names RFC 8785 (JSON Canonicalization Scheme, June 2020, Informational) or
+  a written encoder spec, pinned by a committed known-answer vector. Adds the missing
+  **false-alarm** direction: a default map/JSON encoder is not canonical — quoting the Go
+  spec ("the iteration order over maps is not specified…") and the Elixir `Map` docs
+  ("key-value pairs in a map do not follow any order") — so identical data hashes
+  differently, the ledger reports tamper on untouched records, and an alarm that is wrong
+  on ordinary traffic gets muted, which is `rules/10`'s inert control by another route.
+- **`sota-llm-engineering/rules/01` §5 — a replay harness is not an eval.** Recorded-trace
+  or cassette replay re-executes nothing, so it tests pipeline determinism, not the
+  system's behaviour; wired into the gate as if it were the suite, the CI job stays green
+  through a prompt rewrite, a model swap or a retrieval change. Suites must declare what
+  is live and what is replayed, and the gate must fail with the model endpoint
+  unreachable — the file's first link into the silent-control family.
+
 ## [1.22.3] - 2026-08-05
 
 **Closing the loop on the gates.** The v1.22.x cycle built a harness to prove our checks

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -103,6 +103,13 @@ lessons-log — its own best structural idea, applied to ourselves.
 | 2026-08-05 | Report B, R8 | **GSN / assurance-case notation** for critical controls | **rejected: non-fit** | — a notation, not a mechanism; its own cited critique (Leveson: arguments "assume the conclusion") points back at what we already run, `sota/rules/01` §7 adversarial refutation |
 | 2026-08-05 | Report A, Rule 4 | Cryptographically **signed volumetric execution artifacts** verified by release gateways | **rejected: partial — insight kept, machinery dropped** | the insight (SLSA proves execution, never efficacy) landed in `sota-devsecops/rules/05` §5.6; the signing machinery is speculative and unbuilt |
 | 2026-08-05 | Both reports — checked and found already ours | R2 execution evidence/volumetric assertions; R3 fail-closed gates; R6 assertion polarity + egress sandbox; R7 meta-monitoring/heartbeat; the **ML Test Score** rubric ("worth adopting wholesale") | **rejected: already ours** | — (`rules/11` §2.2/§2.4/§3.1, `rules/10` §2.1/§2.4/§2.6, `sota-testing/rules/02` §2.6–2.7, `sota-observability/rules/04:249`, and `sota-ml-engineering/rules/04:6` which has cited ML Test Score since before these reports) |
+| 2026-08-11 | [spanchain](https://github.com/ghostfactory-art/spanchain) `docs/arch/hash-chain.md` | **A partitioned chain must chain its partitions** — segmenting a ledger (epochs, rotated files, daily partitions) with a per-segment `prev_hash = NULL` reset makes deletion of a whole *interior* segment verify clean; their pre-fix verifier also reset its carried hash at the boundary | **adopted** | `sota-code-security/rules/04` §8 + checklist · unreleased |
+| 2026-08-11 | Same source — where the bug actually lived | A verifier that walks a sequence in chunks and **resets its carried state at the seam**: predicate right, traversal right, blind to the removal of a whole chunk — a fourth form of "the guard that is an instance of what it guards", and a seam axis for per-target verification | **adopted** | `sota-code-security/rules/12` §3 + checklist · unreleased |
+| 2026-08-11 | Same source — `canonical_encode` and its stated cause | Canonicalization fails in **two** directions: the library stated only forgery. A default map/JSON encoder is not canonical, so identical data hashes differently and the ledger reports tamper on untouched records — an alarm wrong on ordinary traffic gets muted. Name the spec (RFC 8785) and pin it with a known-answer vector, or the "verify off the storing system" requirement is two implementations free to disagree | **adopted** | `sota-code-security/rules/04` §8 + checklist · unreleased |
+| 2026-08-11 | spanchain README, "Replay validates Span Chain's integrity, not your agent's behavior" | A record-and-replay (cassette) harness re-executes nothing: it tests pipeline determinism, and as a CI quality gate it stays green through a prompt rewrite, a model swap or a retrieval change | **adopted** | `sota-llm-engineering/rules/01` §5 + checklist · unreleased |
+| 2026-08-11 | spanchain — six findings checked against our tree first | Unkeyed chain forgeable by a DB-write attacker; tail truncation invisible; unhashed projection columns; canonical preimage required; in-memory ingest buffer loses records with no gap (integrity ≠ completeness); offline verification | **rejected: already ours** | — `sota-code-security/rules/04` §8, six for six, arrived at independently: `:217` unkeyed, `:224` tail truncation, `:241` unhashed projection columns, `:244` canonical preimage, `:265` integrity ≠ completeness, `:279` off-system verification |
+| 2026-08-11 | spanchain — pre-GF-703 telemetry inside `Repo.transaction`; GF-827 conditional terminal write; append-only store holding personal data; EU AI Act Art. 12 | Post-commit notification, compare-and-set instead of check-then-write, erasure from immutable stores, AI Act record-keeping | **rejected: already covered** | — `sota-ruby/rules/05:82`, `sota-databases/rules/05:175`, `sota-architecture/rules/02:127`; `sota-async-concurrency/rules/02` §"Check-then-act / TOCTOU"; `sota-privacy-compliance/rules/03:125`; `sota-code-security/rules/04:214` |
+| 2026-08-11 | spanchain — dead-letter drops deliberately break `verify_ledger` ("a deliberate audit signal") | An integrity verdict that is routinely red for operational reasons trains operators to ignore it; a known gap should be a signed in-chain marker, not a hole | **deferred** | revisit if a second implementation shows the same design — one project's trade-off is not yet a rule |
 
 ## Entries
 
@@ -749,3 +756,45 @@ not EUR-Lex, which returned only recitals; the file says so at the point of use)
 
 **Measurement status:** adopted on reasoning. **No efficacy lift is claimed or
 measured. Do not cite one.**
+
+### 2026-08-11 — spanchain (ghostfactory-art), three adopted, three rejected, one deferred
+
+Source: <https://github.com/ghostfactory-art/spanchain> — an Elixir/OTP hash-chained
+audit ledger for AI agent runs (MIT, v0.x, 1 star, created 2026-06-06, last push
+2026-06-15). Read: `README.md`, `docs/arch/hash-chain.md`, `docs/arch/eval-and-replay.md`,
+`docs/arch/open-questions.md`, plus repo metadata and the commit list via `gh api`.
+
+**Why a 1-star project was worth reading.** Its architecture docs state the *limits* of
+its own crypto rather than the marketing version — the README says "immutable,
+cryptographically verifiable" while `hash-chain.md` says an attacker with DB write can
+recompute a clean chain. Six of its lessons are already in `sota-code-security/rules/04`
+§8, arrived at independently on both sides; that convergence is the reason to trust the
+three that were **not** there.
+
+**The three adopted are one incident, one omission, and one sentence.** The incident
+(their GF-666) is an interior-segment deletion that verified clean because each epoch
+restarted `prev_hash = NULL` *and* the verifier reset its carried hash at the boundary —
+so it landed twice, as a ledger rule in `rules/04` §8 and as a fourth guard form in
+`rules/12` §3, since the defect was in the checking, not the writing. The omission is
+that every canonicalization mention in the library framed it as an attacker problem; the
+false-alarm direction (non-deterministic encoder → tamper reported on untouched records →
+alarm muted → inert control) was absent, and no file named a canonicalization spec. The
+sentence is the README's "Replay validates Span Chain's integrity, not your agent's
+behavior", which generalises to any cassette harness wired into a CI quality gate.
+
+**Verification.** RFC 8785 confirmed at rfc-editor.org (JSON Canonicalization Scheme,
+June 2020, Informational, Independent Submission). The Go quote is verbatim from the
+language specification, "For statements with range clause"; the Elixir quote is verbatim
+from the `Map` documentation. **Not verified and therefore not asserted:** the ">32 keys
+switches to a HAMT" threshold their doc gives as the cause — the official Elixir docs
+state only that map entries follow no order, so `rules/04` says the order "may change
+with size as the map switches internal representation" and gives no number.
+
+**Not usable as an audit fixture.** The obvious hope — a real repo with a real defect,
+which [`ROADMAP.md`](ROADMAP.md) records as the only remaining route to measuring audit
+recall — does not survive contact: the public history is 18 commits starting from a
+squashed `Initial release — Span Chain v0.1.0` (2026-06-07), so the pre-fix verifier is
+not in it. Only the narrative is.
+
+**Measurement status:** adopted on reasoning. **No efficacy lift is claimed or measured.
+Do not cite one.**

--- a/skills/sota-code-security/rules/04-cryptography.md
+++ b/skills/sota-code-security/rules/04-cryptography.md
@@ -225,12 +225,43 @@ records: hash-chained audit logs, compliance trails (EU AI Act Art. 12, FINRA
   newest N records leaves a perfectly valid chain; so does deleting an entire
   chain/stream. Detection needs an externally recorded head (hash + count),
   signed close markers, or an out-of-store registry of chains.
+- **A partitioned chain must chain its partitions.** Ledgers get segmented for
+  ordinary operational reasons — fixed-size epochs to bound an index, daily
+  partitions, rotated files, a re-shard — and the obvious implementation starts
+  each segment fresh with `prev_hash = NULL`. Deleting an entire *interior*
+  segment is then undetectable: both sides of the hole verify clean and the new
+  first record looks like a legitimate start. Carry the previous segment's head
+  hash into the first record of the next, and have the verifier carry its
+  running hash **across** the boundary instead of resetting at it — the defect
+  is usually in the verifier, not the writer, which makes it a `rules/12` §3
+  guard-shaped bug rather than a crypto bug. Deletion has three geometries and a
+  chain walk covers only two: interior record (caught by the `prev_hash`
+  mismatch), interior segment (caught **only** with boundary continuity), tail
+  or whole stream (never caught by a walk — needs the external head above).
 - Hash **every field you attest** — including server-assigned timestamps and
   anything used to order or attribute records. Unhashed "projection" columns
   can be rewritten without breaking the chain.
-- The preimage must be a canonical, unambiguous encoding (§7): delimiter-joined
-  concatenation of attacker-influenced fields is forgeable via field-boundary
-  shifting.
+- The preimage must be a canonical, unambiguous encoding (§7) — and "canonical"
+  has to name a **spec**, not an intention: RFC 8785 (JSON Canonicalization
+  Scheme, June 2020, Informational) or a written encoder with its key sort,
+  number format, string escaping and null/absent handling pinned. It fails in
+  two directions and most guidance states only the first. **Forgery:**
+  delimiter-joined concatenation of attacker-influenced fields is breakable by
+  field-boundary shifting. **False alarm:** a language's default map/JSON
+  encoder is not a canonical encoder — Go's spec says "the iteration order over
+  maps is not specified and is not guaranteed to be the same from one iteration
+  to the next", Elixir's `Map` documentation says "key-value pairs in a map do
+  not follow any order", and an implementation may change that order with size
+  as the map switches internal representation; float formatting, unicode
+  escaping and implicit numeric→string conversion vary the same way. Identical
+  data then hashes to different bytes, and the ledger reports tamper on records
+  nobody touched. That is the more dangerous direction operationally: an
+  integrity alarm that is wrong on ordinary traffic gets muted or ignored, and a
+  muted alarm is an inert control (rules/10). Pin the encoding with a
+  **known-answer test vector** committed as a fixture and reproduced by every
+  implementation — without one, the off-system verifier required below is just a
+  second implementation free to disagree with the first, and `chain broken` will
+  not say which of them is wrong.
 - **Integrity ≠ completeness.** A chain proves what was *delivered*, not what
   *happened*: records dropped before ingestion (client buffers, "never raise"
   SDKs, server-assigned sequence numbers) leave no gap. If completeness is a
@@ -304,4 +335,6 @@ createCipheriv\(.*, *(['"]).{1,16}\1  (short/static key/nonce)
 - [ ] Is there a single crypto wrapper module rather than scattered primitive calls?
 - [ ] Is any "tamper-evident"/audit ledger keyed (HMAC/signature) or externally anchored — not a bare unkeyed hash chain — with tail truncation and whole-stream deletion detectable?
 - [ ] Is ledger completeness attested separately from integrity (source-assigned seq / close markers), and is verification possible off the storing system?
+- [ ] If the ledger is segmented (epochs, daily partitions, rotated files), does the first record of each segment chain to the previous segment's head **and** the verifier carry its running hash across the boundary — demonstrated against a fixture with one whole interior segment removed?
+- [ ] Is the hash preimage a **named** canonicalization (RFC 8785 or a written encoder spec) rather than a default JSON/map serializer, pinned by a committed known-answer vector that every verifier implementation reproduces byte-for-byte?
 - [ ] Is a TEE/confidential-computing control proposed to fix a **completeness** gap ("records that were never emitted")? That is a liveness failure and sits outside the CC guarantee — the fix is a separate completeness attestation at a vantage the monitored component does not control.

--- a/skills/sota-code-security/rules/12-verifying-the-verifier.md
+++ b/skills/sota-code-security/rules/12-verifying-the-verifier.md
@@ -165,7 +165,7 @@ control that exists to prevent class X is itself an example of class X.** It is
 not a variant of §2 — an instrument reports a number, a guard renders a verdict,
 and a guard that cannot fail blocks nothing while appearing to block everything.
 
-Three forms, all observed:
+Four forms, all observed:
 
 - **The predicate the defect satisfies.** A test asserting "*every* driver call
   site passes auth" that scanned only one directory **and** accepted `auth=None`
@@ -180,6 +180,15 @@ Three forms, all observed:
   the items that made it past earlier filtering reports high coverage of a
   population it has already narrowed. rules/11 §2.2 catches an *empty* scope;
   this is a scope that is merely **wrong**, which prints a healthy number.
+- **The guard whose scope is continuous but whose state is not.** A verifier
+  that walks a sequence in chunks — a hash chain by epoch, a log by rotated
+  file, a reconciliation by day — and **resets its carried state at each
+  boundary**. It rejects every defect *inside* a chunk and is blind to the
+  removal of a whole one, which is the cheapest edit available to whoever wants
+  the record gone. Predicate right, traversal right, scope nominally complete:
+  the checking stops at the seam between iterations, and nothing in the output
+  distinguishes "all chunks verified" from "verified each chunk in isolation".
+  Worked instance: `rules/04` §8, chained partitions.
 
 The question to ask of every guard, gate, coverage assertion and tripwire:
 
@@ -200,6 +209,12 @@ gate the acceptable kill rate is **100%**: unlike a code mutation score, where
 surviving mutants are triaged and a number below 1.0 is normal
 (`sota-testing` rules/06), a gate that misses its own target defect on a member
 of its population is simply void for that member.
+
+For a guard that walks a sequence, that population includes the **seams**. An
+injected defect lands inside one chunk, exercises the predicate, and never
+touches the carry-over between chunks — so boundary cases have to be enumerated
+deliberately: first chunk, last chunk, a whole interior chunk removed, an empty
+chunk. Three of those four survive any amount of single-record mutation.
 
 The oldest name for the underlying error is **vacuous satisfaction** — a
 conditional that holds because its antecedent is never true. "Every call site
@@ -251,3 +266,7 @@ whose pathspec drifted.
       subject could not author (§2.4)?
 - [ ] No guard nested inside another gate's success branch, and no coverage
       denominator computed over survivors of earlier filtering (§3)?
+- [ ] For any verifier that walks a sequence in chunks (chained epochs, rotated
+      logs, daily partitions), is the **seam** probed as well as the interior —
+      first/last chunk, a whole interior chunk removed, an empty chunk — rather
+      than only single-record mutations that never reach the carry-over (§3)?

--- a/skills/sota-llm-engineering/rules/01-evals.md
+++ b/skills/sota-llm-engineering/rules/01-evals.md
@@ -159,6 +159,19 @@ Eval results are artifacts: persist run ID, git SHA, model versions, scores
 per case. "We can't reproduce last month's score" means you don't have evals,
 you have anecdotes.
 
+**A replay harness is not an eval.** Recorded-trace or cassette replay —
+re-ingesting captured requests and responses instead of calling the model — is
+worth having, but it re-executes nothing, so it tests your pipeline's
+determinism (parsing, schema drift, orchestration, tool wiring), not the
+system's behavior. Wired into the gate as if it were the suite above, it yields
+a CI job that stays green through a prompt rewrite, a model swap, or a
+retrieval change, because none of those are on the replayed path — and the
+greenness is indistinguishable from the real thing. Declare per suite what is
+**live** and what is **replayed**, and apply the falsification question
+(`sota/SKILL.md` BUILD step 4): if your quality gate would still pass with the
+model endpoint unreachable, it is measuring the harness (`sota-code-security`
+rules/10).
+
 ## 6. Error analysis discipline
 
 Scores tell you *that* something is wrong; error analysis tells you *what to
@@ -235,6 +248,9 @@ Production is the only honest distribution. Build the loop:
       tags; cost/latency gated alongside quality.
 - [ ] Eval runs persisted as artifacts (run ID, SHA, model versions,
       per-case results) and reproducible.
+- [ ] Each suite declares what is **live** vs **replayed**, and the quality
+      gate fails with the model endpoint unreachable — a replay-only gate
+      measures the harness, not the model.
 - [ ] Online signal exists (sampled judging and/or user feedback) and is
       distinct from — not a substitute for — offline gates.
 - [ ] Error-analysis loop visible in history: failure taxonomy, incident


### PR DESCRIPTION
Intake pass over [ghostfactory-art/spanchain](https://github.com/ghostfactory-art/spanchain)
(Elixir/OTP hash-chained audit ledger for agent runs, MIT, v0.x). Its architecture docs
state the limits of its own crypto rather than the marketing version — six of its lessons
were **already** in `sota-code-security/rules/04` §8, arrived at independently on both
sides. That convergence is the reason to trust the three that were not there.

Full intake with verdicts, rejections and verification notes: `docs/ADOPTION-LOG.md`,
entry 2026-08-11 (3 adopted · 3 rejected · 1 deferred).

## What changed

- **`rules/04` §8 — a partitioned chain must chain its partitions.** Ledgers get segmented
  for ordinary reasons (fixed-size epochs to bound an index, daily partitions, rotated
  files) and the obvious implementation starts each segment with `prev_hash = NULL`.
  Deleting a whole **interior** segment then verifies clean on both sides of the hole.
  §8 previously enumerated two deletion geometries, tail and whole-stream; it now names
  three and says which a chain walk can and cannot catch.
- **`rules/12` §3 — a fourth form of "the guard that is an instance of what it guards".**
  The segment bug lived in the *verifier*, which reset its carried hash at each boundary:
  predicate right, traversal right, blind to the removal of a whole chunk. Also a new axis
  for §3's per-target rule — for a guard that walks a sequence the population includes the
  **seams** (first chunk, last chunk, interior chunk removed, empty chunk), and three of
  those four survive any amount of single-record mutation.
- **`rules/04` §8 — canonicalization fails in two directions, and "canonical" must name a
  spec.** The library said "canonical, unambiguous encoding" in three places and never said
  how to obtain one; a reader complying with `sort_keys=True` has a single-language encoder
  with unpinned float and escaping behaviour, which contradicts the same section's
  requirement that verification run off the storing system. Now names RFC 8785 or a written
  encoder spec, pinned by a committed known-answer vector, and adds the missing **false
  alarm** direction: a default map/JSON encoder is not canonical, so identical data hashes
  differently, the ledger reports tamper on untouched records, and an alarm wrong on
  ordinary traffic gets muted — `rules/10`'s inert control by another route.
- **`sota-llm-engineering/rules/01` §5 — a replay harness is not an eval.** Cassette replay
  re-executes nothing, so the CI gate stays green through a prompt rewrite, a model swap or
  a retrieval change. Suites declare live vs replayed; the gate must fail with the model
  endpoint unreachable. First link from that file into the silent-control family.

Every build rule ships with its **audit-checklist half** (2 new lines in `rules/04`, 1 in
`rules/12`, 1 in `rules/01`) — the gap shape that keeps recurring is a rule stated three
times with no probe.

## Validation

- **Primary sources fetched this session:** RFC 8785 at rfc-editor.org (JSON
  Canonicalization Scheme, June 2020, Informational, Independent Submission); the Go quote
  verbatim from the language spec, "For statements with range clause"; the Elixir quote
  verbatim from the `Map` documentation.
- **Not verified, therefore not asserted:** their ">32 keys switches to a HAMT" explanation
  is absent from the official Elixir docs, so `rules/04` says the order "may change with
  size as the map switches internal representation" and gives no number. Recorded in the log.
- **Every `rejected: already covered` row cites a line that was read**, and the `rules/04`
  anchors were re-derived *after* the edits, since the new bullets shifted them.
- **Not usable as an audit fixture** (checked, since a real repo with a real defect is the
  roadmap's only remaining route to measuring audit recall): the public history is 18
  commits from a squashed `Initial release` (2026-06-07), so the pre-fix verifier is not in
  it. Only the narrative is.
- **Gates:** `./scripts/check-invariants.sh` → PASS, 16 checks over 298 skill files / 257
  rules files. Re-run **post-commit** so checks 11 and 14 actually executed rather than
  skipping on a missing merge base (`ok (LAST-VERIFIED unchanged)`, `ok (not a release
  commit — VERSION unchanged)`). Files land at 340 / 272 / 259 lines, under the 500 cap.

No efficacy lift is claimed or measured for these — adopted on reasoning, as the log records.
