### PR TITLE
Denominators for all 12 runners, §3.9 re-verified, Harbor ground truth

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,15 +21,32 @@ Every number in this table was re-counted on 2026-08-13, not carried forward.
 | 3 | **Real-repo audit eval** — the *only* remaining way to move AUDIT off +0.00 | A synthetic fixture is **ruled out** (2026-08-03, twice), and the first real candidate failed on evidence: spanchain's public history is 18 commits from a squashed initial release, so its documented pre-fix verifier is not in it ([ADOPTION-LOG](ADOPTION-LOG.md) 2026-08-11) | Pick an OSS repo at a known-vulnerable commit **and confirm the vulnerable commit is actually in the public history before anything else** |
 | 4 | **Paid eval runs** — 2nd cross-family model (~$3), as-deployed competitor comparison (~$8) | Costs money; needs an explicit go and a credit check | Verify OpenRouter credit via its API, then ask before spending |
 | 5 | **Router trim** — 2× the spec's ~5k-token recommendation | Deliberate: trimming breaks `ROUTER_BUILD_SHA` and the +0.39's comparability. **491/500 lines** on 2026-08-13 — the activation rewrite left 9 lines of headroom that `AGENTS.md` was still calling "exactly 500" | **Only when the router must grow** — then trim and re-baseline together |
-| 6 | **Denominators for 5 eval runners** — 7 of 12 declare one (verified 2026-08-13) | No single `cases = load…` line to hook | The five without `note_work`: `run-adjudication`, `run-competitors`, `run-decay`, `run-desc-routing`, `run-silent-open`. Add `note_work(n, "cases")` when next touching each |
-| 7 | **§3.9 tool table rot** — 8 ecosystem rows; the file itself flags that two of the named projects have been renamed under their old URLs | Watch item; needs re-verification, not a decision | Re-check the named projects at the next accuracy sweep |
-| 8 | **6-month accuracy sweep** | Scheduled | `LAST-VERIFIED` reads **2026-07-08**, so due ~**2027-01-08**; bump it only after a full pass |
+| 6 | **6-month accuracy sweep** | Scheduled | `LAST-VERIFIED` reads **2026-07-08**, so due ~**2027-01-08**; bump it only after a full pass |
 
 **Pending, not blocked: a release cut.** `[Unreleased]` carries four rule additions and
 one fix. By this repo's own test (`RELEASING.md` §"Minor or patch?" — minor = the library
 gains a surface someone can *use*; patch = the change lives inside existing surfaces) it
 is a **patch, 1.22.4**: no new skill, script, or gate. Invariant 14 will require a
 `**Front door checked:**` line whose terms resolve.
