### PR TITLE
rules/14 §1: computed is not enough — compute it from what you returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`sota-code-security/rules/14` §1 — computed is not enough; compute it from what you
+  *returned*.** §1 already required every reported number to be **computed from the
+  artifact it produced** rather than printed as a literal. A number derived from an
+  **intermediate the function later discards** satisfies that reading and still lies:
+  `len(mandatory)` logged beside the computation kept printing `1 adjudicated` after
+  `return mandatory + sampled` became `return sampled` — computed, from a real
+  collection, at a line that really ran, describing work that no longer left the
+  function. **A function cannot attest to its own return value**, because every emission
+  site has a *suffix* — a filter, an early return, an exception path, a reassignment —
+  that can drop the result after the line is written. So **site the claim in the
+  consumer**, derived from the value received: a producer may log its *intent*, only the
+  consumer reports the *effect*. That is the reporting-output twin of `sota-kubernetes`
+  rules/04 §7 (a success log is a claim about what was decided, not what landed), and a
+  class generalising across two unrelated domains is worth stating plainly. **Probe it by
+  mutating the application and reading the output, not the test suite** — `rules/12` §1's
+  probe answers *is this tested*, which comes apart from *does the log tell the truth*
+  exactly where it matters: an **unattended run has the log as its only witness**, so a
+  log unchanged by the mutation is itself the finding. Two audit-checklist items added.
+- **Cross-references at both anchors the class sits between.** `rules/11` §2.4 said
+  silence is not evidence of health; it now states the harder inverse — **speech is not
+  either**, when the claim is sited upstream of the effect it describes. And §2.5's "make
+  the new branch emit exactly once" gains its **placement precondition**: an emission
+  proves the line it sits on ran, not that its result survived the rest of the function.
+- **A third instance of §1's own keyword-vs-shape trap, recorded in place.** The
+  reporter's first test for this defect **failed on its own explanatory comment**, which
+  quoted the log line it was hunting for — matching the words instead of the emission,
+  while writing the detector for the paragraph that warns against it.
+
+### Changed
+
+- **README hero line: `~63k` → `~64k` lines.** Caught by invariant 6 rather than by eye
+  (`README hero ~k-lines: says '63', tree says '64'`); the tree reads 63,501.
+
 ## [1.23.0] - 2026-08-20
 
 **Build the gate before the refactor that needs it.** Splitting two capped rules files

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ survives a long context instead of fading into it. That's why it beats a bigger 
 instead of becoming one. Native on Claude Code; works with Gemini CLI, Codex, and any
 agent that reads `AGENTS.md`.
 
