### PR TITLE
Document the denylist's two-places rule and the canary probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ verdicts, rejections and the verification notes: [docs/ADOPTION-LOG.md](docs/ADO
   git history is unchanged and stays an accepted risk — re-confirmed with the sweep's
   scope recorded in [docs/AUDIT-2026-07-01.md](docs/AUDIT-2026-07-01.md) S1.
 
+  [CONTRIBUTING.md](CONTRIBUTING.md) now documents the part that bit: the list lives in
+  two places that cannot see each other (a git-ignored local file and a **write-only**
+  CI secret), so a name added to one silently leaves the other lane open. It also
+  documents the **canary** — a synthetic pattern in both copies that lets anyone prove
+  the secret is loaded and blocking by pushing a file containing it, without printing a
+  real internal name into a public CI log, which is what probing with a real name would
+  do.
+
 ### Added
 
 - **`sota-code-security/rules/04` §8 — a partitioned chain must chain its partitions.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,29 @@ are marked "needs verification", never asserted.
 3. any **internal/private reference** leaking into tracked files (the private
    pattern list is intentionally not in the repo; PRs from forks run the
    generic checks and the maintainer's CI runs the full list);
+
+   The list lives in **two places that cannot see each other**: `.denylist.local`
+   (git-ignored) for the pre-commit hook, and the `SOTA_DENYLIST` repository
+   secret for CI. The secret is **write-only** — nothing can read it back to diff
+   it — so a pattern added to one place and not the other leaves a gate that is
+   green in one lane and blocking in the other. Add a new name to **both**, in
+   the same sitting.
+
+   **A green check 3 means "no match", which is not the same as "clean".** On
+   2026-08-11 a sweep found a project name in two tracked docs that the check had
+   passed over for a month, because the name was simply not in the list — the
+   guard's predicate did not cover its own target (`sota-code-security/rules/12`
+   §3, in our own machinery). When your set of private names changes, the list is
+   what has to change; the check will not discover the gap for you.
+
+   **To prove the secret is live, use the canary — never a real name.** Both
+   copies of the list carry one synthetic pattern that matches nothing real
+   (see the comment in `.denylist.local`). Push a branch with a file containing
+   it and check 3 must fail; that demonstrates the secret is loaded, parsed and
+   blocking, while the only string reaching the **public** CI log is an invented
+   one. Probing with a real internal name would publish exactly what the control
+   exists to suppress. The canary literal must never appear in a tracked file
+   either — it is on the list, so it would fail the build permanently.
 4. any `skills/*/SKILL.md` `description` over **1024 characters** (the Agent
    Skills cap) or written as an unquoted inline scalar containing `: ` —
    invalid YAML that makes loaders skip the skill; use `description: >-`.


### PR DESCRIPTION
Invariant 3's pattern list lives in **two places that cannot see each other** — a git-ignored `.denylist.local` for the pre-commit hook and the **write-only** `SOTA_DENYLIST` secret for CI. Nothing in the repo said so, and on 2026-08-11 that gap let a project name sit in two tracked docs for a month behind a green check.

## What the note says

- **Add a new name to both places.** The secret cannot be read back to diff, so a pattern added to one lane leaves the other open, and nothing reports the divergence.
- **A green check 3 means "no match", not "clean".** The guard's predicate has to be maintained as the set of private names changes — `sota-code-security/rules/12` §3, occurring in this repo's own machinery.
- **Prove the secret is live with the canary, never a real name.** Both copies carry one synthetic pattern that matches nothing real; pushing a file containing it turns check 3 red, demonstrating the secret is loaded and blocking while the only string reaching the **public** CI log is invented. Probing with a real internal name would publish precisely what the control exists to suppress. The canary literal must also stay out of tracked files, since it is on the list and would fail the build permanently.

## Verification

- The new prose was scanned against the full local denylist **including the canary** before committing — zero matches, so the note documenting the control does not trip it.
- Invariants: **16/16 PASS**.
- The canary mechanism itself was demonstrated end-to-end earlier today: PR #206 (closed unmerged) turned `Repository invariants` red on check 3 and nothing but the synthetic string appeared in the log.