+
+**Closed 2026-08-13 (this session), both with evidence rather than a tick:**
+
+- **Every eval runner declares its denominator — 12 of 12.** The five that did not
+  (`run-adjudication`, `run-competitors`, `run-decay`, `run-desc-routing`,
+  `run-silent-open`) now call `note_work` at the point the count is known.
+  `run-decay` gets `arm-depth runs`, not `cases`: it drives **one** case across every
+  arm × depth, so "cases" would have declared a denominator of 1 for a run that does
+  15 units of work — a wrong denominator is worse than none. Verified by executing the
+  import from a script in `evals/`, not by reading it, and `test_scoring.py` still
+  passes 38 checks.
+- **§3.9 tool-table rot: re-checked, none found.** All six named third-party projects
+  resolve, none archived, all pushed within four months (`knip` 2026-08-11, `deptry`
+  2026-08-12, `cargo-machete` 2026-08-10, `cargo-udeps` 2026-04-29, `composer-unused`
+  2026-04-27, `ReferenceTrimmer` 2026-08-12). The rename the file warns about is
+  confirmed live — `fpgmaas/deptry` still answers and reports `full_name:
+  osprey-oss/deptry` — and the rules file already carries the new name. Checked by
+  reading `full_name` back, per the ledger's own lesson that the API follows renames
+  silently.
 
 **Closed since the 2026-08-05 cut** (2026-08-11/13, PRs #204, #205, #207):
 

--- a/evals/cases/harbor-authz-groundtruth.json
+++ b/evals/cases/harbor-authz-groundtruth.json
@@ -1,0 +1,46 @@
+{
+  "_comment": "Ground truth for the real-repo audit eval. See ../DESIGN-real-repo-audit.md.",
+  "subject": {
+    "repo": "goharbor/harbor",
+    "vulnerable_tag": "v2.5.1",
+    "vulnerable_commit": "b0506782b4",
+    "fixed_tag": "v2.5.2",
+    "fixed_commit": "6688271792",
+    "scope": "src/server/ and src/controller/, *.go excluding *_test.go (232 files)"
+  },
+  "defect_class": {
+    "name": "Broken Object Level Authorization (OWASP API1:2023)",
+    "shape": "The permission check IS present and DOES pass. Missing is the object-to-tenant binding: nothing verifies that the policy/execution/robot named in the URL belongs to the project the caller was authorized against.",
+    "why_hard": "A grep for 'does this handler call an authz function' answers YES at every vulnerable site. Only reasoning about WHICH object was authorized finds it.",
+    "fix_signature": "v2.5.2 adds requirePolicyAccess / requireRuleAccess / requirePolicyInProject / requireExecutionInProject, i.e. 'if projectID != obj.ProjectID { return NotFound }' (34 such lines added, against 1 project-access line)"
+  },
+  "scoring": {
+    "unit": "code site (function), not CVE id",
+    "credit": "an arm scores a site when it names the file AND the function or a line inside it AND describes a missing object/tenant ownership check. Naming a CVE id without a location is recorded as contamination, not as a hit.",
+    "out_of_scope": "other real defects at v2.5.1 fixed later are neither credited nor penalised; record them separately as a precision signal",
+    "denominator": 16
+  },
+  "sites": [
+    {"file": "src/server/v2.0/handler/preheat.go", "func": "UpdatePolicy", "line_v251": 257, "advisory": "GHSA-3wpx-625q-22j7", "cve": "CVE-2022-31671"},
+    {"file": "src/server/v2.0/handler/preheat.go", "func": "GetExecution", "line_v251": 576, "advisory": "GHSA-3wpx-625q-22j7", "cve": "CVE-2022-31671"},
+    {"file": "src/server/v2.0/handler/preheat.go", "func": "StopExecution", "line_v251": 644, "advisory": "GHSA-3wpx-625q-22j7", "cve": "CVE-2022-31671"},
+    {"file": "src/server/v2.0/handler/preheat.go", "func": "ListTasks", "line_v251": 682, "advisory": "GHSA-3wpx-625q-22j7", "cve": "CVE-2022-31671"},
+    {"file": "src/server/v2.0/handler/preheat.go", "func": "GetPreheatLog", "line_v251": 720, "advisory": "GHSA-q76q-q8hw-hmpw", "cve": "CVE-2022-31671"},
+    {"file": "src/server/v2.0/handler/preheat.go", "func": "ListProvidersUnderProject", "line_v251": 734, "advisory": "GHSA-3wpx-625q-22j7", "cve": "CVE-2022-31671"},
+    {"file": "src/server/v2.0/handler/retention.go", "func": "UpdateRetention", "line_v251": 196, "advisory": "GHSA-3637-v6vq-xqqw", "cve": "CVE-2022-31670"},
+    {"file": "src/server/v2.0/handler/retention.go", "func": "OperateRetentionExecution", "line_v251": 265, "advisory": "GHSA-3637-v6vq-xqqw", "cve": "CVE-2022-31670"},
+    {"file": "src/server/v2.0/handler/retention.go", "func": "ListRetentionTasks", "line_v251": 313, "advisory": "GHSA-3637-v6vq-xqqw", "cve": "CVE-2022-31670"},
+    {"file": "src/server/v2.0/handler/retention.go", "func": "GetRetentionTaskLog", "line_v251": 343, "advisory": "GHSA-3637-v6vq-xqqw", "cve": "CVE-2022-31670"},
+    {"file": "src/server/v2.0/handler/immutable.go", "func": "DeleteImmuRule", "line_v251": 56, "advisory": "GHSA-8c6p-v837-77f6", "cve": "CVE-2022-31669"},
+    {"file": "src/server/v2.0/handler/immutable.go", "func": "UpdateImmuRule", "line_v251": 69, "advisory": "GHSA-8c6p-v837-77f6", "cve": "CVE-2022-31669"},
+    {"file": "src/server/v2.0/handler/robot.go", "func": "updateV2Robot", "line_v251": 282, "advisory": "GHSA-xx9w-464f-7h6f", "cve": "CVE-2022-31667"},
+    {"file": "src/server/v2.0/handler/notification_policy.go", "func": "UpdateWebhookPolicyOfProject", "line_v251": 109, "advisory": "GHSA-8hwq-5f22-jfr3", "cve": "CVE-2022-31666"},
+    {"file": "src/server/v2.0/handler/notification_policy.go", "func": "DeleteWebhookPolicyOfProject", "line_v251": 137, "advisory": "GHSA-wqpf-jx24-7hmp", "cve": "CVE-2022-31666"},
+    {"file": "src/server/v2.0/handler/notification_job.go", "func": "ListWebhookJobs", "line_v251": 28, "advisory": "GHSA-q76q-q8hw-hmpw", "cve": "CVE-2022-31671"}
+  ],
+  "provenance": {
+    "derived_from": "the v2.5.1...v2.5.2 patch hunks (function context from the @@ headers), with line numbers resolved by grepping the function definitions in a clone pinned at b0506782b4",
+    "verified": "2026-08-13",
+    "caveat": "GHSA-jf8p-3vjh-pq94 (webhook policy - view) has no distinct object-binding hunk of its own; its fix rides along with the Prepare/requirePolicyInProject helper added to notification_policy.go. 16 sites map to 8 advisories, not 1:1."
+  }
+}

--- a/evals/run-adjudication.py
+++ b/evals/run-adjudication.py
@@ -128,6 +128,8 @@ def main():
 
     key = run_clean.load_env_key()
     cases = run_clean.load_cases(a.cases)
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     n_real = sum(1 for c in cases if c["expect"] == ["UPHELD"])
     print(f"model={a.model}  cases={len(cases)} ({n_real} real / {len(cases)-n_real} false)  "
           f"samples={a.samples}  temp={a.temp}\n")

--- a/evals/run-competitors.py
+++ b/evals/run-competitors.py
@@ -114,6 +114,8 @@ def main():
     if a.ids:
         want = set(a.ids.split(","))
         cases = [c for c in cases if c["id"] in want]
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     manifest = json.load(open(a.manifest, encoding="utf-8"))["competitors"]
     comps = list(manifest)
     if a.only:

--- a/evals/run-decay.py
+++ b/evals/run-decay.py
@@ -161,6 +161,10 @@ def main():
     case = next(c for c in _rc.load_cases() if c["id"] == a.task)
     depths = [int(x) for x in a.depths.split(",")]
     arms = ["control", "anchor", "reminder"]
+    # Denominator here is not "cases" — this runner drives ONE case across every
+    # arm x depth combination, so the unit that scales the duration is the run.
+    from _elapsed import note_work
+    note_work(len(arms) * len(depths), "arm-depth runs")
     print(f"task={a.task}  arms={arms}  depths={depths}  build={a.build_model}  "
           f"judge={a.judge_model}  (multi-turn decay, blind judge)\n")
     results = {}

--- a/evals/run-desc-routing.py
+++ b/evals/run-desc-routing.py
@@ -119,6 +119,8 @@ def main():
     key = load_env_key()
     cases = [json.loads(l) for l in open(CASES, encoding="utf-8")
              if l.strip() and not l.startswith("#")]
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     names = [os.path.basename(d) for d in glob.glob(os.path.join(ROOT, "skills/sota-*"))
              if os.path.isdir(d)]
     arms = {"with-xref": catalogue(False), "without-xref": catalogue(True)}

--- a/evals/run-silent-open.py
+++ b/evals/run-silent-open.py
@@ -95,6 +95,8 @@ def main():
 
     key = run_clean.load_env_key()
     cases = run_clean.load_cases(a.cases)
+    from _elapsed import note_work   # duration baseline needs a denominator
+    note_work(len(cases), "cases")
     print(f"model={a.model}  judge={a.judge_model}  cases={len(cases)}  "
           f"samples={a.samples}  temp={a.temp}  (open-ended, no vocabulary)\n")
 


### PR DESCRIPTION
Three roadmap items, each closed **with evidence**.

## 1. Every eval runner declares its denominator (7/12 → 12/12)

`run-adjudication`, `run-competitors`, `run-desc-routing`, `run-silent-open` now call `note_work(len(cases), "cases")`.

`run-decay` deliberately declares **`arm-depth runs`**, not cases: it drives *one* case across every arm × depth, so `"cases"` would have declared a denominator of **1** for a run doing 15 units of work. A wrong denominator is worse than none — that is the whole point of the convention.

Verified by **executing** the import from a script in `evals/` rather than reasoning about `sys.path` (it resolves because `sys.path[0]` is the script's directory — the same pattern `run-clean.py:246` has been using in published runs). `test_scoring.py` still passes **38 checks**.

## 2. §3.9 tool-table rot — re-checked, none found

| Project | Status | Last push |
|---|---|---|
| `webpro-nl/knip` | live | 2026-08-11 |
| `osprey-oss/deptry` | live | 2026-08-12 |
| `bnjbvr/cargo-machete` | live | 2026-08-10 |
| `est31/cargo-udeps` | live | 2026-04-29 |
| `composer-unused/composer-unused` | live | 2026-04-27 |
| `dfederm/ReferenceTrimmer` | live | 2026-08-12 |

None archived. The rename the rules file warns about is confirmed **live**: `fpgmaas/deptry` still answers and reports `full_name: osprey-oss/deptry`, and the file already carries the new name. Checked by reading `full_name` back — the ADOPTION-LOG's own lesson that `gh api` follows renames silently, applied to itself.

## 3. Harbor ground truth

`evals/cases/harbor-authz-groundtruth.json` — **16 code sites** across 6 handlers mapped to the 8 advisories, line numbers resolved by grepping the function definitions in a clone pinned at `b0506782b4`. Scoring unit is the **code site**, not the CVE id; a CVE named without a location is recorded as contamination, not a hit. Validated as JSON with `len(sites) == declared denominator`.