-Under the hood: **41 skills (300 files, ~63k lines)** of state-of-the-art 2026
+Under the hood: **41 skills (300 files, ~64k lines)** of state-of-the-art 2026
 practice, each **instruction** file under 500 lines so only the matching rules load —
 the cap applies to `skills/**` alone, never to README/CHANGELOG/`docs/` — every fast-moving
 claim web-verified against a primary source.

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -180,6 +180,7 @@ lessons-log — its own best structural idea, applied to ourselves.
 | 2026-08-20 | Same brief, idea 3 | **Gateway access logs, still absent — which is why "is this graph feature used?" was answered by measuring the corpus instead** | **adopted with a correction** | `sota-observability/rules/05` §7a + checklist, cross-ref from `sota-api-design/rules/02` §5 step 4, observability SKILL.md row. Correction: the requirement is **already stated**, at `sota-api-design/rules/03`:227 ("without per-field usage data you can never delete anything") and `rules/02`:100 ("You cannot sunset what you can't attribute") — so the accurate verdict is *unreachable, not absent*: it lives in `sota-api-design`, which an observability or platform task never loads, and `sota-observability` mentions access logs exactly once (`rules/05`:56) and only to *exclude* the health endpoint from them. The genuinely new part is the **residual** the brief's incident actually produced — the substitute measurement. `grep -rniE "proxy (metric\|measure)\|answers a different question" skills/` returned zero hits · v1.23.0 |
 | 2026-08-20 | Same brief, idea 2 (deferred, then answered the same day with a measured field report) | **The in-band sentinel — a value from the domain standing in for absent** | **adopted** | `sota-architecture/rules/02` §8a (**the class, stated once, language-neutral**), `sota-python/rules/02` §2a (worked example) + checklist greps, `sota-databases/rules/01` *Modeling hygiene* + checklist (persistence half), one-line pointer in `sota-python/rules/03` §12, two SKILL.md rows. Confirmed absent by two searches before writing (`sentinel` → 23 hits, all unrelated; `return -1|in-band|magic (number|value)` → nothing on the class); nearest prior coverage was `sota-c-cpp/rules/04`:25 (one banned-API row) and `sota-performance/rules/05`:170 (the principle, stated once and scoped to cached absence). **Filed to databases `rules/01` rather than the reporter's suggested `rules/02`**: how absence is encoded is a modeling decision, and `rules/02` is migrations. **Scope corrected on review**: the first cut filed the class inside `sota-python`, which would have hidden a language-neutral defect from nine other language readers — the per-language part is the *detector*, not the class. Now a §8a in architecture plus a **measured** row in each of Go, Rust, C/C++, JVM, JS/TS, .NET, PHP, Ruby, and a pointer from Swift. The reporter's measurement is what made it writable — see the entry · v1.23.0 |
 | 2026-08-20 | Operator question — "if `sota-code-security` is close to full, can't you split it… maybe `-audit` and `-build`?" | **Split the files, not the skill — and gate `§` references first** | **adopted with a correction** | `scripts/check-invariants.sh` invariant **18** + `scripts/lib/check-section-refs.py` + harness probe 18 (24 probes), then `rules/13` (from `rules/11` §3) and `rules/14` (from `rules/10` §2.10–2.14): 497→357 and 496→362 lines. **Correction, with the measurement**: a skill split buys **no** headroom — invariant 1 enumerates per *file*, so the files arrive unchanged — and build/audit is the wrong axis here because invariant 2 welds an `## Audit checklist` onto all 259 rules files. The build-vs-audit framing is recorded as declined in `docs/ROADMAP.md` item 12, with the defensible seam (classes vs verification) and its router-line cost. The check went first **because the split is what creates the hazard**, and it found six live defects before a single line moved, then caught 27 the split itself broke · v1.23.0 |
+| 2026-08-20 | Field brief from a session applying the library — a refinement of `rules/14` §1 | **Computed is not enough — compute it from what you *returned***, and site the claim in the **consumer** | **adopted** | `sota-code-security/rules/14` §1 + two checklist items, with cross-refs added at `rules/11` §2.4 (silence is not evidence of health — *and neither is speech*, when the claim is sited upstream of the effect) and §2.5 (an emission proves the line it sits on ran, not that its result survived the suffix of the function). Verified absent before writing: `git grep` for *site the claim* / *in the consumer* / *derived from the value received* returned only unrelated hits (Go interface placement, backpressure, registry pinning); *intermediate vs returned value* and *the log is the only witness* returned nothing; and `rules/12` §1's probe says only "run the suite" · unreleased |
 
 ## Entries
 
@@ -1144,3 +1145,48 @@ filed further from where a sweep would look.
 
 **Measurement status:** adopted on reasoning. **No efficacy lift is claimed or
 measured. Do not cite one.**
+
+### 2026-08-20 — a refinement of rules/14 §1, from the session that hit it
+
+`rules/14` §1 already said every reported number must be **computed from the artifact it
+produced**, not printed as a literal. The brief's claim is that this passes a defect it
+should catch, and the worked instance is convincing: `len(mandatory)` logged beside the
+computation kept printing `1 adjudicated` after `return mandatory + sampled` became
+`return sampled`. The count was computed, from a real collection, at a line that really
+ran. It was still false, because the collection it counted no longer left the function —
+and **nothing about the emission was wrong**, which is exactly why nothing about the
+emission changed.
+
+Three parts, all adopted:
+
+- **Compute it from what you returned**, not from an intermediate that is later
+  discarded. This is the narrowing the existing rule lacked: "the artifact it produced"
+  is satisfied by an intermediate.
+- **A function cannot attest to its own return value** — every emission site has a
+  *suffix* (a filter, an early return, an exception path, a reassignment) that can drop
+  or reshape the result after the line is written. Hence: **site the claim in the
+  consumer**, derived from the value received. That is the reporting-output twin of
+  `sota-kubernetes` rules/04 §7, adopted at v1.22.11 for write-back controllers — a
+  success log is a claim about what was *decided*, not about what *landed*. The class
+  generalising across two unrelated domains is the argument for stating it plainly.
+- **Probe by mutating the application and reading the output, not the suite.** `rules/12`
+  §1's probe answers *is this tested*; this asks *does the log tell the truth*. They come
+  apart precisely where it matters — an **unattended run has the log as its only
+  witness**, so a log unchanged by the mutation is itself the finding.
+
+**Verified absent before writing**, three independent searches: *site the claim* /
+*in the consumer* / *derived from the value received* returned only unrelated hits (Go
+interface placement, consumer backpressure, registry digest pinning); *intermediate
+value vs returned value* returned nothing on the class; *only witness* / *unattended*
+returned one shell-scripting hit about install scripts. `rules/12` §1 step 2 reads
+"Run the suite" and nothing else.
+
+**The footnote is the best evidence in the brief.** The reporter's first test for this
+defect **failed on its own explanatory comment**, which quoted the log line it was
+hunting for — matching the *words* instead of the *emission*. That is precisely the
+keyword-vs-shape trap `rules/14` §1 already warns about, committed while writing the
+detector for that very paragraph. Recorded in place, because a rule that catches its own
+author while he is implementing it needs no further argument for being stated.
+
+**Measurement status:** adopted on reasoning and the reporter's observed behaviour. **No
+efficacy lift is claimed or measured. Do not cite one.**

