### PR TITLE
Redact an org project name the internal-name check could not see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ ledger for agent runs) found six of its lessons already in `sota-code-security/r
 verdicts, rejections and the verification notes: [docs/ADOPTION-LOG.md](docs/ADOPTION-LOG.md)
 2026-08-11.
 
+### Fixed
+
+- **An internal-name leak the internal-name check could not see.** Two tracked docs
+  named one of the maintainer's other projects, and one of those lines also carried a
+  local `~/` path; a third line elsewhere did the same. Invariant 3 passed on all of it,
+  because the private denylist had no pattern for that name — the gate was green on an
+  incomplete **list**, not a clean tree, which is `rules/12` §3's guard-whose-predicate-
+  misses-its-own-target in this repo's own machinery. Lines redacted (the meaning is
+  kept, the identifiers are gone), the private list extended, and the new pattern
+  **watched to fail** against a staged known-bad before being trusted (`[3/16]` flagging
+  the probe, full run exiting 1, then 0 once removed). The pre-2026-07-01 disclosure in
+  git history is unchanged and stays an accepted risk — re-confirmed with the sweep's
+  scope recorded in [docs/AUDIT-2026-07-01.md](docs/AUDIT-2026-07-01.md) S1.
+
 ### Added
 
 - **`sota-code-security/rules/04` §8 — a partitioned chain must chain its partitions.**

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -310,7 +310,8 @@ not a change.
 the `PostToolUse` lint hook, the generated slash commands, and the
 `.claude/memory/` index are executable harness machinery, and this library is
 Markdown-only by construction — the same disposition the memory-bank and
-worktree-lock ideas got in the dev-aid pass (PRs #112-114). The one idea inside
+worktree-lock ideas got in the earlier orchestration-project pass (PRs #112-114).
+The one idea inside
 them that generalises, pushing critical invariants into deterministic gates,
 was already the router's BUILD step 4 and is now restated for day zero in §10.
 

--- a/docs/AUDIT-2026-07-01.md
+++ b/docs/AUDIT-2026-07-01.md
@@ -208,6 +208,18 @@ lines of the 500 cap (max rules file: 342).
   a git-ignored local file locally and a CI secret/variable in the workflow;
   decide explicitly whether the residual history disclosure is accepted (a
   history rewrite is the only alternative and has its own costs).
+  **Re-confirmed 2026-08-11, and the accepted set grew.** A sweep for the same
+  class found one further org project named in two tracked docs and four commit
+  subjects — none of it on the denylist, so check 3 passed on an incomplete
+  *list* rather than a clean tree, which is `sota-code-security/rules/12` §3 (a
+  guard whose predicate does not cover its own target). The tracked lines were
+  redacted and the private list extended, with the new pattern **watched to fail
+  on a staged known-bad** before being trusted. The commit subjects stay: the
+  no-rewrite decision above is unchanged, and it now covers them too. Scope of
+  that sweep, so the negative half is auditable: 532 tracked files and 238
+  commits / 3078 objects, per-name regex over every blob in every commit, plus
+  an independent pass over org URLs, the email domain, `~/` paths, commit
+  messages and refs. Names that were never repository names are outside it.
 - **S2 · medium** same line — the denylist grep is case-sensitive (no `-i`), so
   lowercase/mixed-case reintroductions pass CI (verified live: lowercase
   variant → no match, exit 1). Also: `2>/dev/null … || true` converts grep

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -209,7 +209,7 @@ between two of our own rules, plus the router rule for resolving such conflicts.
 All six are content/CI changes — **none measured**, none claiming a lift.
 
 **Field validation this cycle (n=1 per arm, not a measurement).** The day-zero
-trigger fired correctly on a purpose-built fresh repo (`~/Github/daycheck`:
+trigger fired correctly on a purpose-built fresh repo (one throwaway checkout:
 1 commit, no gates/licence/agent file) — once, in a line, offering rather than
 running the scripts, and the build proceeded. It stayed correctly silent on a
 mature 4304-commit repo. **It only fires when the `sota` router actually loads**:
@@ -580,7 +580,7 @@ scoped to skill files only**, a **4-way accuracy sweep**, and **theme-aware
 benchmark + breadth charts**.
 
 **Post-release, same session (PRs #111–#117):** concluded the breadth comparison
-(#111); mined a separate agent-orchestration project (`~/Github/Dev-AID`) and adopted
+(#111); mined a separate agent-orchestration project of the maintainer's and adopted
 **three pure-Markdown conventions, each independently measured** — negative routing
 cross-refs, plan-concreteness in BUILD step 3, and an evidence-based-completion
 operating principle (#112) — with regression checks proving no loss (completeness
@@ -590,7 +590,8 @@ saturated like audit; cross-refs kept as zero-cost defensive clarity); cut **v1.
 (#115); consolidated the breadth chart + full story into RESULTS.md (#116); and added
 **`sota-docs-workflow` rules/01 §8 "The documentation baseline"** — the must-have doc
 set incl. community-health files, GitHub search precedence verified (#117). Runtime-
-bound Dev-AID ideas (memory-bank persistence, RAG, worktree locks, agent framework)
+bound ideas from that project (memory-bank persistence, RAG, worktree locks, agent
+framework)
 were deliberately **not** ported.
 
 **Post-v1.16.0 (2026-07-20):** added **`sota-code-security` rules/10 "Silent


### PR DESCRIPTION
A sweep for the maintainer's other project names across this repo found one named in
**two tracked docs** (one line also carrying a local `~/` path) and a **third line of
the same shape** elsewhere. Invariant 3 passed on all of it.

## Why the gate was green

Not because the tree was clean — because the private denylist had **no pattern for that
name**. Green meant "not on the list". That is `sota-code-security/rules/12` §3, the
guard whose predicate does not cover its own target, occurring in this repo's own
machinery about a week after we wrote the rule.

Related and worth knowing: `check-invariants.sh` excludes itself from its own scan (it
holds the generic phrases), which is exactly why the pre-2026-07-01 **inlined** list was
invisible to the check that used it — finding S1 of the 2026-07-01 audit.

## What changed

- `docs/ROADMAP.md` (×3) and `docs/ADOPTION-LOG.md` (×1): identifiers and `~/` paths
  removed, each sentence's meaning kept.
- **Private denylist** (git-ignored, untracked, so not in this diff): extended to cover
  the missed names plus separator variants of the org name — the previous pattern
  matched the dotted form only, so the hyphenated form would have passed.
- `docs/AUDIT-2026-07-01.md` S1: the no-rewrite decision **re-confirmed** and extended to
  the four commit subjects that name the project, with the sweep's scope recorded.

## Verification

- **Watched to fail before being trusted.** A staged known-bad produced
  `[3/16] Internal reference(s) found` naming the probe file, full run exit **1**; probe
  removed → exit **0**. The new patterns produce **zero** hits on the current tree, so
  they gate without false-positiving on legitimate text.
- **Residual scan clean:** no org project name, org URL, email domain or `~/` path left
  in any tracked file.
- **Scope of the negative claim** (532 tracked files, 238 commits / 3078 objects): per-name
  regex over every blob in every commit, plus an independent pass over org URLs, the email
  domain, `~/` paths, commit messages and refs. Names that were never repository names are
  outside it — the candidate list came from `gh repo list` today, so a repo renamed or
  deleted earlier would not appear.
- Invariants: **16/16 PASS**.

## Not done here, needs you

The CI `SOTA_DENYLIST` secret needs the same patterns. It is write-only, so it cannot be
updated from this branch without overwriting a value I cannot read — until it is updated,
the local hook blocks a regression and **CI does not**.
