### PR TITLE
Probe 5 more invariants; close the last audit findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,10 @@ Keep it under 200: put detail in `CONTRIBUTING.md` and leave a pointer.
 **Every file-list-driven check reports its denominator** (`ok (257 rules files)`)
 and **fails closed on an empty scope**. Added 2026-07-30 after a mutation showed
 checks 2 and 10 printing `ok` — and the script exiting 0 — while examining *zero*
-files. `0 checked, 0 failed, exit 0` is the signature of a gate that verifies
+files. **This sentence was false for two more checks until 2026-08-16**: 4 and 8
+were never retrofitted with `scope()`, so a drifted glob printed `ok` and exited 0
+in the one file that states the rule. Both now print counts and were watched to
+fail closed. If you add a check, the sentence is a promise you have to keep. `0 checked, 0 failed, exit 0` is the signature of a gate that verifies
 nothing (`sota-code-security` rules/11 §2.2). Adding a check? The script's header
 carries the three rules that file learned the hard way: watch it fail first, print
 your denominator, and skip rather than guess.
@@ -91,10 +94,14 @@ as its own job, over **two** subjects: `check-invariants.sh` (part A) and
 check* to be the one that complains — a non-zero exit for any other reason is a
 **FALSE PASS**, not a catch. Part A mutates a good tree in a disposable git worktree;
 part B is inverted — it builds a fully-configured fake machine (`CLAUDE_CONFIG_DIR`
-+ a throwaway repo + a stub `gh`) and removes one thing per probe. **16 probes**
-(re-counted 2026-08-14; it said 15 and omitted invariant 16, which shipped in
-v1.22.2 with its own probe): invariants 1, 2, 6, 10, 15, 16 and verify-setup checks
-1, 2, 3, 4, 6a, 6b, 7, 8, 9, 10a. What is *not*
++ a throwaway repo + a stub `gh`) and removes one thing per probe. **21 probes**
+(2026-08-16; was 16, and before that the sentence said 15 while omitting invariant
+16): invariants **1, 2, 3, 4, 6, 7, 8, 10, 13, 15, 16** — 11 of 16 — and
+verify-setup checks 1, 2, 3, 4, 6a, 6b, 7, 8, 9, 10a. The five unprobed invariants
+(5, 9, 11, 12, 14) each need state a disposable worktree lacks — a tag, a merge
+base, an mtime — and the harness prints that reason. **A probe now asserts its own
+mutation landed**: every mutation is a hardcoded literal, and a stale one used to
+make the harness print `NOT CAUGHT: INERT`, accusing a healthy gate. What is *not*
 covered is printed, not implied. Too slow for pre-commit (one full run per mutation).
 **Adding a check to either script? Add its known-bad here too**, or you have shipped
 something nobody has watched fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Docs re-synced to what the audit changed, with the numbers re-counted rather than
+  carried forward.** `AGENTS.md`: **16 → 21 negative-control probes**, and the enumeration
+  now names the 11 probed invariants plus the five that need a fixture a worktree cannot
+  provide. Its "every file-list-driven check reports its denominator" sentence is now
+  annotated with the fact that it was **false for checks 4 and 8** until this cycle — in
+  the one file that states the rule. `CONVENTIONS-LEDGER`: runner-enforced conventions
+  **5 → 8** (judge-verdict shape, pin-what-you-compare-against, a probe must assert its own
+  mutation) — every one of them arrived from an incident, which is that ledger's own
+  thesis. `evals/README` gained the judge-shape convention with the two demonstrated
+  0.00/12 failures. `ROADMAP` records the audit outcome and its two deliberate residuals.
+
 ### Fixed
 
 - **Instrument audit, final pass — every remaining finding closed.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Instrument audit, final pass — every remaining finding closed.**