--- a/skills/sota-code-security/rules/11-dead-path-diagnostics.md
+++ b/skills/sota-code-security/rules/11-dead-path-diagnostics.md
@@ -144,13 +144,23 @@ on a data path emits at least a start/finish pair carrying its denominator
 (§2.2). See rules/10 §3 for the degraded-control helper and the gauge that stays
 1 while a control is degraded.
 
+**The inverse also holds, and it is the harder half: speech is not evidence of health
+either**, when the claim is sited *upstream* of the effect it describes. A line reading
+`1 adjudicated` proves a count was computed there, not that the count survived the rest
+of the function. Site the claim in the consumer, derived from the value received —
+`rules/14` §1.
+
 ### 2.5 Did the changed code execute?
 
 **After any fix, prove the new path ran.** A fix that is never reached is
 indistinguishable from a fix that works — and both look like a green suite.
 
 The cheap proof: make the new branch emit exactly once (a log line, a counter, a
-one-shot `print`), run the real workload, and show the emission. The same trap
+one-shot `print`), run the real workload, and show the emission. **Placement is a
+precondition of that proof**: an emission establishes that the line it sits on ran, not
+that its result survived the suffix of the function — the filter, early return or
+reassignment that comes after it. Put the emission where the value is *consumed*, or it
+answers a weaker question than the one you asked (`rules/14` §1). The same trap
 bites mutation testing: an editable install, a copied tree, a stale image, or
 cached bytecode means the code you edited may not be the code that ran
 (rules/12 §1). Assert the runtime effect before trusting any before/after result.

--- a/skills/sota-code-security/rules/14-control-not-in-force.md
+++ b/skills/sota-code-security/rules/14-control-not-in-force.md
@@ -26,6 +26,30 @@ Rule: every number a tool reports is **computed from the artifact it produced**
 (`len(written)`, the actual byte count, the loaded rule count). Literals drift
 silently and operators record wrong values — including in compliance evidence.
 
+**Computed is not enough — compute it from what you *returned*.** A number derived
+from an **intermediate the function later discards** satisfies the no-literals reading
+above and still lies. `len(mandatory)` logged beside the computation kept printing
+`1 adjudicated` after `return mandatory + sampled` became `return sampled`: the count
+was computed, from a real collection, at a line that really ran — and it described work
+that no longer left the function. Nothing about the emission was wrong, which is why
+nothing about the emission changed.
+
+**A function cannot attest to its own return value.** Every emission site has a *suffix*
+after it — a filter, an early return, an exception path, a later reassignment — that can
+drop or reshape the result long after the line has been written. So **site the claim in
+the consumer, derived from the value it actually received**. A producer may log its
+*intent*; only the consumer can report the *effect*. This is the reporting-output twin
+of `sota-kubernetes` rules/04 §7: a success log is a claim about what was decided, not
+about what landed.
+
+**Probe it by mutating the application and reading the output — not the test suite.**
+The usual probe changes the control's body and watches the suite fail (`rules/12` §1);
+that answers *is this tested*, a different question from *does the log tell the truth*.
+Change what the function returns, run the real workload, and read the emitted line.
+Where the process runs **unattended — a cron job, a pipeline stage, an agent loop — the
+log is the only witness**, so a log that survives the mutation unchanged is itself the
+finding.
+
 The same rule governs the **words**, and that half is missed far more often
 because prose does not look like data. `verified`, `confirmed`, `reachable
 from`, `tainted`, `exploitable`, `sanitized` — and any `severity` or
