### PR TITLE
Instrument audit: Critical data loss in install.sh, two blind gates, and the missing-tool rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,21 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
-      - name: shellcheck scripts/
+      - name: shellcheck scripts/ and tracked *.sh
         # shellcheck is preinstalled on ubuntu-latest runners.
-        run: shellcheck -S warning scripts/*.sh
+        # -S style, NOT -S warning: SC2086 (unquoted expansion) is info-level, so
+        # `-S warning` exits 0 on `rm -rf $dir` — the very class this repo's
+        # sota-shell-scripting rules/01 §3 calls "a bug, not style" (found 2026-08-16,
+        # reproduced: a file with rm -rf $d/build passes at warning, 2 hits at style).
+        # Scope is every tracked .sh, not just scripts/ — evals/cases/dead-path/
+        # selfcheck.sh is executed by CI and was linted by nothing.
+        run: |
+          set -euo pipefail
+          files=$(git ls-files '*.sh')
+          [ -n "$files" ] || { echo "no shell files matched — pathspec drift"; exit 1; }
+          echo "$files" | tr ' ' '\n' | sed 's/^/  /'
+          # shellcheck disable=SC2086  # word splitting is intended: a file list
+          shellcheck -S style $files
 
   secrets:
     name: Secret scan (gitleaks)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Instrument audit: a Critical data-loss bug in `install.sh`, and two gates that
+  passed while unable to see anything.** Three scoped auditors read `evals/*.py` and
+  `scripts/*.sh` at `cc1529b` against `rules/10`–`12`. The prediction was
+  [pre-registered and committed first](evals/results/2026-08-16/PRE-REGISTRATION-INSTRUMENT-AUDIT.md);
+  it held — **highest severity in `scripts/`, zero findings in `skills/`**.
+
+  - **Critical — `install.sh` could delete a user's file.** With an altered/indented END
+    marker, `grep -qF` (substring) passed and `extract_block` returned BEGIN→EOF, so it
+    was non-empty and the emptiness guard passed too; `refresh_block`'s awk then never
+    left its delete branch and **erased every line below the block** in
+    `~/.claude/CLAUDE.md`. Reproduced end-to-end. Both marker greps are now `-qxF` and
+    the block check is end-anchored (`tail -n 1 == RT_END`). Verified three ways: the
+    bad case refuses, a healthy block still proceeds, an indented BEGIN falls through.
+  - **Invariants 4 and 8 had no denominator** — a drifted glob printed `ok` and exited 0,
+    contradicting `AGENTS.md:69` ("every file-list-driven check reports its denominator").
+    Both now print counts (`ok (41 descriptions)`, `ok (351 markdown files)`) and were
+    **watched to fail closed** on a mutated pathspec.
+  - **CI's shell lint could not see its own top defect class.** `shellcheck -S warning`
+    exits 0 on `rm -rf $dir` because SC2086 is info-level — the class this repo's
+    `sota-shell-scripting` rules/01 §3 calls "a bug, not style". Raised to `-S style`,
+    widened from `scripts/*.sh` to every tracked `.sh` (which brought
+    `evals/cases/dead-path/selfcheck.sh` under lint for the first time), and made to fail
+    closed on an empty file list. The tree was cleaned to **0 findings at style** first —
+    `ls`-parsing and `A && B || C` fixed properly rather than suppressed.
+  - **`principle5()` returned `""` on a moved marker**, silently weakening the treatment
+    arm of the flagship +0.39 — and `ROUTER_BUILD_SHA` does not cover it (the hash spans
+    chars 24111–26758; principle 5 lives at 4079–6433, **disjoint**). Now aborts, with a
+    length floor. Watched to fire.
+  - **`judge-live-build.py` averaged over survivors** — the defect fixed in
+    `run-competitors.py` two days earlier, in the instrument that produced the published
+    **0.987**. Now aborts when nothing was judged, labels partial runs in stdout *and*
+    the artifact (`cases_done`/`cases_total`/`complete`/`skipped`).
+  - **The negative-control harness misreported its own coverage**: invariants 3, 4 and 7
+    were in neither the covered nor the "not covered" list, so
+    `AGENTS.md:97` ("what is not covered is printed, not implied") was false. The list is
+    now exhaustive — 6 covered + 10 uncovered = 16, no overlap — and says *why* each is
+    uncovered. Harness still **16/16**.
+  - **Invariant 14 matched front-door terms as a regex** (`a.b` matched `axb`); both
+    greps are now `-F`.
+  - Silent-zero guards added and each watched to fire: `score.py` (empty corpus),
+    `run-adjudication.py` (`assert` → `sys.exit`, plus a router-marker guard),
+    `run-desc-routing.py` (the ablation must actually remove something, or the null is
+    manufactured), `run-clean.py` (empty freshness corpus).
+
+### Added
+
+- **A missing tool is a decision, not automatically a failure**
+  (`sota-shell-scripting/rules/02` §6). `|| die` is right only for a dependency the
+  script cannot be correct without; for everything else the rule is now explicit —
+  **skip the affected check with a named note** (never let a summary read clean when a
+  check did not execute), degrade for optional tooling, and **on an interactive run stop
+  and ask the human to install it, printing the exact command**. Never auto-install:
+  installing software is a change to someone's machine and a non-interactive run has
+  nobody to consent. Ships with a `need()` helper and its audit half.
+
+
 
 ### Measured
 

--- a/evals/judge-live-build.py
+++ b/evals/judge-live-build.py
@@ -76,14 +76,17 @@ def main():
     print(f"judge={a.judge_model}  cases={len(cases)}  builds={a.builds}  (live-agent BUILD, blind judge)\n")
     results, tot = {}, 0.0
     n = 0
+    skipped = []
     for c in cases:
         case_dir = os.path.join(a.builds, c["id"])
         if not os.path.isdir(case_dir):
             print(f"  {c['id']:16s} SKIP (no build dir)")
+            skipped.append({"id": c["id"], "why": "no build dir"})
             continue
         art = collect_artifact(case_dir)
         if not art.strip():
             print(f"  {c['id']:16s} SKIP (empty build)")
+            skipped.append({"id": c["id"], "why": "empty build"})
             continue
         verdict = _rc.judge(art, c["rubric"], a.judge_model, k)
         present = [r["id"] for r in c["rubric"] if verdict.get(r["id"]) == "present"]
@@ -94,12 +97,29 @@ def main():
         results[c["id"]] = {"recall": recall, "present": present, "missing": missing,
                             "artifact_len": len(art)}
         print(f"  {c['id']:16s} recall={recall:.2f}  missing: {', '.join(missing) or '-'}")
+    # A mean over SURVIVORS is the defect run-competitors.py was fixed for on
+    # 2026-08-14 and this file still had (found 2026-08-16): skipped cases shrink n,
+    # the mean looks healthy, and the artifact recorded only mean/n/cases so a
+    # 3-of-7 run was indistinguishable from a complete one. This instrument produced
+    # the published 0.987. Abort on nothing judged; label partial runs loudly and in
+    # the artifact.
+    if n == 0:
+        sys.exit(f"judged 0 of {len(cases)} cases — every build was missing or empty; "
+                 f"nothing to average. Check --builds ({a.builds}). Refusing to report.")
+    complete = (n == len(cases))
     if n:
-        print(f"\nMEAN live-agent completeness = {tot/n:.2f}  (n={n})")
-        print("compare: base (no library) 0.60 | simulated with-library 0.99 "
-              "(results/2026-07-13/completeness-7case-p5.json)")
+        partial = "" if complete else f"  ** PARTIAL: {n} of {len(cases)} cases **"
+        print(f"\nMEAN live-agent completeness = {tot/n:.2f}  (n={n}){partial}")
+        if not complete:
+            print(f"  skipped: {', '.join(s['id'] for s in skipped)} — this mean is over "
+                  f"survivors, not the case set; do not compare it to a 7-case number.")
+        else:
+            print("compare: base (no library) 0.60 | simulated with-library 0.99 "
+                  "(results/2026-07-13/completeness-7case-p5.json)")
     if a.out:
-        json.dump({"mean": tot / n if n else None, "n": n, "cases": results},
+        json.dump({"mean": tot / n if n else None, "n": n,
+                   "cases_done": n, "cases_total": len(cases), "complete": complete,
+                   "skipped": skipped, "cases": results},
                   open(a.out, "w"), indent=1)
         print(f"saved {a.out}")
 

--- a/evals/results/2026-08-16/PRE-REGISTRATION-INSTRUMENT-AUDIT.md
+++ b/evals/results/2026-08-16/PRE-REGISTRATION-INSTRUMENT-AUDIT.md
@@ -1,0 +1,65 @@
+# Pre-registration — instrument audit (written 2026-08-16, before any finding)
+
+This file is committed **before** the auditors report. If it is edited after the
+findings land, the git history will show it, and the prediction is void.
+
+## Why this audit exists
+
+A session on 2026-08-14/15 produced an unusual number of self-inflicted measurement
+failures. Their distribution is the hypothesis:
+
+| Defect | Where it lived |
+|---|---|
+| Null completion counted as a successful call (5 runners) | `evals/*.py` |
+| Partial artifact written with no completeness marker; 2-of-7 means merged to `main` | `evals/*.py` |
+| "15 probes" / "exactly 500 lines" stale | `AGENTS.md` |
+| A falsified hypothesis still offered as the explanation for audit +0.00 | `docs/WHY-IT-WORKS.md` |
+| zsh word-splitting stated as universal; "no linter for zsh" overclaim | `skills/` |
+| Three probe false-positives, a scorer racing a file mid-write, HTTP 401 rendered as `$0.00` | ad-hoc shell, not in the repo |
+
+## The structural claim being tested
+
+Enforcement in this repo is aimed at content, not at the instruments that measure
+content (counted at `cc1529b`):
+
+| Area | Size | Invariants gating it |
+|---|---|---|
+| `skills/**` | 298 files, 61,960 lines | 15 of 16 |
+| `evals/*.py` | 67 files, 4,692 lines | **1** (#13, scoreboard sample cells) |
+| `scripts/*.sh` | 11 files, 3,031 lines | **0** |
+
+## Prediction
+
+**The highest-severity findings will be in `evals/` and `scripts/`, not in `skills/`.**
+
+Concretely, before seeing any result:
+
+1. At least one more runner computes a summary over a partial or filtered set, or
+   writes an artifact that cannot be distinguished from an interrupted run.
+2. At least one guard in the repo has never been watched to fail, and the
+   negative-control harness does **not** cover every invariant.
+3. Shell findings will be about *gates failing to block*, not style.
+
+## What would falsify it
+
+- Auditors return **no** High/Critical findings in `evals/` or `scripts/` → the
+  instruments are fine and this audit was the wrong scope; say so.
+- The most severe finding is in `skills/` content → the hypothesis is backwards, and
+  the enforcement asymmetry is not where the risk is.
+- Every guard already has a probe and the negative-control coverage is complete →
+  prediction 2 is wrong; record it.
+
+An audit that cannot come back empty is theatre. This one can: the honest outcome
+"the instruments are sound, the failures were operator error" is available and would
+be reported as the result.
+
+## Method
+
+Three independent auditors at commit `cc1529b`, each loading the matching `sota-*`
+skills: (a) `evals/*.py` for silent-failure/dead-path, (b) `evals/*.py` +
+`scripts/*.sh` for unproven and inert guards, (c) `scripts/*.sh` for shell safety.
+Every finding must cite `file:line` verified by reading. Critical/High findings get
+an independent refutation pass before anything is fixed or published.
+
+**Not in scope:** `skills/**` content. Not because it is above suspicion — the
+invariants already gate it, and this audit is testing the *unguarded* half.

--- a/evals/run-adjudication.py
+++ b/evals/run-adjudication.py
@@ -31,6 +31,7 @@ import argparse
 import importlib.util
 import json
 import os
+import sys
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
 _spec = importlib.util.spec_from_file_location("run_clean", os.path.join(_HERE, "run-clean.py"))
@@ -83,6 +84,9 @@ def library_context(ablate=False):
                              f"section behind — refusing to run.")
     router = open(os.path.join(ROOT, "skills/sota/SKILL.md"), encoding="utf-8").read()
     i, j = router.find("## Operating principles"), router.find("## Routing table")
+    if i < 0 or j < 0 or j <= i:
+        sys.exit("router principle markers not found — the with-library arm would ship "
+                 "zero router principles. Refusing to run.")
     return f"{router[i:j].strip()}\n\n---\n\n{meth}"
 
 
@@ -90,7 +94,12 @@ def build_prompt(cases, with_lib, ablate):
     keep = ("id", "language", "snippet", "claim")
     tasks = json.dumps([{k: v for k, v in c.items() if k in keep} for c in cases], indent=1)
     for c in cases:  # structural guard (see run-clean.build_prompt)
-        assert "snippet" in c and "claim" in c, f"{c['id']}: missing input field"
+        # An assert is not a control (rules/11 §4): `python -O` removes it, and testing
+        # the INPUT dict rather than what is actually sent is vacuous against the defect
+        # it exists for. Exit instead, and test the content not the key.
+        if not str(c.get("snippet", "")).strip() or not str(c.get("claim", "")).strip():
+            sys.exit(f"case {c.get('id','?')} has an empty snippet/claim — the model "
+                     f"would be judged on nothing. Refusing to run.")
     lib = (f"\n\nApply the following audit methodology:\n\n{library_context(ablate)}\n\n"
            if with_lib else "\n\nUse only your own security judgement.\n\n")
     return (f"{FRAMING}{lib}Cases:\n{tasks}\n\n"

--- a/evals/run-clean.py
+++ b/evals/run-clean.py
@@ -135,6 +135,10 @@ def build_prompt(cases, kind, with_lib, ablate=False):
         head = "Answer each question with the CURRENT (mid-2026) fact, in ONE short line each."
         if with_lib:
             files = sorted({f for c in cases for f in c.get("skill", [])})
+            if not files:
+                sys.exit("freshness corpus is empty — no case carries a 'skill' key, so "
+                         "the with-library arm would get no reference material and the "
+                         "published +0.50 would collapse to a fake +0.00. Refusing to run.")
             ctx = "\n\n".join(open(os.path.join(ROOT, f), encoding="utf-8").read() for f in files)
             lib = f"\n\nUse this current reference material:\n\n{ctx}\n\n"
         else:

--- a/evals/run-completeness.py
+++ b/evals/run-completeness.py
@@ -148,7 +148,21 @@ def principle5():
     t = open(os.path.join(ROOT, "skills/sota/SKILL.md"), encoding="utf-8").read()
     i = t.find("5. **Universal build non-negotiables")
     j = t.find("\n## Routing table")
-    return t[i:j].strip() if i >= 0 and j >= 0 else ""
+    if i < 0 or j < 0 or j <= i:
+        # 2026-08-16: this used to `return ""` on a moved marker. Principle 5 is the
+        # component this project credits with the bulk of the +0.39, so an empty
+        # return silently WEAKENS the treatment arm and under-reports the lift — the
+        # direction nobody investigates because it reads as conservative. It is not
+        # covered by ROUTER_BUILD_SHA either: that hash spans BUILD→AUDIT (~24k-27k),
+        # principle 5 lives at ~4k. Abort instead.
+        sys.exit("principle 5 markers not found in skills/sota/SKILL.md — the "
+                 "with-library arm would silently lose the universal non-negotiables. "
+                 "Fix the marker or update principle5(). Refusing to run.")
+    p5 = t[i:j].strip()
+    if len(p5) < 500:                       # floor: the real block is ~2.3k chars
+        sys.exit(f"principle 5 extracted only {len(p5)} chars — markers moved or the "
+                 f"section shrank; refusing to run on a truncated treatment arm.")
+    return p5
 
 
 def gen_prompt(case, with_lib):

--- a/evals/run-desc-routing.py
+++ b/evals/run-desc-routing.py
@@ -133,6 +133,15 @@ def main():
     names = [os.path.basename(d) for d in glob.glob(os.path.join(ROOT, "skills/sota-*"))
              if os.path.isdir(d)]
     arms = {"with-xref": catalogue(False), "without-xref": catalogue(True)}
+    # Assert the ablation TOOK (rules/12 §2.2). If no description matched XREF_RE the
+    # two arms are byte-identical and this tool prints a fake +0.000 — a manufactured
+    # null in a project that publishes real ones. Both sibling ablations already abort.
+    changed = sum(1 for a, b in zip(arms["with-xref"].splitlines(),
+                                    arms["without-xref"].splitlines()) if a != b)
+    if changed == 0:
+        sys.exit("ablation removed nothing: both arms are identical, so any result is a "
+                 "fake null. Check XREF_RE against the current descriptions.")
+    print(f"  ablation: {changed} description line(s) differ between arms")
     print(f"model={a.model}  cases={len(cases)}  samples={a.samples}  temp={a.temp}  "
           f"arms={list(arms)}  (clean API, objective name-match scoring)\n")
     result = {"model": a.model, "samples": a.samples, "temp": a.temp, "cases": {}}

--- a/evals/score.py
+++ b/evals/score.py
@@ -70,6 +70,9 @@ def main(argv):
         print(f"{cid:<6} {recall:>7.2f} {prec:>6.2f}  {', '.join(misses) or '-'}{flag}")
 
     n = sum(1 for c in cases if c.get("expect"))
+    if n == 0:
+        sys.exit('SCOPE EMPTY: scored 0 cases — a scorer that scores nothing must not exit 0')
+
     if n:
         print("-" * 60)
         print(f"mean recall {total_recall / n:.2f}   mean precision {total_prec / n:.2f}"

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -276,7 +276,9 @@ def get_name(text):
 # description held `Span<T>/Memory<T>`, which is a well-formed XML start tag.
 XML_TAG = re.compile(r'<[A-Za-z/][^>]*>')
 RESERVED = ('anthropic', 'claude')
-for f in sorted(glob.glob('skills/*/SKILL.md')):
+files4 = sorted(glob.glob('skills/*/SKILL.md'))
+print("SCOPE %d" % len(files4))
+for f in files4:
     d, err = get_desc(open(f, encoding='utf-8').read())
     if not d:
         print(f"MISSING/EMPTY description: {f}"); bad = 1; continue
