### PR TITLE
Document the ninth audit class, and re-count what INDEX claimed

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ difficulty, not the domain — we measure it and say so.
 
 ### What the audit hunts that a scanner can't
 
-Eight classes of defect survive every linter, SAST rule, and CVE scanner, because in
+Nine classes of defect survive every linter, SAST rule, and CVE scanner, because in
 each one the code isn't *wrong*. The library hunts them as explicit passes:
 
 - **Controls that are inert** — a safeguard whose success and whose total failure look
@@ -141,6 +141,20 @@ each one the code isn't *wrong*. The library hunts them as explicit passes:
   shipped, a report whose word "verified" traces to no line that can fail, a test that
   still passes when the control's body is replaced with a no-op.
   ([rules/10](skills/sota-code-security/rules/10-silent-control-failure.md))
+- **Controls that block everything** — the mirror image, and the one every other pass
+  here looks past. An *enforcement* control (cap, quota, filter, allowlist, sandbox
+  policy) can be tightened until it refuses the legitimate case too, and it passes the
+  same tests: a security suite asserts *refusal*, refusal is exactly what an over-tight
+  control produces, and the mutation probe above only ever installs the **permissive**
+  no-op, so it looks in one direction. The fix is an **allow arm** — a representative
+  legitimate case that must complete *through* the control, never against the bare
+  environment, because proving the machine can do the work says nothing about whether
+  your control permits it. Worked instance: a memory budget set with `RLIMIT_AS`
+  refuses the runaway allocation exactly as intended, and also kills every Go or JVM
+  process **at startup**, since those runtimes reserve gigabytes of address space they
+  never touch (measured: 1.17 GiB reserved against 2.3 MiB resident).
+  ([rules/12 §1a](skills/sota-code-security/rules/12-verifying-the-verifier.md),
+  [sandboxing rules/02](skills/sota-sandboxing/rules/02-linux-os-hardening.md))
 - **Layers that were never layers** — the same test applied to an *architecture*
   diagram rather than a function. A second-opinion classifier drawn from the same
   model family as the system it guards shares its blind spots by construction
@@ -179,7 +193,11 @@ each one the code isn't *wrong*. The library hunts them as explicit passes:
   framework asks for this**: NIST SSDF and the EU CRA require a record that a scan
   *ran*, OpenSSF Scorecard's SAST check detects only that a tool is *configured*, and
   SLSA will sign provenance for a scanner set to scan zero files. A passing
-  compliance check is evidence of process, not of protection.
+  compliance check is evidence of process, not of protection. And a negative control
+  answers only whether the gate *can* fail — never whether it still covers you: a
+  refactor into a nested module, a second manifest or a sidecar image moves code out of
+  a gate's scope with no diff to the workflow file, so watch the number of units each
+  gate **enumerated** and treat a drop as a failure.
   ([rules/12](skills/sota-code-security/rules/12-verifying-the-verifier.md),
   [devsecops rules/05](skills/sota-devsecops/rules/05-analysis-gates.md))
 - **Dependencies declared but never reached** — packages, modules, and plugins wired in

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -39,11 +39,11 @@ trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issu
 | See the SOTA-vs-competitor benchmark | [COMPETITOR-BENCHMARK.md](../evals/results/2026-07-13/COMPETITOR-BENCHMARK.md) |
 | Read a shareable write-up of the key finding | [writeups/completeness-blind-spot.md](writeups/completeness-blind-spot.md) |
 | See what the library does **not** lift (the honest +0.00s) | [AUDIT-PROCESS.md](../evals/results/2026-07-20/AUDIT-PROCESS.md) |
-| Understand why the **audit** half has no measured lift (7 instruments, 3 designs) | [UNSCOPED-AUDIT.md](../evals/results/2026-07-30/UNSCOPED-AUDIT.md) · [DEAD-PATH.md](../evals/results/2026-07-30/DEAD-PATH.md) |
+| Understand why the **audit** half has no measured lift (**9 instruments, 4 designs** — closed 2026-08-14) | [UNSCOPED-AUDIT.md](../evals/results/2026-07-30/UNSCOPED-AUDIT.md) · [DEAD-PATH.md](../evals/results/2026-07-30/DEAD-PATH.md) |
 | See a prediction written down **before** the run that killed it | [PRE-REGISTRATION.md](../evals/results/2026-07-30/PRE-REGISTRATION.md) |
 | Read an eval that failed as an *instrument* rather than as a result | [BUILD-SAFE.md](../evals/results/2026-07-30/BUILD-SAFE.md) |
 | See the edges of the do-not-reimplement rule (§3.9.6), as worked cases | [`evals/cases/reimplement.jsonl`](../evals/cases/reimplement.jsonl) — documentation, never run |
