### PR TITLE
Guard the empty-completion defect in the four remaining runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The same empty-completion defect was in four more runners — now guarded in all of
+  them.** After fixing `run-completeness.py`, a sweep found `run-clean.py`,
+  `run-decay.py`, `run-desc-routing.py` and `run-repo-audit.py` reading
+  `choices[0].message.content` raw with no check. That set includes **`run-clean.py`,
+  which produces the flagship +0.39** — and the two importers (`run-adjudication`,
+  `run-silent-open`) plus `run-competitors` inherit its `call()`, so four files cover all
+  twelve runners. Each guard was **watched to fire** against a stubbed
+  200-with-null-content response, not merely compiled: two exit with
+  `empty completion from …: finish_reason=length`, two raise it so their retry loop
+  engages first.
 - **`run-completeness.py` treated an empty completion as a successful call.** A reasoning
   model can spend its whole `max_tokens` budget on reasoning and return
   `content: null` under HTTP 200; the harness passed that to the judge, where it

--- a/evals/run-clean.py
+++ b/evals/run-clean.py
@@ -199,7 +199,13 @@ def call(model, key, prompt, temp=0.0):
                                  headers={"Authorization": f"Bearer {key}",
                                           "Content-Type": "application/json"})
     with urllib.request.urlopen(req, timeout=180) as r:
-        txt = json.load(r)["choices"][0]["message"]["content"]
+        d = json.load(r)
+    ch = d["choices"][0]
+    txt = ch["message"]["content"]
+    # HTTP 200 with null/empty content is NOT success (see run-completeness.py call()):
+    # None here would surface later as an AttributeError far from the cause.
+    if not txt:
+        sys.exit(f"empty completion from {model}: finish_reason={ch.get('finish_reason')}")
     s, e = txt.find("{"), txt.rfind("}")
     if s < 0 or e < 0:
         sys.exit(f"model did not return JSON:\n{txt[:400]}")

--- a/evals/run-decay.py
+++ b/evals/run-decay.py
@@ -127,7 +127,16 @@ def chat(model, messages, k, max_tokens=32000, temp=0.0):
                 "https://openrouter.ai/api/v1/chat/completions", data=body,
                 headers={"Authorization": f"Bearer {k}", "Content-Type": "application/json"})
             with urllib.request.urlopen(req, timeout=300) as r:
-                return json.load(r)["choices"][0]["message"]["content"]
+                d = json.load(r)
+            ch = d["choices"][0]
+            content = ch["message"]["content"]
+            # HTTP 200 with null/empty content is NOT success — a reasoning model can
+            # burn the whole max_tokens budget on reasoning and return nothing. Raise so
+            # the retry above engages, then fail loudly. See run-completeness.py call().
+            if not content:
+                raise RuntimeError(f"empty completion from {model}: "
+                                   f"finish_reason={ch.get('finish_reason')}")
+            return content
         except Exception as e:  # noqa: BLE001
             last = e
             import time

--- a/evals/run-desc-routing.py
+++ b/evals/run-desc-routing.py
@@ -93,7 +93,16 @@ def call(model, key, prompt, temp, tries=4):
                                          headers={"Authorization": f"Bearer {key}",
                                                   "Content-Type": "application/json"})
             with urllib.request.urlopen(req, timeout=180) as r:
-                return json.load(r)["choices"][0]["message"]["content"]
+                d = json.load(r)
+            ch = d["choices"][0]
+            content = ch["message"]["content"]
+            # HTTP 200 with null/empty content is NOT success — a reasoning model can
+            # burn the whole max_tokens budget on reasoning and return nothing. Raise so
+            # the retry above engages, then fail loudly. See run-completeness.py call().
+            if not content:
+                raise RuntimeError(f"empty completion from {model}: "
+                                   f"finish_reason={ch.get('finish_reason')}")
+            return content
         except Exception as e:  # transient network/5xx — retry with linear backoff
             if attempt == tries - 1:
                 raise

--- a/evals/run-repo-audit.py
+++ b/evals/run-repo-audit.py
@@ -107,7 +107,13 @@ def call(model, prompt, k, temp=0.0):
     req = urllib.request.Request("https://openrouter.ai/api/v1/chat/completions", data=body,
                                  headers={"Authorization": f"Bearer {k}", "Content-Type": "application/json"})
     with urllib.request.urlopen(req, timeout=240) as r:
-        txt = json.load(r)["choices"][0]["message"]["content"]
+        d = json.load(r)
+    ch = d["choices"][0]
+    txt = ch["message"]["content"]
+    # HTTP 200 with null/empty content is NOT success (see run-completeness.py call()):
+    # None here would surface later as an AttributeError far from the cause.
+    if not txt:
+        sys.exit(f"empty completion from {model}: finish_reason={ch.get('finish_reason')}")
     s, e = txt.find("["), txt.rfind("]")
     if s < 0 or e < 0:
         sys.exit(f"model did not return a JSON array:\n{txt[:400]}")


### PR DESCRIPTION
Fixing `run-completeness.py` last turn raised the obvious question — *is this defect anywhere else?* It was, in four more runners, including the one behind the flagship number.

| runner | shape | guard |
|---|---|---|
| `run-clean.py` | assign → `.find()` | `sys.exit` with finish reason |
| `run-repo-audit.py` | assign → `.find()` | `sys.exit` with finish reason |
| `run-decay.py` | `return` inside retry loop | `raise` so the retry engages first |
| `run-desc-routing.py` | `return` inside retry loop | `raise` so the retry engages first |

**`run-clean.py` produces the flagship +0.39**, and `run-adjudication`, `run-silent-open` and `run-competitors` inherit its `call()` — so these four files cover all twelve runners.

## Watched to fire, not just compiled

Each guard was proved against a **stubbed HTTP 200 carrying `content: null`**:

```
run-clean.py         SystemExit    empty completion from x: finish_reason=length
run-desc-routing.py  RuntimeError  empty completion from x: finish_reason=length
run-repo-audit.py    SystemExit    empty completion from x: finish_reason=length
run-decay.py         RuntimeError  empty completion from x: finish_reason=length
```

The stub is a better probe than a live API call here: it costs nothing, and it hits the branch deterministically rather than waiting for a reasoning model to intermittently exhaust its token budget — which is exactly how the original defect hid from the n=1 run at temp 0.

`test_scoring.py` passes 38 checks; invariants 16/16.
