### PR TITLE
Two session lessons: gate-then-act, and how invariant 14 really matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A gate and the irreversible action it gates must be joined by `&&`, never `;`**
+  (`sota-shell-scripting` rules/04 §1b, with an audit probe). In a script `set -e` stops
+  you; typed at a prompt or joined with `;` inside a CI `run:` block, nothing does — the
+  check runs, prints FAIL, and the push happens anyway because it was the next token.
+  Two aggravating factors named because they make it invisible rather than merely
+  ignored: a pipe rewrites the status (`check | tail -2` reports `tail`), and
+  **diff-based checks legitimately differ before and after a push** because their merge
+  base changes — so a pre-push result must never be what authorises the push.
+
+### Changed
+
+- **`RELEASING.md` now documents how invariant 14 actually matches.** The comparison is
+  literal (`grep -F`) and the front-door line is excluded from the entry search, so a
+  term cannot satisfy itself. Both failure modes are recorded because both happened on
+  real cuts: declaring `negative control` when the entry writes `negative-control`, and
+  declaring a word that appears only in the declaration. Includes a one-liner to test a
+  candidate term before committing to it, plus the note that invariants 11 and 14 are
+  diff-based and should be re-run once the branch exists upstream.
+
 ## [1.22.6] - 2026-08-16
 
 **The audit turned inward.** A scoped audit of the code that *measures* this library —

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -108,7 +108,24 @@ section:
 ```
 
 Every term must appear in `README.md` or `docs/INDEX.md` **and** in that release's own
-CHANGELOG entry, so a filler word cannot buy a pass. The check fires **only** when
+CHANGELOG entry, so a filler word cannot buy a pass.
+
+**The match is literal (`grep -F`) and the front-door line is excluded from the entry
+search**, so a term cannot satisfy itself. Two ways this bites at cut time, both seen on
+real cuts: declaring `negative control` when the entry writes `negative-control`
+(hyphenation counts), and declaring a word that only appears in the declaration line.
+Check a candidate before you commit to it:
+
+```sh
+sec=$(awk -v v="## [$VER]" 'index($0,v)==1{f=1;print;next} f&&/^## \[/{exit} f{print}' CHANGELOG.md)
+printf '%s\n' "$sec" | grep -v 'ront door checked' | grep -qiF -- "$term" && \
+  grep -qiF -- "$term" README.md docs/INDEX.md && echo "usable"
+```
+
+Note also that invariant 14 and invariant 11 are **diff-based**: they resolve against a
+merge base, so they can report differently before and after the release branch is pushed.
+Re-run the gate once the branch exists upstream, and never let a pre-push result be the
+thing that authorises the push (`sota-shell-scripting` rules/04 §1b). The check fires **only** when
 `VERSION` changes, so ordinary PRs are unaffected. It gates the *verification*, not
 the *discovery* — deciding what counts as a capability is still yours, and the grep
 above is still how you find them. Two habits that go with it: say where a capability is *not* backed by a measured

--- a/skills/sota-shell-scripting/rules/04-ci-and-operational.md
+++ b/skills/sota-shell-scripting/rules/04-ci-and-operational.md
@@ -52,6 +52,37 @@ extra variables:
 **Beyond ~30 lines, move the step body to a committed script** (`ci/build.sh`): testable
 locally, lintable by ShellCheck directly, diffable, and immune to YAML quoting.
 
+## 1b. Separate a gate from the thing it gates with `&&`, never `;`
+
+The one-liner that runs a check and then does the irreversible thing is where the
+check quietly stops mattering:
+
+```bash
+# BAD — the push runs whether or not the gate passed. `;` ignores exit status.
+./scripts/check.sh; git push
+./scripts/check.sh | tail -2; git push          # worse: the pipe hides it too
+
+# GOOD — the gate is a precondition, not a preamble
+./scripts/check.sh && git push
+./scripts/check.sh || { echo "gate failed, not pushing" >&2; exit 1; }
+git push
+```
+
+This is the *interactive* twin of `set -e` (§1, rules/01 §2): in a script errexit would
+stop you; typed at a prompt or joined with `;` in a CI `run:` block, nothing does. The
+tell is that you saw the failure scroll past and the next command ran anyway.
+
+Two aggravating factors worth naming, because they make the failure invisible rather
+than merely ignored:
+
+- **A pipe rewrites the status.** `check.sh | tail -2` reports `tail`'s success, so even
+  `&&` would not save you — read the producer's status (`${PIPESTATUS[0]}` in bash,
+  `${pipestatus[1]}` in zsh, rules/01 §3) or drop the pipe.
+- **Diff-based checks can legitimately differ before and after a push**, because their
+  merge base changes. Re-run the gate *after* the branch exists upstream before
+  concluding the tree is broken — and never let the first, pre-push result authorise the
+  push.
+
 ## 2. Container entrypoint scripts
 
 **`exec` the final process — non-negotiable.** Without `exec`, the shell stays as PID 1,
@@ -155,6 +186,7 @@ exec > >(stdbuf -oL tee -a "$logfile") 2>&1
 
 ## Audit checklist
 
+- [ ] **Gate-then-act joined by `;`**: `grep -rnE '\.(sh|py)[^&|]*; *(git (push|tag|commit)|kubectl|terraform apply|rm )' --include='*.sh' .` — a check whose exit status the next command ignores. Also flag `check | tail`/`| head` before an action: the pipe hides the producer's status.
 - [ ] Workflows: `grep -rn '\${{' .github/workflows/ | grep -i 'head_ref\|pull_request\.\(title\|body\)\|commits\|issue\.\(title\|body\)\|comment\.body'`
       inside `run:` → CRITICAL (injection); fix via `env:` indirection.
 - [ ] `grep -rLn 'shell: bash\|pipefail' .github/workflows/*.yml` — steps relying on


### PR DESCRIPTION
Two lessons from this session, both written because I made the mistake rather than because I read about it.

## New rule: gate-then-act needs `&&`, never `;`

`sota-shell-scripting` rules/04 §1b, with an audit probe.

I ran this and the push happened while the gate printed FAIL:

```
./scripts/check-invariants.sh 2>&1 | tail -2   # FAIL
git push -u origin release-1-22-6              # ran anyway
```

`;` ignores exit status. In a script `set -e` would have stopped me; typed at a prompt, or joined with `;` inside a CI `run:` block, nothing does.

Two aggravating factors are named, because they make the failure *invisible* rather than merely ignored:

- **A pipe rewrites the status** — `check | tail -2` reports `tail`'s success, so even `&&` would not have saved it.
- **Diff-based checks legitimately differ before and after a push**, because their merge base changes. A pre-push result must never be the thing that authorises the push.

## `RELEASING.md`: how invariant 14 actually matches

The comparison is **literal** (`grep -F`) and the front-door line is **excluded from the entry search**, so a term cannot satisfy itself. Both failure modes are documented because both happened on real cuts:

- declaring `negative control` when the entry writes `negative-control` — hyphenation counts
- declaring a word that appears only in the declaration line

Includes a one-liner to test a candidate term *before* committing to it, and a note that invariants 11 and 14 are diff-based and worth re-running once the branch exists upstream.

## Memory (outside the repo)

New entry for the gate-then-act discipline; release pointer → v1.22.6; and the instrument-audit entry gained the observation worth keeping — **the gates caught their own maintainer five times this session** (duplicate `[Unreleased]`, my own probe tripping the denylist, a near-miss front-door term, a subshell trap that cleaned nothing, two IndentationErrors), and **none of it came from re-reading my own work**.

Invariants 16/16 · shellcheck `-S style` clean · denylist clean.
