### PR TITLE
DO NOT MERGE — canary rotation probe

### DIFF
--- a/docs/_probe.md
+++ b/docs/_probe.md
@@ -1,1 +1,2 @@
 Probe A: previous canary sota-denylist-canary-9f3a — after rotation this must NOT trip check 3.
+Probe B: current canary sota-denylist-canary-c41d — this MUST trip check 3.

--- a/docs/_probe.md
+++ b/docs/_probe.md
@@ -1,0 +1,1 @@
+Probe A: previous canary sota-denylist-canary-9f3a — after rotation this must NOT trip check 3.


### PR DESCRIPTION
Two-sided proof that the rewritten `SOTA_DENYLIST` is the value CI is using. **Probe A** (this commit) contains the *previous* canary: check 3 must **pass**, proving the old value is gone. **Probe B** (next commit) contains the *new* canary: check 3 must **fail**, proving the new value is live. Closed immediately after.