@@ -36,7 +60,11 @@ Two traps: hedging every message containing "tainted" leaves the identical claim
 phrased "reachable from input", so match the claim's *shape*, not a keyword; and
 "TLS certificate not verified" describes the *analysed code's* defect and is
 correct English, so read the sentence before counting it — a regex classifier
-over-counts badly here (rules/12 §2.2).
+over-counts badly here (rules/12 §2.2). A third instance, reported by someone writing a
+test for this very paragraph: the test **failed on its own explanatory comment**, which
+quoted the log line it was hunting for. Matching the *words* rather than the *emission*
+is precisely the error above, committed while building the detector for it — which is
+how reliably this trap fires.
 
 ## 2. Shipped-artifact gaps
 
@@ -164,6 +192,13 @@ dashboard can tell the difference.
 - [ ] Does any **report or output** claim more than the run establishes — a count
       of things not examined, or a verification word (`verified`, `reachable`,
       `tainted`) applied to something merely matched (§1)?
+- [ ] Is every reported number computed from the value the function **returned**, not
+      from an intermediate it discards — and is the claim **sited in the consumer**,
+      derived from what was received rather than from what the producer intended to
+      send (§1)?
+- [ ] Was that verified by **mutating the application and reading the output** rather
+      than by a passing test suite? Anything running unattended has the log as its only
+      witness, so a log unchanged by the mutation is the finding (§1).
 - [ ] Is every control the runtime needs **present in the shipped artifact** — the
       image, the wheel, the bundle — and not only in the source tree (§2)?
 - [ ] Is any safeguard carried by a **natural-language instruction** where an


### PR DESCRIPTION
A field-brief refinement of a rule that already existed, which is the interesting part:
`rules/14` §1 required every reported number to be **computed from the artifact it
produced** rather than printed as a literal — and a real defect passes that reading.

## The instance

```
len(mandatory)  logged beside the computation
return mandatory + sampled   →   return sampled
```

The log kept printing `1 adjudicated`. The count was **computed**, from a **real
collection**, at a line that **really ran** — and it described work that no longer left
the function. Nothing about the emission was wrong, which is exactly why nothing about
the emission changed.

## What was added

- **Compute it from what you *returned***, not from an intermediate later discarded.
- **A function cannot attest to its own return value** — every emission site has a
  *suffix* (filter, early return, exception path, reassignment) that can drop the result
  after the line is written. So **site the claim in the consumer**, derived from the
  value received: a producer may log its *intent*; only the consumer reports the *effect*.
- **Probe by mutating the application and reading the output, not the test suite.**
  `rules/12` §1 answers *is this tested*; an **unattended run has the log as its only
  witness**, so a log unchanged by the mutation is itself the finding.

This is the reporting-output twin of `sota-kubernetes` rules/04 §7 (adopted v1.22.11 for
write-back controllers: a success log is a claim about what was *decided*, not what
*landed*). The class holding in two unrelated domains is the argument for stating it
plainly.

## Cross-references, at both anchors the class sits between

- `rules/11` **§2.4** said silence is not evidence of health. It now states the harder
  inverse: **speech is not either**, when the claim is sited upstream of its effect.
- `rules/11` **§2.5**'s "make the new branch emit exactly once" gains its **placement
  precondition** — an emission proves the line it sits on ran, not that its result
  survived the rest of the function.

## Absence verified before writing

Three independent searches: *site the claim* / *in the consumer* / *derived from the
value received* returned only unrelated hits (Go interface placement, consumer
backpressure, registry digest pinning); *intermediate vs returned value* returned
nothing on the class; `rules/12` §1 step 2 reads **"Run the suite"** and nothing else.

## The footnote, kept deliberately

The reporter's first test for this defect **failed on its own explanatory comment**,
which quoted the log line it was hunting for — matching the *words* instead of the
*emission*, which is precisely the keyword-vs-shape trap `rules/14` §1 already warns
about, committed while writing the detector for that paragraph.

Also in this PR: README hero `~63k` → `~64k` lines, caught by **invariant 6**, not by eye.

**No efficacy lift is claimed or measured.**