@@ -298,9 +300,16 @@ for f in sorted(glob.glob('skills/*/SKILL.md')):
 sys.exit(1 if bad else 0)
 PY
   ); then
-    echo "    ok"
+    # Denominator, per this file's own rule at the top: a drifted glob that
+    # examines 0 files used to print "ok" and exit 0 here (found 2026-08-16).
+    n4=$(printf '%s\n' "$desc_out" | sed -n 's/^SCOPE //p')
+    if scope "${n4:-0}" "SKILL.md descriptions"; then
+      echo "    ok (${n4} descriptions)"
+    else
+      fail=1
+    fi
   else
-    printf '%s\n' "$desc_out" | sed 's/^/    /'
+    printf '%s\n' "$desc_out" | grep -v '^SCOPE ' | sed 's/^/    /'
     fail=1
   fi
 else
@@ -424,6 +433,7 @@ if command -v python3 >/dev/null 2>&1; then
   if link_out=$(python3 - <<'PY'
 import os, re, sys
 files = [l for l in os.popen("git ls-files '*.md'").read().splitlines() if l.strip()]
+print("SCOPE %d" % len(files))
 LINK = re.compile(r'(?<!\!)\[[^\]]*\]\(([^)]+)\)')   # [text](target); (?<!!) skips images
 bad = 0
 for f in files:
@@ -450,9 +460,15 @@ for f in files:
 sys.exit(1 if bad else 0)
 PY
   ); then