+  - **Negative-control coverage: 6 of 16 invariants probed → 11 of 16.** New probes for
+    invariants **3, 4, 7, 8, 13** — all single-file edits, so the old "diff-, history- or
+    release-shaped" rationale never applied to them. `PASS: 21/21`. The remaining five
+    (5, 9, 11, 12, 14) genuinely need state a worktree lacks (a tag, a merge base, an
+    mtime) and the harness now says exactly that. Probe 3 synthesises its trigger phrase
+    at runtime because writing it literally made the harness trip check 3 — **the gate
+    caught its own probe**, which is the best evidence it works.
+  - **`run-decay` silently measured a different depth than it printed.** `FILLER[:depth]`
+    caps at 30, so `--depths 0,12,60` reported "depth=60" while measuring 30 — and the
+    DECAY headline is computed from `depths[-1]`. Now refuses.
+  - **`run-repo-audit` had no empty-fixture guard** (its sibling ten lines below does): a
+    renamed fixture dir would hand both arms an empty source and print a fake `+0.00`.
+  - **`run-unscoped-audit` credited a defect when the file and the mechanism appeared
+    anywhere in the report** — a report naming `db.py` in one paragraph and "sql
+    injection" in another scored a hit. Matching is now windowed to the same block.
+    **This changes a published method:** the +0.00 in `RESULTS.md` was produced by the
+    looser matcher and would need a re-run to be strictly comparable. Both arms were at
+    ceiling, so the direction of any change is to lower both — recorded rather than
+    quietly re-scored.
+  - **`install.sh` leaked temp files on any abort** — four `mktemp` sites cleaned only on
+    the success path. Now a registry plus an `EXIT` trap. The first attempt was **broken
+    and the test caught it**: the tracker ran inside `$( )`, a subshell, so the parent's
+    registry stayed empty and the trap cleaned nothing. Rewritten to track in the parent
+    shell; verified by aborting mid-run and confirming zero files remain.
+
+
 - **Instrument audit, second pass — the remaining findings.**
   - **The judge parser validated nothing.** All four judge-driven instruments call one
     `judge()`; it parsed the reply and scored `verdict.get(id) == "present"`, so a

--- a/docs/CONVENTIONS-LEDGER.md
+++ b/docs/CONVENTIONS-LEDGER.md
@@ -55,7 +55,7 @@ single `[Unreleased]` · rules-file indexed by its SKILL.md · `LAST-VERIFIED` s
 pairing · rendered asset no older than its source · scoreboard rows declare their sample size. Each is in
 `scripts/check-invariants.sh` and documented in `AGENTS.md`.
 
-### Enforced in code, outside the invariant script (5)
+### Enforced in code, outside the invariant script (8)
 
 | Convention | Where enforced |
 |---|---|
@@ -64,6 +64,9 @@ pairing · rendered asset no older than its source · scoreboard rows declare th
 | Guards abort, never warn | the runners' own abort paths |
 | Don't trust the scrub | gitleaks is the backstop, in pre-commit and CI |
 | **A 200 with empty content is not success** (added 2026-08-14) | every runner that calls a model: empty completion → retry → fail loudly with `finish_reason`; `finish_reason == "length"` warns, because a truncated artifact is a floor not a measurement |
+| **A judge verdict must match the rubric it was asked about** (2026-08-16) | `run-completeness.judge()`, shared by all four judge-driven instruments: aborts on missing/extra ids or values outside present/absent, and normalises case — a well-formed reply of the wrong shape used to score 0.00 in silence |
+| **Pin what you compare against** (2026-08-16) | `run-competitors.py` compares each clone's `git rev-parse HEAD` to the manifest SHA and refuses on mismatch; the artifact records models, manifest path and resolved SHAs |
+| **A probe must assert its own mutation landed** (2026-08-16) | `check-negative-controls.sh probe()`: a stale hardcoded literal used to make the harness report the *gate* inert |
 
 ### Judgment — correctly ungateable (≈18)
 
@@ -188,11 +191,12 @@ what was never stated, so finding 2 bounds the **documented** set, not the real 
 Practical consequence: re-deriving this ledger will not find the next invariant 12.
 Only an incident will.
 
-**3. Enforcement is not concentrated in the invariant script.** **Five** conventions are
-enforced inside the eval runners (four when this ledger was first derived; the fifth
-arrived on 2026-08-14 the way the ledger predicts they do — from an incident, not from
-re-reading the docs). Anyone auditing "what does this repo actually enforce?" by reading
-`check-invariants.sh` alone would undercount.
+**3. Enforcement is not concentrated in the invariant script.** **Eight** conventions are
+enforced outside it (four when this ledger was first derived). Every one added since
+arrived the way this ledger predicts — **from an incident, never from re-reading the
+docs**: three of them on 2026-08-16 from a scoped audit of the instruments themselves.
+Anyone auditing "what does this repo actually enforce?" by reading `check-invariants.sh`
+alone would undercount by a third.
 
 ## What this does not claim
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,7 +29,23 @@ gains a surface someone can *use*; patch = the change lives inside existing surf
 is a **patch, 1.22.4**: no new skill, script, or gate. Invariant 14 will require a
 `**Front door checked:**` line whose terms resolve.
 
