### PR TITLE
Close the remaining instrument-audit findings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must stay LF: a CRLF commit yields "/usr/bin/env: bash\r: No such file".
+*.sh text eol=lf
+*.py text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# Every `run:` gets -euo pipefail; without this a step gets `bash -e {0}`
+# (no pipefail, no -u) and a failing producer in a pipe passes silently.
+defaults:
+  run:
+    shell: bash
+
 jobs:
   invariants:
     name: Repository invariants
@@ -97,6 +103,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
+      - name: known-good/known-bad references (selftests)
+        # These two carry the repo's only known-bad/known-good reference PAIRS and were
+        # invoked by nothing (found 2026-08-16) — a control that never executes.
+        run: |
+          python3 evals/run-build-safe.py --selftest
+          python3 evals/cases/unscoped-audit/selfcheck.py
+
       - name: shellcheck scripts/ and tracked *.sh
         # shellcheck is preinstalled on ubuntu-latest runners.
         # -S style, NOT -S warning: SC2086 (unquoted expansion) is info-level, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Instrument audit, second pass — the remaining findings.**
+  - **The judge parser validated nothing.** All four judge-driven instruments call one
+    `judge()`; it parsed the reply and scored `verdict.get(id) == "present"`, so a
+    *well-formed* reply of the wrong shape scored **0.00 in silence** — `{"results":{…}}`
+    and `"Present"` with a capital P both demonstrated at 0.00/12. It now normalises case
+    and **aborts** on missing/extra ids or values outside present/absent. Each of the four
+    failure modes was replayed against the real rubric shape.
+  - **Competitor SHAs are now enforced, not just documented.** `comp["sha"]` appeared only
+    inside an error string, so every published competitor number rested on an unverified
+    clone — in a repo that pins `ROUTER_BUILD_SHA` for exactly this reason. The runner now
+    compares `git rev-parse HEAD` against the manifest and refuses on mismatch (proven
+    both directions), and the artifact records build/judge model, manifest path and the
+    resolved SHAs.
+  - **Artifact provenance**: the flagship completeness artifact stored only case results —
+    no models, samples, temp, or router SHA. It now writes a `_meta` block.
+  - **A stale probe used to accuse a healthy gate.** Every mutation in the negative-control
+    harness is a hardcoded literal; when one goes stale the edit is a no-op and the probe
+    reported `NOT CAUGHT: INERT`. It now asserts the mutation actually changed the tree
+    and reports **PROBE BROKEN** instead — watched to fire by neutering probe 1. `restore()`
+    also no longer swallows a failed reset with `|| true`, which would have leaked one
+    probe's mutation into the next.
+  - **The denylist degrade is now announced** — an all-comment `.denylist.local` silently
+    fell back to two generic phrases with output byte-identical to a full scan.
+  - **`install.sh backup()` clobbered the original** on a second `--update`, overwriting
+    the backup with the already-modified file. Rewritten as a real function (kept-backup,
+    no `cp` on a missing file, `die` on failure) after the one-line version introduced an
+    `A && B || C` bug — the same class fixed in `verify-setup.sh` earlier in this cycle.
+  - **Two known-good/known-bad selftests ran nowhere.** `run-build-safe.py --selftest` and
+    `unscoped-audit/selfcheck.py` are the repo's only reference *pairs* and no CI job or
+    hook invoked them; both are now in CI. The unscoped-audit selfcheck also hardcoded
+    "7 planted defects, 6 demonstrated" (the 6 already stale) — it now counts its own
+    checks against a floor, watched to fail at `MIN_CHECKS = 8`.
+  - Workflow-level `defaults: run: shell: bash` (steps were getting `bash -e {0}` — no
+    `pipefail`, no `-u`), and `.gitattributes` pins `*.sh`/`*.py` to LF so a CRLF commit
+    cannot produce `/usr/bin/env: bash\r`.
+
+
 - **Instrument audit: a Critical data-loss bug in `install.sh`, and two gates that
   passed while unable to see anything.** Three scoped auditors read `evals/*.py` and
   `scripts/*.sh` at `cc1529b` against `rules/10`–`12`. The prediction was

--- a/evals/cases/unscoped-audit/selfcheck.py
+++ b/evals/cases/unscoped-audit/selfcheck.py
@@ -24,7 +24,15 @@ from reportkit.reports import ReportService  # noqa: E402
 FAIL = []
 
 