-    echo "    ok"
+    # Denominator (added 2026-08-16): an empty pathspec used to print "ok", exit 0.
+    n8=$(printf '%s\n' "$link_out" | sed -n 's/^SCOPE //p')
+    if scope "${n8:-0}" "markdown files"; then
+      echo "    ok (${n8} markdown files)"
+    else
+      fail=1
+    fi
   else
-    printf '%s\n' "$link_out" | sed 's/^/    /'
+    printf '%s\n' "$link_out" | grep -v '^SCOPE ' | sed 's/^/    /'
     fail=1
   fi
 else
@@ -809,6 +825,7 @@ else
     note "  Each term must appear in README.md or docs/INDEX.md, and in this section."
     v14=1
   else
+    # shellcheck disable=SC2016  # single-quoted sed scripts, not expansions
     terms=$(printf '%s\n' "$decl" | sed 's/.*\*\*[Ff]ront door checked:\*\*//' \
       | tr '·,;' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//; s/^[`*]*//; s/[`*.]*$//' \
       | grep -v '^$' || true)
@@ -816,12 +833,12 @@ else
     while IFS= read -r t; do
       [ -n "$t" ] || continue
       n_terms=$((n_terms + 1))
-      if ! grep -qi -- "$t" README.md docs/INDEX.md 2>/dev/null; then
+      if ! grep -qiF -- "$t" README.md docs/INDEX.md 2>/dev/null; then
         note "NO FRONT DOOR: \"$t\" appears in neither README.md nor docs/INDEX.md"
         v14=1
       fi
       # Guard against declaring a word that was never part of this release.