-| Know what the audit hunts that a scanner can't (inert controls, unreached dependencies, stale decisions, refutation, absence claims) | [README → What the audit hunts](../README.md#what-the-audit-hunts-that-a-scanner-cant) |
+| Know what the audit hunts that a scanner can't (inert controls, **controls that block everything**, unreached dependencies, stale decisions, refutation, absence claims) | [README → What the audit hunts](../README.md#what-the-audit-hunts-that-a-scanner-cant) |
 | Read the retraction + the retired anchoring hypothesis | [SILENT-FAILURE.md](../evals/results/2026-07-20/SILENT-FAILURE.md) |
 
 ## Contribute / operate the repo

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,6 +21,7 @@ Every number in this table was re-counted on 2026-08-18, not carried forward.
 | 3 | **Competitor comparison — content-only re-run DONE 2026-08-14/15, claim holds. As-deployed REJECTED 2026-08-16** | Re-run at the pinned SHAs with the same build model: SOTA 98.7 / ECC 84.9 / cursorrules 80.0 / claude-skills 77.0 / unguided 58.2, 17 wins / 4 ties / 0 losses of 21, unguided arm reproducing to 0.2 points as the drift control. **As-deployed is rejected, not deferred:** it measures corpus size and a retrieval path we have already found saturated, not guidance quality — reasoning below the table | Nothing. Do not re-open without a new argument that answers the corpus-size confound |
 | 4 | **Router trim** — 2× the spec's ~5k-token recommendation | Deliberate: trimming breaks `ROUTER_BUILD_SHA` and the +0.39's comparability. **494/500 lines** on 2026-08-18 (re-counted with `grep -c '' skills/sota/SKILL.md`; it has read "exactly 500", then 491, then 494 — never trust the number in prose) — **six lines of headroom**, so the next router addition almost certainly reflows or replaces a line rather than appending one | **Only when the router must grow** — then trim and re-baseline together |
 | 5 | **6-month accuracy sweep** | Scheduled | `LAST-VERIFIED` reads **2026-07-08**, so due ~**2027-01-08**; bump it only after a full pass |
+| 7 | **`sota-rust` has no `std::process::Command` coverage at all** (found 2026-08-18 while validating cross-references for `sota-sandboxing/rules/04` R5.3a) | Out of scope for a batch whose subject was the *placement* of existing language guidance; writing a Rust subprocess section on the spot would have been unvalidated breadth | Confirm with `grep -rn 'process::Command' skills/sota-rust/` (read **zero** on 2026-08-18). Then either add argv/env/deadline guidance to `sota-rust/rules/05` §security, or decide deliberately that `sota-sandboxing/rules/04` R5.1's one-line table is the intended home and say so there. Do **not** infer the Rust deadline semantics from Go's or Python's — both were measured this session and they *disagree* |
 | 6 | **Two deferred ideas from the 2026-08-17 intake** ([ADOPTION-LOG](ADOPTION-LOG.md) 2026-08-17) | Both are one source's judgement call, not established practice, so neither cleared the bar for `adopted` | **(a) Event-sourcing replay preconditions** — the state machine must be deterministic (no wall clock, RNG, external IO), and since commands are non-deterministic only the *event* log needs durability. Fold into `sota-architecture/rules/03` §6 the next time that paragraph is edited; not worth a standalone PR. **(b) Geospatial modelling/indexing** — **thin, not absent**: `sota-databases/rules/03:40` already lists geometry under GiST, so this is SRID/geography-vs-geometry, `ST_DWithin` vs a hand-rolled bounding box, and haversine in `WHERE` defeating the index. Revisit only if a second source raises it or a real audit hits it |
 
 **Why the as-deployed competitor comparison is rejected (2026-08-16), not deferred.**
@@ -61,6 +62,32 @@ adding a skill, script, or gate. Invariant 14 requires each one to carry a
 `**Front door checked:**` line whose terms resolve, and at the 1.22.9 cut it did its job —
 the release's own capability (double-entry ledgers, reconciliation) read **zero** in
 `README.md` until the cut added the sentence.