-**Closed 2026-08-13 (this session), both with evidence rather than a tick:**
+**Closed 2026-08-16 — the instrument audit (PRs #223, #224, #225).** Prediction
+[pre-registered and committed before any finding](../evals/results/2026-08-16/PRE-REGISTRATION-INSTRUMENT-AUDIT.md);
+it held — **highest severity in `scripts/`, zero findings in `skills/`**. Closed: a
+**Critical** data-loss bug in `install.sh` (an altered END marker deleted every user line
+below the managed block), invariants 4 and 8 printing `ok` over an empty scope, CI's shell
+lint unable to see SC2086, `principle5()` silently emptying the flagship's treatment arm,
+`judge-live-build` averaging over survivors, a judge parser that scored 0.00 on a
+wrong-shaped reply, unpinned competitor clones, and a negative-control harness that
+misreported its own coverage. Probe coverage **6/16 → 11/16** (21/21 mutations caught).
+
+**Still open from that audit, deliberately:** probes for invariants 5, 9, 11, 12, 14 —
+each needs state a disposable worktree lacks (a tag, a merge base, an mtime), so they need
+a fixture, not another probe. And `run-unscoped-audit`'s scoring was tightened *after* its
++0.00 was published: the number would need a re-run to be strictly comparable (both arms
+were at ceiling, so any change lowers both).
+
+**Closed 2026-08-13, both with evidence rather than a tick:**
 
 - **Every eval runner declares its denominator — 12 of 12.** The five that did not
   (`run-adjudication`, `run-competitors`, `run-decay`, `run-desc-routing`,

--- a/evals/README.md
+++ b/evals/README.md
@@ -328,6 +328,23 @@ of them were **mine, in the harness I had just written**.
   deleted the `rules/NN` citations it existed to find. Keep a known-positive and a
   known-negative report and check both after any change.
 
+### Validate the judge's verdict, don't just parse it (learned 2026-08-16)
+
+All four judge-driven instruments share one `judge()`. It parsed the reply and scored
+`verdict.get(id) == "present"` — so a **well-formed reply of the wrong shape scored 0.00
+in silence**. Demonstrated against the real rubric: `{"results": {…}}` nests the ids away
+(0.00/12) and `"Present"` with a capital P is not `"present"` (0.00/12). Neither is a
+parse error, so nothing raised.
+
+- **Assert the key set, not just the JSON.** `set(verdict) == {r["id"] for r in rubric}`,
+  and every value in `{present, absent}`. Missing or extra ids mean the judge answered a
+  different question than the one asked.
+- **Normalise what is safely normalisable** (case), **abort on the rest**. Guessing at a
+  nested shape is how you invent a score.
+- The same discipline applies to *your own* artifacts: record `_meta` (models, samples,
+  temp, the SHA the comparison is pinned to). A number nobody can attribute is not
+  evidence, and this repo published one for months.
+
 ### An HTTP 200 with empty content is not a successful call (learned 2026-08-14)
 
 Every runner here reads `choices[0].message.content`. A **reasoning model can spend its

--- a/evals/run-decay.py
+++ b/evals/run-decay.py
@@ -169,6 +169,13 @@ def main():
     k = _rc.key()
     case = next(c for c in _rc.load_cases() if c["id"] == a.task)
     depths = [int(x) for x in a.depths.split(",")]
+    # FILLER[:depth] caps SILENTLY (found 2026-08-16): --depths 0,12,60 printed
+    # "depth=60" while measuring depth 30, and the DECAY headline is computed from
+    # depths[-1]. A measurement that quietly measures something else is worse than
+    # one that fails.
+    if max(depths) > len(FILLER):
+        sys.exit(f"--depths max is {max(depths)} but only {len(FILLER)} filler turns "
+                 f"exist; the run would report a depth it never reached.")
     arms = ["control", "anchor", "reminder"]
     # Denominator here is not "cases" — this runner drives ONE case across every
     # arm x depth combination, so the unit that scales the duration is the run.

--- a/evals/run-repo-audit.py
+++ b/evals/run-repo-audit.py
@@ -70,6 +70,12 @@ def repo_text():
         if name == "__init__.py":
             continue
         parts.append(f"===== FILE: {name} =====\n{open(f, encoding='utf-8').read()}")
+    # Empty scope must fail closed (rules/11 §2.2). library_context() ten lines below
+    # already guards this; repo_text() did not, so a renamed fixture dir would hand
+    # BOTH arms an empty application source and print LIFT +0.00 — a manufactured null.
+    if not parts:
+        sys.exit(f"fixture repo is empty: no *.py under {REPO_DIR}. Both arms would "
+                 f"audit nothing and the run would report a fake +0.00.")
     return "\n\n".join(parts)
 
 

--- a/evals/run-unscoped-audit.py
+++ b/evals/run-unscoped-audit.py
@@ -94,10 +94,24 @@ def contamination(text):
 
 
 def found(case, text):
+    """Credit a defect only when the file and the mechanism appear in the SAME block.
+
+    The pre-registered rule is "names the mechanism AND points at one of that case's
+    primary files". Matching both anywhere in the report (the pre-2026-08-16 behaviour)
+    credits a report that mentions db.py in one paragraph and "sql injection" in
+    another — over-crediting BOTH arms toward the ceiling, which is the direction that
+    manufactures a +0.00. Blocks are paragraph-ish: blank-line separated, which is how
+    findings are actually written.
+    """
     low = text.lower()
-    file_hit = any(os.path.basename(f).lower() in low for f in case["primary"])
-    mech_hit = any(re.search(k, low, re.IGNORECASE) for k in case["must"])
-    return file_hit and mech_hit, file_hit, mech_hit
+    file_any = any(os.path.basename(f).lower() in low for f in case["primary"])
+    mech_any = any(re.search(k, low, re.IGNORECASE) for k in case["must"])
+    for block in re.split(r"\n\s*\n", low):
+        f_hit = any(os.path.basename(f).lower() in block for f in case["primary"])
+        m_hit = any(re.search(k, block, re.IGNORECASE) for k in case["must"])
+        if f_hit and m_hit:
+            return True, file_any, mech_any
+    return False, file_any, mech_any
 
 
 def score(cases, text):

--- a/scripts/check-negative-controls.sh
+++ b/scripts/check-negative-controls.sh
@@ -159,6 +159,36 @@ probe 15 "router library map omits an existing rules file" "map missing:"
 ( cd "$WT" && perl -0pi -e 's/\(3\) ROUTE BEFORE YOU ACT/(3) route whenever/' README.md )
 probe 16 "README's documented hook drifted from HOOK_CMD" "README documents a hook install.sh does not write."
 
+# --- Added 2026-08-16 -------------------------------------------------------
+# These five invariants were previously unprobed AND (3, 4, 7) not even declared
+# uncovered. All five are single-file edits, so the old rationale ("diff-, history-
+# or release-shaped") never applied to them. Probe 3 deliberately uses a GENERIC
+# phrase: the worktree is `git worktree add HEAD`, so the untracked .denylist.local
+# is absent and only the built-in patterns are active locally.
+
+# 3 — an internal-name leak (generic phrase, always in DENY).
+# Build the phrase at runtime: writing it literally here would make THIS file trip
+# check 3 (it did, on the first attempt — the gate caught its own probe).
+deny_word=user
+( cd "$WT" && printf '\nNote: the %s runs a private cluster.\n' "$deny_word" >> README.md )
+probe 3 "internal-name leak in a tracked file" "Internal reference(s) found"
+
+# 4 — a SKILL.md description pushed over the 1024-char cap.
+( cd "$WT" && perl -0pi -e 's/(\nname: sota-golang\ndescription: )/$1PADDING. /' skills/sota-golang/SKILL.md   && perl -0pi -e 's/(\ndescription: PADDING\. )/$1 . ("filler text to breach the description cap. " x 25)/e' skills/sota-golang/SKILL.md )
+probe 4 "SKILL.md description over the 1024-char cap" "OVER 1024"
+
+# 7 — a skill missing from the router's routing table.
+( cd "$WT" && perl -ni -e 'print unless /^\| `sota-golang` \|/' skills/sota/SKILL.md )
+probe 7 "skill missing from the router routing table" "routing table missing:"
+
+# 8 — a relative link to a *.md target that does not resolve.
+( cd "$WT" && printf '\nSee [the missing page](docs/NO-SUCH-FILE-HERE.md).\n' >> README.md )
+probe 8 "internal markdown link does not resolve" "BROKEN LINK"
+
+# 13 — a scoreboard row with an empty Samples cell.
+( cd "$WT" && perl -pi -e 's/\| 2 runs × 3, temp 0\.7 \|/|  |/ if /\*\*Completeness\*\* \(7 build tasks\)/' evals/results/RESULTS.md )
+probe 13 "scoreboard row with no sample size" "NO SAMPLE SIZE:"
+
 
 # =============================================================================
 # Part B — negative controls for scripts/verify-setup.sh
@@ -280,11 +310,10 @@ if [ "$failed" -ne 0 ]; then
   exit 1
 fi
 printf 'PASS: %d/%d mutations caught by the intended check.\n' "$caught" "$tested"
-echo "      check-invariants.sh COVERED: invariants 1, 2, 6, 10, 15, 16."
-echo "      NOT COVERED, and why (corrected 2026-08-16 — 3, 4 and 7 were in neither"
-echo "      list, so \"what is not covered is printed, not implied\" was false):"
-echo "        3, 4, 7, 8, 13  — single-file edits; probes are cheap and SHOULD exist."
-echo "        5, 9            — need a version/CHANGELOG-shaped fixture."
-echo "        11, 12, 14      — genuinely diff-, mtime- or release-shaped: need real commits."
+echo "      check-invariants.sh COVERED: 1, 2, 3, 4, 6, 7, 8, 10, 13, 15, 16 (11 of 16)."
+echo "      NOT COVERED, and why — every remaining one needs state a worktree lacks:"
+echo "        5, 9        — a version/CHANGELOG-shaped fixture (VERSION vs tag vs top entry)."
+echo "        11, 14      — diff-based: they compare against a merge base."
+echo "        12          — mtime-based: needs a rendered asset older than its source."
 echo "      verify-setup.sh: checks 1, 2, 3, 4, 6a, 6b, 7, 8, 9, 10a. Checks 5"
 echo "      and 11 are judgement (N/A by design) and 10b/12 need a different fixture."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -173,6 +173,17 @@ report_version() {
 # --- interactive / routing helpers -------------------------------------------
 readonly RT_BEGIN="<!-- >>> sota-skills routing (managed by install.sh) >>> -->"
 readonly RT_END="<!-- <<< sota-skills routing <<< -->"
+
+# Temp-file registry + EXIT trap. Four mktemp sites were cleaned only on the success
+# path (found 2026-08-16), so any `set -e` abort or Ctrl-C between creation and the
+# trailing `rm -f` leaked a file into $TMPDIR. gen-agents-md.sh already does this.
+TMPFILES=""
+# track() runs in the PARENT shell on purpose. An earlier attempt wrapped mktemp in a
+# function whose output was captured with $( ) — a subshell, so TMPFILES never made it
+# back and the trap cleaned nothing. The test caught it; the shape is the lesson.
+track() { TMPFILES="$TMPFILES $1"; }
+# shellcheck disable=SC2064,SC2154  # expand TMPFILES at trap time; _t is the loop var
+trap 'for _t in $TMPFILES; do rm -f "$_t"; done' EXIT
 # kept on one line; contains "sota" so re-runs detect it and never duplicate
 # Match on a phrase that survives rewording, not on the opening words. The old
 # marker was "sota standing rules:" — the first three words of the message — so a
@@ -246,7 +257,7 @@ extract_block() {  # $1 file
 # target keeps its link.
 refresh_block() {  # $1 file
   local f="$1" blk tmp
-  blk="$(mktemp)"; tmp="$(mktemp)"
+  blk="$(mktemp)"; track "$blk"; tmp="$(mktemp)"; track "$tmp"
   emit_routing_block >"$blk"
   awk -v b="$RT_BEGIN" -v e="$RT_END" -v blk="$blk" '
     $0 == b { while ((getline l < blk) > 0) print l; close(blk); inblk = 1; next }
@@ -331,7 +342,7 @@ setup_update_reminder() {
     log "sota update-reminder hook already present — up to date"; return
   fi
   ask_yn "Add a SessionStart hook that reminds you to check for updates every ~14 days (no network calls)?" y || return
-  tmp="$(mktemp)"
+  tmp="$(mktemp)"; track "$tmp"
   if [ -e "$s" ]; then
     backup "$s"
     if jq --arg c "$cmd" '.hooks.SessionStart = ((.hooks.SessionStart // []) + [{hooks:[{type:"command",command:$c}]}])' "$s" >"$tmp" 2>/dev/null; then
@@ -361,7 +372,7 @@ setup_hook() {
       fi
       ask_yn "The sota UserPromptSubmit reminder hook is out of date — refresh its wording?" y \
         || { log "left existing hook unchanged"; return; }
-      tmp="$(mktemp)"; backup "$s"
+      tmp="$(mktemp)"; track "$tmp"; backup "$s"
       if jq --arg c "$HOOK_CMD" --arg sig "$HOOK_SIG" \
           '.hooks.UserPromptSubmit |= map(.hooks |= map(if ((.command // "") | contains($sig)) then .command = $c else . end))' \
           "$s" >"$tmp" 2>/dev/null; then
@@ -377,7 +388,7 @@ setup_hook() {
     fi
   fi
   ask_yn "Add a UserPromptSubmit hook that re-injects the standing rules each prompt?" y || return
-  tmp="$(mktemp)"
+  tmp="$(mktemp)"; track "$tmp"
   if [ -e "$s" ]; then
     backup "$s"
     if jq --arg c "$HOOK_CMD" '.hooks.UserPromptSubmit = ((.hooks.UserPromptSubmit // []) + [{hooks:[{type:"command",command:$c}]}])' "$s" >"$tmp" 2>/dev/null; then


### PR DESCRIPTION
Final pass on the instrument audit.

## Negative-control coverage: 6/16 → 11/16

New probes for invariants **3, 4, 7, 8, 13** — all single-file edits, so the old *"diff-, history- or release-shaped"* rationale never applied to them.

```
[3]  internal-name leak in a tracked file           — caught
[4]  SKILL.md description over the 1024-char cap    — caught
[7]  skill missing from the router routing table    — caught
[8]  internal markdown link does not resolve        — caught
[13] scoreboard row with no sample size             — caught
PASS: 21/21 mutations caught by the intended check.
```

The five that remain (5, 9, 11, 12, 14) genuinely need state a worktree lacks — a tag, a merge base, an mtime — and the harness now says that, instead of listing seven and silently omitting three.

**Probe 3 synthesises its trigger phrase at runtime**, because writing it literally made this file trip check 3. The gate caught its own probe on the first run, which is the strongest possible evidence the probe is real.

## Remaining findings

- **`run-decay` printed a depth it never measured.** `FILLER[:depth]` caps at 30, so `--depths 0,12,60` reported `depth=60` while measuring 30 — and the DECAY headline is computed from `depths[-1]`. Now refuses.
- **`run-repo-audit` had no empty-fixture guard**, while its sibling ten lines below does. A renamed fixture would hand both arms an empty source and print a fake `+0.00`.
- **`run-unscoped-audit` matched file and mechanism anywhere in the report** — `db.py` in one paragraph and "sql injection" in another scored a hit. Now windowed to the same block; verified that different-block no longer credits, same-block still does, and the selftest still separates a full report from an empty one.

  **This changes a published method.** The +0.00 in `RESULTS.md` was produced by the looser matcher and would need a re-run to be strictly comparable. Both arms sat at ceiling, so any change lowers both — recorded here rather than quietly re-scored.
- **`install.sh` leaked temp files on any abort** — four `mktemp` sites cleaned only on the success path. Now a registry plus an `EXIT` trap.

## The fix that was broken, and how I knew

My first temp-file fix wrapped `mktemp` in a function whose output was captured with `$( )` — **a subshell** — so the parent's registry stayed empty and the trap cleaned nothing. The behaviour test showed 2 files remaining after an abort. Rewritten to track in the parent shell: 0 remaining.

That is the same silent-no-op class this entire audit was about, committed by me, inside the fix for it, and caught only because I tested behaviour rather than syntax.

## Gates

```
invariants            16/16
scoring tests         38 checks
negative controls     21/21
shellcheck -S style   0 findings / 12 tracked .sh
selftests             build-safe 0 · unscoped 0 · dead-path 0
```