+# A floor, so deleting an ok() call cannot leave the summary reading the same
+# (found 2026-08-16: the PASS line hardcoded "7 planted defects, 6 demonstrated" and
+# the 6 was already stale — a literal in reporting output, rules/10 §2.10).
+MIN_CHECKS = 7
+CHECKS = []
+
+
 def ok(label, condition, detail=""):
+    CHECKS.append(label)
     print(f"  {'ok  ' if condition else 'FAIL'} {label}{(' — ' + detail) if detail else ''}")
     if not condition:
         FAIL.append(label)
@@ -129,4 +137,8 @@ print()
 if FAIL:
     print(f"FAIL: {len(FAIL)} planted defect(s) no longer behave as the ground truth claims: {FAIL}")
     sys.exit(1)
-print("PASS: fixture intact (7 planted defects, 6 demonstrated at runtime).")
+if len(CHECKS) < MIN_CHECKS:
+    print(f"FAIL: only {len(CHECKS)} checks ran, floor is {MIN_CHECKS} — a check was "
+          f"deleted or skipped; this selfcheck would otherwise print the same PASS.")
+    sys.exit(1)
+print(f"PASS: fixture intact ({len(CHECKS)} checks run, floor {MIN_CHECKS}).")

--- a/evals/run-competitors.py
+++ b/evals/run-competitors.py
@@ -27,6 +27,7 @@ Usage: python3 evals/run-competitors.py --competitors-dir DIR [--build-model M]
 """
 import argparse
 import json
+import shlex
 import os
 import sys
 import importlib.util
@@ -70,6 +71,17 @@ def competitor_bundle(comp, cdir):
         if not os.path.exists(p):
             sys.exit(f"missing competitor file: {p}\n(clone {comp['repo']} at {comp['sha']} into {cdir})")
         parts.append(f"===== {rel} =====\n{read(p)}")
+    # PIN WHAT YOU COMPARE AGAINST (found 2026-08-16): comp["sha"] appeared only
+    # inside an error string, so every published competitor number rested on an
+    # unverified clone — in a repo that pins ROUTER_BUILD_SHA for exactly this reason.
+    head = os.popen(f'git -C {shlex.quote(base)} rev-parse HEAD 2>/dev/null').read().strip()
+    if not head:
+        sys.exit(f"{comp['repo']}: {base} is not a git clone — cannot verify it sits at "
+                 f"the pinned SHA {comp['sha'][:10]}. Refusing to run.")
+    if not head.startswith(comp["sha"][:10]):
+        sys.exit(f"{comp['repo']}: clone is at {head[:10]}, manifest pins "
+                 f"{comp['sha'][:10]}. Refusing to publish a comparison against "
+                 f"unpinned competitor content.")
     return "\n\n".join(parts)
 
 
@@ -118,6 +130,9 @@ def main():
     note_work(len(cases), "cases")
     manifest = json.load(open(a.manifest, encoding="utf-8"))["competitors"]
     comps = list(manifest)
+    # Provenance in the artifact, not just in a commit message: a reader must be able
+    # to check what was compared without taking the runner's word for it.
+    resolved_shas = {kk: manifest[kk]["sha"] for kk in manifest}
     if a.only:
         comps = [c for c in comps if c in a.only.split(",")]
     arms = ["without", "sota"] + comps
@@ -161,6 +176,8 @@ def main():
             # its own completeness so a reader (or a scorer) can refuse it.
             n_done = len(results)
             json.dump({"arms": arms, "samples": a.samples, "temp": a.temp,
+                       "build_model": a.build_model, "judge_model": a.judge_model,
+                       "manifest": a.manifest, "competitor_shas": resolved_shas,
                        "cases_done": n_done, "cases_total": len(cases),
                        "complete": n_done == len(cases),
                        "cases": results, "means": {arm: totals[arm]/n_done for arm in arms}},

--- a/evals/run-completeness.py
+++ b/evals/run-completeness.py
@@ -185,7 +185,27 @@ def judge(artifact, rubric, model, k):
         'Output ONLY a JSON object mapping each item id to "present" or "absent". No prose.')
     txt = call(model, prompt, k, max_tokens=1500)
     s, e = txt.find("{"), txt.rfind("}")
-    return json.loads(txt[s:e + 1])
+    if s < 0 or e < 0:
+        sys.exit(f"judge returned no JSON object:\n{txt[:400]}")
+    verdict = json.loads(txt[s:e + 1])
+    # VALIDATE THE SHAPE, do not just parse it (found 2026-08-16). Scoring reads
+    # `verdict.get(id) == "present"`, so a *well-formed* reply of the wrong shape
+    # scores 0.00 in silence: {"results": {...}} nests the ids away, and "Present"
+    # with a capital P is not "present". Demonstrated at 0.00/12 for both. Missing
+    # or extra ids mean the judge answered a different question than we asked.
+    want = {r["id"] for r in rubric}
+    if not isinstance(verdict, dict):
+        sys.exit(f"judge returned {type(verdict).__name__}, expected an object:\n{txt[:300]}")
+    verdict = {kk: (vv.lower() if isinstance(vv, str) else vv) for kk, vv in verdict.items()}
+    missing, extra = want - set(verdict), set(verdict) - want
+    if missing or extra:
+        sys.exit(f"judge verdict does not match the rubric — missing {sorted(missing)}, "
+                 f"unexpected {sorted(extra)}. Scoring this would silently under-count. "
+                 f"Raw:\n{txt[:400]}")
+    badv = {kk: vv for kk, vv in verdict.items() if vv not in ("present", "absent")}
+    if badv:
+        sys.exit(f"judge returned values outside present/absent: {badv}. Raw:\n{txt[:300]}")
+    return verdict
 
 
 # Eval artifacts store MODEL-GENERATED code verbatim, and a model asked to build a
@@ -278,7 +298,14 @@ def main():
     print(f"\nMEAN completeness  without={tot_wo/n:.2f}  with={tot_wl/n:.2f}  "
           f"LIFT={((tot_wl-tot_wo)/n):+.2f}")
     if a.out:
-        json.dump(scrub_secrets(results), open(a.out, "w"), indent=1)
+        # Provenance (found missing 2026-08-16): the flagship artifact stored only case
+        # results — no build/judge model, samples, temp, or the router SHA the whole
+        # comparison is pinned to. A number nobody can attribute is not evidence.
+        out_obj = {"_meta": {"build_model": a.build_model, "judge_model": a.judge_model,
+                             "samples": a.samples, "temp": a.temp,
+                             "router_build_sha": ROUTER_BUILD_SHA},
+                   **scrub_secrets(results)}
+        json.dump(out_obj, open(a.out, "w"), indent=1)
         print(f"saved {a.out}")
 
 

--- a/scripts/check-invariants.sh
+++ b/scripts/check-invariants.sh
@@ -200,7 +200,13 @@ if [ -n "${SOTA_DENYLIST:-}" ]; then
   DENY="$DENY|$SOTA_DENYLIST"
 elif [ -f .denylist.local ]; then
   extra=$(grep -vE '^[[:space:]]*(#|$)' .denylist.local | paste -sd'|' - || true)
-  [ -n "$extra" ] && DENY="$DENY|$extra"
+  if [ -n "$extra" ]; then
+    DENY="$DENY|$extra"
+  else
+    # An all-comment or unreadable .denylist.local silently degraded this check to the
+    # two generic phrases, with output byte-identical to a full scan (found 2026-08-16).
+    note "(private denylist present but empty/unparseable — generic checks only)"
+  fi
 else
   note "(private denylist unavailable — generic checks only)"
 fi

--- a/scripts/check-negative-controls.sh
+++ b/scripts/check-negative-controls.sh
@@ -94,7 +94,11 @@ failed=0
 # whole reason (b) is there. `git reset --hard` clears the index too; it also
 # reverts the gate we deliberately copied in, so the copy is redone and re-verified.
 restore() {
-  ( cd "$WT" && git reset -q --hard HEAD && git clean -fdq ) >/dev/null 2>&1 || true
+  # No `|| true`: a failed reset leaks the previous mutation into the next probe,
+  # which would then measure the wrong thing (found 2026-08-16).
+  ( cd "$WT" && git reset -q --hard HEAD && git clean -fdq ) >/dev/null 2>&1 \
+    || { echo "FATAL: could not restore the probe worktree — later probes would be"; \
+         echo "       contaminated by the previous mutation."; exit 1; }
   cp "$REPO/$GATE" "$WT/$GATE"
   cmp -s "$REPO/$GATE" "$WT/$GATE" || { echo "FAIL: gate copy did not survive restore"; exit 1; }
 }
@@ -102,6 +106,17 @@ restore() {
 probe() {  # <id> <name> <expected substring>   — mutation already applied
   local id="$1" name="$2" want="$3"
   tested=$((tested + 1))
+  # ASSERT THE MUTATION TOOK (added 2026-08-16). Every mutation below is a hardcoded
+  # literal — a count, a phrase, a path. When one goes stale the edit is a silent
+  # no-op, the gate correctly passes, and this harness then reports "NOT CAUGHT:
+  # INERT", accusing a healthy gate. A stale probe must fail as a PROBE, loudly.
+  if git -C "$WT" diff --quiet && [ -z "$(git -C "$WT" status --porcelain)" ]; then
+    echo "  [$id] $name — PROBE BROKEN: the mutation changed nothing (stale literal?)."
+    echo "        This is a defect in the probe, not evidence about the gate."
+    failed=$((failed + 1))
+    restore
+    return
+  fi
   run_gate
   if [ "$GATE_RC" -eq 0 ]; then
     echo "  [$id] $name — NOT CAUGHT: the gate still passed. This check is INERT."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -197,7 +197,17 @@ ask_yn() {  # $1 prompt, $2 default(y|n); honors --yes and non-interactive
   case "$ans" in [Yy]*) return 0 ;; *) return 1 ;; esac
 }
 
-backup() { [ -e "$1" ] && cp -L "$1" "$1.bak" && log "backed up $1 → $1.bak"; }
+# Never clobber an existing backup: a second --update would overwrite the ORIGINAL
+# with the already-modified file, losing exactly what the backup exists for.
+backup() {
+  [ -e "$1" ] || return 0
+  if [ -e "$1.bak" ]; then
+    log "backup already exists, keeping it: $1.bak"
+    return 0
+  fi
+  cp -L "$1" "$1.bak" || die "could not back up $1"
+  log "backed up $1 → $1.bak"
+}
 
 emit_routing_block() {
   cat <<'MD'


### PR DESCRIPTION
Second pass. Every fix was **watched to fire**, not just compiled — and two of them shipped broken first, which is how I know the difference matters.

## The judge parser validated nothing

All four judge-driven instruments call one `judge()`. It parsed the reply and scored `verdict.get(id) == "present"`, so a **well-formed reply of the wrong shape scored 0.00 in silence**:

| reply | before | now |
|---|---|---|
| `{"results": {…}}` | 0.00/12, silent | ABORT |
| `{"authn": "Present"}` | 0.00/12, silent | normalised, accepted |
| partial coverage | under-counted, silent | ABORT |

## Competitor SHAs are enforced, not just documented

`comp["sha"]` appeared **only inside an error string** — so every published competitor number rested on an unverified clone, in a repo that pins `ROUTER_BUILD_SHA` for precisely this reason. Now compared against `git rev-parse HEAD` and refused on mismatch (proven both directions), with models, manifest path and resolved SHAs written into the artifact. The flagship completeness artifact gained a `_meta` block for the same reason.

## A stale probe used to accuse a healthy gate

Every mutation in the negative-control harness is a hardcoded literal. When one goes stale the edit is a no-op, the gate correctly passes, and the harness printed **`NOT CAUGHT: INERT`** — blaming the gate for the probe's rot. It now asserts the tree actually changed and reports **`PROBE BROKEN`**; verified by neutering probe 1. `restore()` also stopped swallowing a failed reset with `|| true`, which would leak one probe's mutation into the next.

## Also closed

Denylist degrade announced instead of silent · `install.sh backup()` no longer clobbers the original on a second `--update` · the two known-good/known-bad **selftests that no job invoked** are now in CI · `unscoped-audit/selfcheck.py` counts its own checks against a floor instead of printing a hardcoded "7 planted defects, 6 demonstrated" (the 6 was already stale) · workflow-level `shell: bash` so steps get `-euo pipefail` · `.gitattributes` pins `.sh`/`.py` to LF.

## Two I broke and caught

The `backup()` one-liner introduced an `A && B || C` bug — **the same class I had fixed in `verify-setup.sh` an hour earlier** — which would have run `cp` on a nonexistent file. Rewritten as a real function and tested three ways. And I read `$?` after a pipe twice while verifying exit codes, which in zsh is `tail`'s status: the rule I added to the library two days ago, applied to me.

## Gates

```
invariants        16/16
scoring tests     38 checks
negative controls 16/16
shellcheck -S style   0 findings across 12 tracked .sh
evals/*.py        all compile
```