+
+**This cycle (PR #236, 2026-08-18) — a session transcript, five for five.** A session
+that *applied* the library to Go subprocess sandboxing handed back five proposals; all
+five landed, **three of them with a correction**, which is the field-brief pattern
+holding at a larger sample (see [ADOPTION-LOG](ADOPTION-LOG.md) 2026-08-18). Three
+things worth carrying forward:
+
+1. **The library's own rules had a direction.** `rules/12`'s mutation probe installs the
+   *permissive* no-op, `sota-testing` rules/09 §1 says the assertion is refusal "not that
+   the happy path works", and `sota-sandboxing` rules/01's probe list was **entirely**
+   denial arms. Three independent sites all pointed one way, so a control that blocks
+   *everything* passed all of them. When a class is missing, check whether the existing
+   rules are asymmetric rather than absent — that shape is invisible to a coverage grep,
+   because the rule *is* there.
+2. **Both of the transcript's self-reported misses were already ours**, the zsh one
+   **twice** (routing rule 17 and `rules/12` §2). A third statement was deliberately not
+   written: that is the effect measured in
+   [WHY-COMPLETENESS-RESIDUAL](WHY-COMPLETENESS-RESIDUAL.md), where adding the missing
+   rule made adherence *worse*. The fix taken was **placement** — a cross-reference at
+   the paragraph where the exec call gets written, not another statement of the rule.
+3. **Reviewing the rendered diff caught two defects the invariants could not.** A
+   comparison table in `rules/12` contained a cell filled in by symmetry rather than by a
+   run (a 400 MiB deny arm at a 512 MiB `RLIMIT_DATA` cap — which would have *succeeded*),
+   and an "orders of magnitude" claim that the table beneath it contradicted. Both were
+   mine, both survived authoring, and neither is machine-checkable. Read the diff as a
+   reader, not as the author.
 
 **Closed 2026-08-16 — the instrument audit (PRs #223, #224, #225).** Prediction
 [pre-registered and committed before any finding](../evals/results/2026-08-16/PRE-REGISTRATION-INSTRUMENT-AUDIT.md);


### PR DESCRIPTION
Follow-up to #236. The allow arm landed in `rules/12` and reached **no front-door surface** — the shape this repo's history keeps repeating: an invariant catches a wrong *number*, never a missing *feature*.

## Changed

- **`README.md` → "What the audit hunts that a scanner can't": eight classes → nine.** The new one, **"controls that block everything"**, sits next to the inert-control bullet it inverts, with the measured `RLIMIT_AS` instance (1.17 GiB reserved against 2.3 MiB resident). The instrument bullet gains the gate-scope corollary: a negative control answers whether a gate *can* fail, never whether it still **covers** you.
- **`docs/INDEX.md`** — `7 instruments, 3 designs` was stale **present-tense** prose; the audit question closed at **nine instruments across four designs** on 2026-08-14. Corrected, and the audit-hunts row now names the new class.
- **`docs/ROADMAP.md`** — open item 7, plus the #236 cycle note.

## On the other "seven instruments" hits

Left as written, deliberately. `RESULTS.md` §"Final (2026-07-30)", `UNSCOPED-AUDIT.md`, `DESIGN-real-repo-audit.md` ("at design time…") and the ROADMAP cycle blocks are **dated retrospectives**, each already superseded by a later line above it. The repo's rule is to supersede dated prose, not edit it — rewriting them would falsify what was known when they were written. Only INDEX's row was an undated, live navigational claim.

## New open item

`sota-rust` has **zero** coverage of `std::process::Command` — found while validating the cross-references for `sota-sandboxing/rules/04` R5.3a, which is why Rust was dropped from that pointer list. Absence confirmed by two independent greps. Roadmap notes the trap for whoever picks it up: **do not infer Rust's deadline semantics from Go's or Python's** — both were measured this session and they disagree.

## Cycle note carry-forwards

1. **The library's rules had a *direction*.** `rules/12`'s probe installs the permissive no-op, `sota-testing` rules/09 §1 says the assertion is refusal, and `sota-sandboxing` rules/01's probe list was entirely denial arms. Three independent sites pointing one way — invisible to a coverage grep, because the rule *is* there.
2. **Both self-reported misses were already ours**, the zsh one twice. Fix taken was **placement**, not a third statement — per [WHY-COMPLETENESS-RESIDUAL](docs/WHY-COMPLETENESS-RESIDUAL.md).
3. **Reviewing the rendered diff caught two defects no gate can check** — a table cell filled in by symmetry rather than by a run, and a summary statistic the table beneath it contradicted.

All 16 invariants pass; pre-commit green.