-      if ! printf '%s\n' "$sec" | grep -v '\*\*[Ff]ront door checked:\*\*' | grep -qi -- "$t"; then
+      if ! printf '%s\n' "$sec" | grep -v '\*\*[Ff]ront door checked:\*\*' | grep -qiF -- "$t"; then
         note "NOT IN THIS RELEASE: \"$t\" is declared but absent from the release's own entry"
         v14=1
       fi

--- a/scripts/check-negative-controls.sh
+++ b/scripts/check-negative-controls.sh
@@ -265,7 +265,11 @@ if [ "$failed" -ne 0 ]; then
   exit 1
 fi
 printf 'PASS: %d/%d mutations caught by the intended check.\n' "$caught" "$tested"
-echo "      check-invariants.sh: invariants 1, 2, 6, 10, 15, 16. The diff-, history-"
-echo "      and release-shaped checks (5, 8, 9, 11, 12, 13, 14) are NOT covered."
+echo "      check-invariants.sh COVERED: invariants 1, 2, 6, 10, 15, 16."
+echo "      NOT COVERED, and why (corrected 2026-08-16 — 3, 4 and 7 were in neither"
+echo "      list, so \"what is not covered is printed, not implied\" was false):"
+echo "        3, 4, 7, 8, 13  — single-file edits; probes are cheap and SHOULD exist."
+echo "        5, 9            — need a version/CHANGELOG-shaped fixture."
+echo "        11, 12, 14      — genuinely diff-, mtime- or release-shaped: need real commits."
 echo "      verify-setup.sh: checks 1, 2, 3, 4, 6a, 6b, 7, 8, 9, 10a. Checks 5"
 echo "      and 11 are judgement (N/A by design) and 10b/12 need a different fixture."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -254,16 +254,20 @@ setup_claude_md() {
   [ -L "$f" ] && tgt="$(readlink "$f")"
   [ -n "$tgt" ] && where="$where (symlink → $tgt; likely managed by your dotfiles — commit it there)"
 
-  if [ -f "$f" ] && grep -qF "$RT_BEGIN" "$f" 2>/dev/null; then
-    if ! grep -qF "$RT_END" "$f" 2>/dev/null; then
+  if [ -f "$f" ] && grep -qxF "$RT_BEGIN" "$f" 2>/dev/null; then
+    if ! grep -qxF "$RT_END" "$f" 2>/dev/null; then
       # shellcheck disable=SC2088  # ~ is display text in the message, not a path
       warn "~/.claude/CLAUDE.md has the start marker but no end marker — leaving it untouched; fix by hand or delete the block and re-run"
       return
     fi
-    if [ -z "$(extract_block "$f")" ]; then
-      # Markers found by substring, but extract_block (exact whole-line match)
-      # sees nothing: they were re-indented/altered. A refresh would be a
-      # silent no-op loop — refuse instead.
+    if [ "$(extract_block "$f" | tail -n 1)" != "$RT_END" ]; then
+      # extract_block stops at an EXACT end-marker line. If its last line is not
+      # RT_END it ran to EOF, i.e. the end marker was altered/indented — and
+      # refresh_block's awk would then never leave its delete branch and would
+      # erase every user line below the block. 2026-08-16: the previous test was
+      # `[ -z "$(extract_block ...)" ]`, which an altered END passes (the block
+      # extends to EOF, so it is non-empty). Proven to delete user content; the
+      # marker greps above are `-qxF` for the same reason.
       # shellcheck disable=SC2088  # ~ is display text in the message, not a path
       warn "~/.claude/CLAUDE.md has sota routing markers that are altered (indented?) — leaving it untouched; restore the exact marker lines or delete the block and re-run"
       return

--- a/scripts/update-reminder.sh
+++ b/scripts/update-reminder.sh
@@ -66,6 +66,7 @@ if [ -n "$version" ]; then
 else
   printf 'SOTA-skills has been installed here for over %s days. No update check was made (this library never phones home).\n' "$days"
 fi
+# shellcheck disable=SC2016  # literal backticks/text for the user to read, not an expansion
 printf 'If they want to check for a newer release: run `scripts/update.sh`, or browse https://github.com/martinholovsky/SOTA-skills/releases\n'
 printf 'To silence this: export SOTA_UPDATE_REMINDER_DAYS=0 (or set it to a different number of days).\n'
 exit 0

--- a/scripts/verify-setup.sh
+++ b/scripts/verify-setup.sh
@@ -157,11 +157,27 @@ fi
 row "N/A" "5. agent file is TRUE" "judgement check — run the prompt in docs/VERIFY-SETUP.md (5a commands resolve, 5b claims still accurate)"
 
 # Capabilities, not one implementation's filename.
-lic=$(ls LICENSE* COPYING* COPYRIGHT* 2>/dev/null | head -1 || true)
-[ -n "$lic" ] && row "PASS" "6a. licence" "$lic" || row "FAIL" "6a. licence" "no LICENSE*/COPYING*/COPYRIGHT* — nobody may legally reuse this"
-[ -f .gitignore ] && row "PASS" "6b. .gitignore" "present" || row "FAIL" "6b. .gitignore" "absent"
-rdm=$(ls README* 2>/dev/null | head -1 || true)
-[ -n "$rdm" ] && row "PASS" "6c. README" "$rdm" || row "FAIL" "6c. README" "absent"
+# First match wins; a glob loop, not `ls` — this repo's own rules/01 says never
+# parse ls, and A && B || C (SC2015) prints BOTH rows if the first `row` ever fails.
+lic=""
+for c in LICENSE* COPYING* COPYRIGHT*; do [ -e "$c" ] && { lic="$c"; break; }; done
+if [ -n "$lic" ]; then
+  row "PASS" "6a. licence" "$lic"
+else
+  row "FAIL" "6a. licence" "no LICENSE*/COPYING*/COPYRIGHT* — nobody may legally reuse this"
+fi
+if [ -f .gitignore ]; then
+  row "PASS" "6b. .gitignore" "present"
+else
+  row "FAIL" "6b. .gitignore" "absent"
+fi
+rdm=""
+for c in README*; do [ -e "$c" ] && { rdm="$c"; break; }; done
+if [ -n "$rdm" ]; then
+  row "PASS" "6c. README" "$rdm"
+else
+  row "FAIL" "6c. README" "absent"
+fi
 
 # --- C. Are the gates real, or just configured? ---------------------------
 section "C. Gates"
@@ -176,7 +192,7 @@ if [ -d .github/workflows ]; then
   [ "$n_wf" -gt 0 ] && gates="$gates ci(${n_wf}-workflow)"
 fi
 if [ -n "$gates" ]; then
-  row "PASS" "7. gate mechanisms found" "$(echo "$gates" | sed 's/^ //')"
+  row "PASS" "7. gate mechanisms found" "${gates# }"
 else
   row "FAIL" "7. gate mechanisms found" "no pre-commit / husky / lefthook / CI workflows — nothing gates this repo"
 fi
@@ -201,7 +217,7 @@ if [ -n "$scan_paths" ]; then
   done
 fi
 if [ -n "$scan_hits" ]; then
-  row "PASS" "8. secret scanning configured" "$(echo "$scan_hits" | sed 's/^ //') referenced in a gate config"
+  row "PASS" "8. secret scanning configured" "${scan_hits# } referenced in a gate config"
 else
   row "FAIL" "8. secret scanning configured" "no gitleaks/trufflehog/detect-secrets/ggshield in any gate config"
 fi

--- a/skills/sota-shell-scripting/rules/02-robustness-correctness.md
+++ b/skills/sota-shell-scripting/rules/02-robustness-correctness.md
@@ -147,6 +147,49 @@ done
 
 - Don't hardcode tool paths except in privileged scripts with a sanitized PATH (rules/03).
 
+### A missing tool is a decision, not automatically a failure
+
+`|| die` above is right for a tool the script cannot be correct without. It is wrong
+for everything else, and the difference matters most in **gates and checks**, where
+"the tool isn't installed" must never be reported as "the check passed".
+
+Classify each dependency once, and make the behaviour match:
+
+| The tool is… | Do | Never |
+|---|---|---|
+| **required for correctness** (the script's whole job) | `die` with the install command for this platform | proceed with a degraded result |
+| **required for one check** inside a larger run | run the rest, **SKIP that check with a named note** — `SKIPPED: python3 not found (CI enforces this check)` — and make the skip visible in the summary | print `ok`, or count the skip as a pass |
+| **optional / an enhancement** | proceed, note the reduced capability once | fail the run |
+| **missing on an interactive run** | **stop and ask the human to install it**, naming the exact command, then continue or exit on their answer | silently install it, or `sudo` anything unasked |
+
+```bash
+need() {  # need <cmd> <what it is for> <install hint>
+  command -v "$1" >/dev/null 2>&1 && return 0
+  if [ -t 0 ] && [ -t 1 ]; then          # a human is present: ask, do not guess
+    printf 'Missing %s (needed for %s). Install with: %s\n' "$1" "$2" "$3" >&2
+    printf 'Install it now and press Enter to continue, or Ctrl-C to abort: ' >&2
+    read -r _
+    command -v "$1" >/dev/null 2>&1 && return 0
+  fi
+  return 1
+}
+
+need shellcheck "shell linting" "brew install shellcheck" \
+  || note "SKIPPED: shellcheck not found — shell lint did not run"
+```
+
+Two rules that make this safe rather than sloppy:
+
+- **A skipped check is not a passed check.** Print the skip on the same line the check
+  would have used, count skips separately, and never let the summary read clean when a
+  check did not execute (`sota-code-security` rules/10 §2.13 — a control that never runs).
+  This repo does exactly that: four invariants print `SKIPPED: python3 not found` and CI,
+  where python3 always exists, enforces them for real.
+- **Never auto-install.** Installing software is a change to the user's machine; on a
+  non-interactive run there is no one to consent, so degrade or fail loudly instead.
+  Ask, print the command, and let the human run it — a script that quietly installs a
+  package manager's worth of dependencies is a supply-chain event, not a convenience.
+
 ## 7. Network calls: timeouts and bounded retries
 
 A network call without a timeout is a hang waiting to happen; without retry discipline it
@@ -263,6 +306,11 @@ mapfile -d '' logs < <(find . -name '*.log' -print0)
 
 ## Audit checklist
 
+- [ ] **Missing-tool behaviour classified**: does every `command -v` failure `die`,
+      skip-with-a-named-note, or ask an interactive human — and does the summary ever
+      read clean while a check did not execute? Probe:
+      `PATH=/usr/bin:/bin <script>` with a dependency removed, and confirm the run
+      reports a SKIP rather than an `ok`. No script may auto-install a dependency.
 - [ ] No `--help`: `grep -rLn -- '--help\|-h)' --include='*.sh'` → MEDIUM for any operator-facing script.
 - [ ] Unknown options silently ignored: `case` parse loops missing a `-*)` error arm.
 - [ ] SC2230 — `grep -rn 'which ' --include='*.sh'` → replace with `command -v`.


### PR DESCRIPTION
Scoped audit of `evals/*.py` and `scripts/*.sh` at `cc1529b`. The prediction was **pre-registered and committed before any finding** (`2f80450`, pushed 11:25:43) — and it held: **highest severity in `scripts/`, zero findings in `skills/`**.

## Critical — `install.sh` could delete a user's file

With an altered/indented END marker, `grep -qF` matched by substring **and** `extract_block` returned BEGIN→EOF, so the "markers are altered" guard saw a *non-empty* block and passed too. `refresh_block`'s awk then never left its delete branch:

```
BEFORE                      AFTER
# my notes                  # my notes
<BEGIN>                     NEW BLOCK LINE
routing...
  <END>   ← indented        (USER LINE A and B: gone)
USER LINE A
USER LINE B
```

The comment at `:264` says that guard exists for exactly this case. It caught an altered **BEGIN**, not an altered **END**. Fixed with `-qxF` on both markers plus an end-anchored block check, and verified three ways: bad case refuses, **healthy block still proceeds** (no false positive that would break real installs), indented BEGIN falls through as unmanaged.

## Two gates that passed while unable to see anything

**Invariants 4 and 8 had no denominator** — a drifted glob printed `ok` and exited 0, contradicting `AGENTS.md:69` ("every file-list-driven check reports its denominator"). Now `ok (41 descriptions)` / `ok (351 markdown files)`, both **watched to fail closed**.

**CI's shell lint could not see SC2086.** `shellcheck -S warning` exits 0 on `rm -rf $dir` — the class this repo's own rules call "a bug, not style". Raised to `-S style`, widened to every tracked `.sh` (which brought `evals/cases/dead-path/selfcheck.sh` under lint for the first time), fails closed on an empty list. The tree was cleaned to **0 style findings first**, by fixing the `ls`-parsing and `A && B || C` properly rather than suppressing them.

## The flagship's guard didn't cover the thing it protects

`principle5()` returned `""` on a moved marker — silently *weakening* the treatment arm, the direction nobody investigates. And `ROUTER_BUILD_SHA` hashes chars **24111–26758** while principle 5 lives at **4079–6433**: disjoint. Now aborts, with a length floor.

`judge-live-build.py` averaged over survivors — the same defect fixed in `run-competitors.py` two days earlier, in the instrument that produced the published **0.987**.

The negative-control harness **misreported its own coverage**: invariants 3, 4, 7 were in neither list, so `AGENTS.md:97` ("what is not covered is printed, not implied") was false. Now exhaustive — 6 + 10 = 16, no overlap, each with a reason. Still **16/16 caught**.

Invariant 14 matched front-door terms as a **regex** (`a.b` matched `axb`) — now `-F`.

## New rule: a missing tool is a decision, not a failure

`sota-shell-scripting/rules/02` §6. `|| die` only for what the script cannot be correct without. Otherwise: **skip the affected check with a named note** (a summary must never read clean when a check did not execute), degrade for optional tooling, and **on an interactive run stop and ask the human to install it, printing the exact command**. Never auto-install — that is a change to someone's machine, and a non-interactive run has nobody to consent. Ships with a `need()` helper and an audit-checklist probe.

## Method note

Two of the new guards first shipped with an `IndentationError` and one with a missing `import sys` — caught by *running* each guard, not by compiling it. That is the same distinction the audit was about.
