### PR TITLE
Authoring vs auditing: the method a durable guard is written in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`sota-testing/rules/02` §2.10 — which method a durable guard is written in.** The
+  library stated a method default for an **audit search** (widen it, use a second
+  independent method, say what you ran) and none for the **guard** that search leaves
+  behind. The two differ in *lifetime*: a search is discarded the day it runs; a guard is
+  a standing claim re-evaluated on every commit by people who will not re-derive it. So:
+  **AST as the floor for structural claims, execution or interception for behavioural
+  ones, mutation on both, regex only where no parser exists** — and name which, so the
+  exception does not spread by imitation. Two failure modes are specific to text and
+  neither is prevented by care: a guard can match a **comment about** the code it
+  policies, and a file-scope check lets **one compliant site excuse every other site in
+  the same file** (a real regression passed that way). Added beyond the brief: **name the
+  parser, per language** — "no parser at hand" is exactly when people reach for regex, so
+  that choice belongs in the same decision as the guard. Stated with its limit, because
+  the phrase "AST-based" invites false confidence: **AST does not resolve types**, a name
+  collision reads as live — a false *negative* — and the output is a candidate list, never
+  a verdict. Three audit-checklist items; cross-referenced from `sota-code-security`
+  rules/10's absence-claim bullet.
+
+### Changed
+
+- **Formatter reflow is now a fourth "the mutation did not take" cause**, in both homes
+  (`sota-testing/rules/06` §6.3 and `sota-code-security/rules/12` §1). A multi-line revert
+  can silently match nothing because `ruff format`/`black`/`prettier` folded the target
+  onto one line — the most common cause in any formatted repo, and the one an
+  *environmental* checklist (editable installs, stale bytecode, cached images) will never
+  catch, because nothing about the environment is wrong.
+- **Invariant 18's `` `NN` `` shorthand now has to sit immediately before the `§`.** It
+  read a backticked configuration value — `` `16` `` — as a rules-file reference and
+  reported `rules/16 ... does not exist`: a false positive on correct prose, which is the
+  failure that gets a gate switched off. The explicit `rules/NN` form keeps its wide
+  window. Verified discriminating rather than merely disabled: `` `02` §9 `` still
+  resolves to a file with a §9 from a file that has only §1–§7. References resolved
+  1,363 → 1,368.
+
+
 - **Invariant 19 — every check has a known-bad, and the exempt set is pinned.** Three
   proposed refinements of the previous day's `--self-test` collapsed into one gate.
   **(a) Run it always.** The structural pass costs **49 ms** (measured), and it sat

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -183,6 +183,7 @@ lessons-log — its own best structural idea, applied to ourselves.
 | 2026-08-20 | Field brief from a session applying the library — a refinement of `rules/14` §1 | **Computed is not enough — compute it from what you *returned***, and site the claim in the **consumer** | **adopted** | `sota-code-security/rules/14` §1 + two checklist items, with cross-refs added at `rules/11` §2.4 (silence is not evidence of health — *and neither is speech*, when the claim is sited upstream of the effect) and §2.5 (an emission proves the line it sits on ran, not that its result survived the suffix of the function). Verified absent before writing: `git grep` for *site the claim* / *in the consumer* / *derived from the value received* returned only unrelated hits (Go interface placement, backpressure, registry pinning); *intermediate vs returned value* and *the log is the only witness* returned nothing; and `rules/12` §1's probe says only "run the suite" · v1.23.1 |
 | 2026-08-20 | **Self-audit of the same day's own work** — "do we have gaps elsewhere?" | Four classes shipped 2026-08-20 were stated only where the incident happened, and were **unreachable from the skills that need them** | **adopted** | `sota-devsecops/rules/05` §5.6 + checklist (a negative control belongs in a `--self-test` **mode of the runner**, not only as a fixture beside it — that file is the canonical home for "every gate ships a known-bad" and a DevSecOps reader never loads `rules/12`), `sota-observability/rules/01` §5 (**"at completion" is load-bearing** — a mid-function line attests only that the line ran; site the claim where the value is consumed), `sota-testing/rules/06` §6.3 (**mutate and read the output, not the suite** — every other probe in that section ends in "run the tests", which cannot answer whether the report is truthful), and `sota-code-security/rules/12` §1b.1 (**a planned change is a legitimate source of a gate**). Verified absent in all four before writing · unreleased |
 | 2026-08-20 | Operator question — "are there other bright ideas like this we should adopt?" | Three refinements of the same day's `--self-test`, which collapsed into one gate: **run it always**, **fail closed**, and **pin the exempt set** | **adopted** | `scripts/check-invariants.sh` invariant **19** + harness probe 19 (25 probes, 14 of 19). The third is the one with teeth: without a pin, "every check is probed or declared unprobeable" is satisfied by adding your new check number to the exempt list. Measured first — the structural pass costs **49 ms**, which is what makes "always" defensible. It caught **itself** on introduction. Also derived probe 17's mutation instead of pinning the invariant count, after that literal went stale twice in one day · unreleased |
+| 2026-08-20 | Field brief — *a method hierarchy for authoring durable guards* (one session on a 38k-test Python codebase) | **Auditing and authoring are different activities**: the library states a method default for the search and none for the guard the search leaves behind | **adopted with one addition** | `sota-testing/rules/02` §2.10 + three checklist items, cross-referenced from `sota-code-security/rules/10`'s absence bullet; **formatter reflow** added as a fourth mutation-did-not-take cause in `sota-testing/rules/06` §6.3 and `sota-code-security/rules/12` §1. Both of the brief's "not a duplicate" citations verified **accurate** (rules/10:286-292 and rules/06:169), and the gap confirmed: all seven `AST` mentions in `skills/` are about auditing, RAG splitting, Python `match`, or a coincidental Cypher relationship name — **none about authoring**. My addition: **name the parser per language**, because "no parser at hand" is precisely when people reach for regex · unreleased |
 
 ## Entries
 
@@ -1192,3 +1193,56 @@ author while he is implementing it needs no further argument for being stated.
 
 **Measurement status:** adopted on reasoning and the reporter's observed behaviour. **No
 efficacy lift is claimed or measured. Do not cite one.**
+
+### 2026-08-20 — authoring vs auditing, and the guard that matched its own comment
+
+A field brief proposing a method hierarchy for **authoring** durable guards: AST as the
+floor for structural claims, execution for behavioural ones, mutation on both, regex only
+where no parser exists.
+
+**Both "this is not a duplicate" citations were checked and both are accurate** — which
+is worth recording, because the failure mode of a well-argued proposal is usually its
+citations (see 2026-08-05, where one of two reports did not survive quoting).
+`sota-code-security/rules/10`:286-292 does carry *"a negative claim needs more proof than
+a positive one"* together with the *"second independent method (grep **and** AST/call-graph
+**and** a mutation run)"* wording, and `sota-testing/rules/06`:169 does warn that the
+mutation may not have taken. The brief's point is that **both govern the search, not the
+guard** — and that is right. The distinction the library was missing is one of *lifetime*:
+an audit search is discarded the day it runs; a guard is a standing claim re-evaluated on
+every commit by people who will not re-derive it, so it deserves the stronger default.
+
+Gap confirmed independently: all seven `AST` mentions in `skills/` are about auditing, RAG
+chunk-splitting, Python `match` destructuring, or a Cypher relationship type that happens
+to be spelled `[:AST*]`. None is about the method a guard is written in.
+
+**The strongest evidence is a recurrence, not the argument.** Failure mode 1 — *a guard
+matched its own explanatory comment*, a regex for `Scanner\s*\(` flagging the file that
+documented in a comment that the call had been removed — is the **second independent
+report of that exact shape in one day**. The earlier one was a test that failed on its own
+comment because the comment quoted the log line it hunted for. Two different people, two
+different guards, the same trap, hours apart. That is a class, not an anecdote.
+
+**Adopted with one addition.** The brief's hierarchy is stated as written, including its
+honest limit (AST does not resolve types, so a name collision reads as live — a **false
+negative**, the more dangerous direction, and the output stays a candidate list rather
+than a verdict). What it does not say, and what decides whether the rule is followed:
+**name the parser, per language.** AST is free in Python/Go/Rust/Ruby and an install away
+elsewhere, and "no parser at hand" is exactly the moment someone reaches for regex — so
+the parser choice belongs in the same decision as the guard, not in a later one.
+
+**Formatter reflow** is adopted as a fourth mutation-did-not-take cause alongside the
+environmental three. It is the most common cause in any repo running `ruff format`,
+`black` or `prettier`, and the one least likely to be caught by an environmental
+checklist, because nothing about the environment is wrong.
+
+**A finding about our own instrument, from writing this up.** Invariant 18 rejected the
+new §2.10 — it read a backticked configuration value, `` `16` ``, as the `` `NN` ``
+rules-file shorthand and reported `rules/16 ... does not exist`. A false positive on
+correct prose, which is the failure that gets a gate switched off. The shorthand now has
+to sit **immediately** before the `§` (the only way it is ever actually written), while
+the explicit `rules/NN` form keeps its wide window. Verified discriminating: pointing
+`` `02` §9 `` still resolves to `sota-threat-modeling/rules/02`, which has a §9, from a
+file that has only §1–§7. References resolved: 1,363 → 1,368.
+
+**Measurement status:** the brief's 74 → 61 orphan-candidate figure is the reporter's,
+on their codebase, and is quoted as such. **No efficacy lift is claimed for the library.**

--- a/scripts/lib/check-section-refs.py
+++ b/scripts/lib/check-section-refs.py
@@ -87,7 +87,7 @@ def main():
             prev = lines[i - 2][-80:] if i >= 2 else ''
             joined, off = prev + ' ' + line, len(prev) + 1
             skills_here = [m.group(1) for m in SKILL.finditer(joined)] + [own]
-            rules_here = [(m.start(), m.end(), m.group(1) or m.group(2))
+            rules_here = [(m.start(), m.end(), m.group(1) or m.group(2), m.group(1) is None)
                           for m in RULES.finditer(joined)]
             for m in SEC.finditer(joined):
                 if m.end() <= off:            # matched wholly inside the carried tail
@@ -95,8 +95,16 @@ def main():
                 if EXTERNAL.search(joined[:m.start()]):
                     continue
                 sec, cands, dangling = m.group(1), {f}, set()
-                for (start, end, nn) in rules_here:
-                    if 0 <= m.start() - end <= 120 or 0 <= start - m.end() <= 40:
+                for (start, end, nn, shorthand) in rules_here:
+                    # `NN` (backticked bare number) is genuinely ambiguous with a
+                    # literal value — `16` as a configured depth read as "rules/16"
+                    # and produced a false positive on correct prose. The explicit
+                    # `rules/NN` form keeps a wide window; the shorthand must sit
+                    # immediately before the §, which is the only way it is ever
+                    # actually written (`(\`02\` §8)`).
+                    near = ((0 <= m.start() - end <= (2 if shorthand else 120))
+                            or (0 <= start - m.end() <= 40 and not shorthand))
+                    if near:
                         hit = False
                         for sk in skills_here:
                             target = rules_file(sk, nn)

--- a/skills/sota-code-security/rules/10-silent-control-failure.md
+++ b/skills/sota-code-security/rules/10-silent-control-failure.md
@@ -290,6 +290,10 @@ Design:
   (synonyms, other languages, generated code, vendored trees), use a **second
   independent method** (grep *and* AST/call-graph *and* a mutation run), and
   state the search you actually performed so the reader can judge its reach.
+  That governs the **search**, which is discarded once it has answered. If the
+  conclusion is instead left behind as a durable **guard**, it needs the stronger
+  default in `sota-testing` rules/02 §2.10: structure in AST, behaviour by execution,
+  regex only where no parser exists.
 - **Before claiming a fix works**: add the regression test, then **revert the fix
   and confirm the test fails**. A regression test is not evidence until it has
   been watched to fail. Report the exact command and the pass/fail counts —

--- a/skills/sota-code-security/rules/12-verifying-the-verifier.md
+++ b/skills/sota-code-security/rules/12-verifying-the-verifier.md
@@ -57,7 +57,10 @@ Two traps that make step 3 lie:
   ran. Force the dependency present (monkeypatch the availability check) so the
   control is actually exercised.
 - **The mutation did not take.** Editable installs, copied/rsync'd trees, stale
-  bytecode, and cached images mean the original code may still be running.
+  bytecode, and cached images mean the original code may still be running — as does a
+  **formatter reflow**, where a multi-line revert silently matches nothing because
+  `ruff format`/`black`/`prettier` folded the target onto one line. That last one is
+  not an environment fault, which is why it survives the environmental checklist.
   **Assert the mutation's runtime effect** — make the no-op print or raise once —
   before trusting a "zero failures" result.
 

--- a/skills/sota-testing/rules/02-test-design-quality.md
+++ b/skills/sota-testing/rules/02-test-design-quality.md
@@ -272,8 +272,66 @@ rendered emails. They are a trap as a default assertion.
   can only understand by chasing four helper files has the mystery-guest
   smell with extra steps.
 
+## 2.10 Which method a durable guard is written in
+
+Auditing and authoring are different activities with different lifetimes, and the
+library states a default for the first but not the second. An **audit search** is
+discarded the day it runs — grep is often the right tool, and `sota-code-security`
+rules/10's absence rule already governs it (widen the search, use a second independent
+method, state what you ran). A **guard** is a permanent claim that a property holds,
+re-evaluated on every commit by people who will not re-derive it. It deserves a stronger
+default:
+
+| method | establishes | cannot establish |
+|---|---|---|
+| text / regex | nothing durable | code vs. a *comment about* code; per-site scope |
+| **AST** | structure — call sites, arguments, definitions | dynamic access, types, runtime values |
+| **execution / interception** | behaviour — the value actually arrives | only what the test exercises |
+| **mutation** | that the guard *can* fail | that the mutation took — assert it |
+
+- **Author structural guards in AST, not text.** Two failure modes are specific to text
+  and neither is prevented by care. A guard for `Scanner\s*\(` flagged the file that
+  documented *in a comment* that the call had been removed — text cannot tell code from
+  prose about code. And a file-scope check ("does this file mention the factory
+  anywhere?") lets **one compliant site excuse every other site in the same file**; a
+  real regression passed. Inspect the node: for a call, its own keyword arguments.
+- **A structural guard cannot carry a behavioural claim.** *"The argument is forwarded"*
+  is structure; *"the configured value arrives"* is behaviour, and needs interception or
+  execution. Reported case: AST proved a `depth` argument was forwarded and could not
+  show whether the forwarded value was the configured `16` or a stale `4`.
+- **Mutation-test the guard, then verify the mutation took** (rules/06 §6.3).
+- **Regex only where no parser exists** — a DSL, a log format, a config dialect, prose.
+  Name which, in a comment, so the exception does not spread by imitation.
+- **Name the parser, or the rule gets ignored exactly where it is least convenient.**
+  AST is free in some ecosystems (Python `ast`, Ruby `Prism`, Go `go/ast`, Rust `syn`,
+  TS `typescript` compiler API / `ts-morph`, Java `JavaParser`, PHP `nikic/PHP-Parser`)
+  and an install away in others — and "no parser at hand" is the moment people reach for
+  regex. Decide the parser once, per language, at the same time you decide the guard.
+
+**The honest limit, which the guidance must state or it manufactures the false
+confidence the rest of this library exists to prevent: AST does not resolve types.** A
+field audit still counts `.timeout_sec` on *any* object, so a name collision with an
+unrelated attribute reads as live — a **false negative**, the more dangerous direction.
+AST removes string-and-comment noise; it does not remove name ambiguity. The output of a
+structural sweep is a **candidate list to verify**, never a verdict, and "AST-based" is
+exactly the phrase that tempts a reader to treat it as one.
+
+Measured on one 38k-test Python codebase: the same audit rewritten from `grep` to
+`ast.walk` went from **74 orphan candidates to 61**. The thirteen were fields read via
+`getattr(cfg, "name")` with a string literal — which the AST pass sees and grep does not.
+More precise *and* more sensitive, not a trade.
+
 ## Audit checklist
 
+- [ ] Durable guards written in **AST** where the claim is structural, not regex over
+      source? Two tells that a text guard is in place: it can match a *comment about*
+      the code, and it checks file scope rather than the offending node, so one
+      compliant site excuses the rest of the file (§2.10).
+- [ ] Any structural guard carrying a **behavioural** claim ("the configured value
+      arrives") that only execution or interception can support (§2.10)?
+- [ ] Does any structural sweep get reported as a **verdict** rather than a candidate
+      list? AST does not resolve types, so a name collision reads as live — a false
+      negative (§2.10).
 - [ ] Assertion-free tests? Mechanical sweep: list test functions lacking any
       assert/expect/require/verify token → Critical each.
 - [ ] Can flagship tests fail? Invert one assertion or `return` early in the

--- a/skills/sota-testing/rules/06-property-fuzzing-mutation.md
+++ b/skills/sota-testing/rules/06-property-fuzzing-mutation.md
@@ -167,8 +167,12 @@ hours):
   Nothing fails ⇒ that control is untested however many tests name it. Two traps
   make this lie — the path may be skipped for an unrelated reason (a disabled
   optional dependency), and the mutation may not have taken (editable installs,
-  stale bytecode, cached images). Force the path live and assert the mutation's
-  runtime effect before trusting a green run. `sota-code-security` rules/10.
+  stale bytecode, cached images — and, in any repo with `ruff format`/`black`/
+  `prettier`, a **formatter reflow**: a multi-line patch that no longer matches
+  because the code was folded onto one line, which is the most common cause of all
+  and the one that looks least like an environment problem). Force the path live and
+  assert the mutation's runtime effect before trusting a green run.
+  `sota-code-security` rules/10.
 
 ```text
 # What a survivor means (PIT/Stryker-style report line)


### PR DESCRIPTION
A field brief proposing a method hierarchy for **authoring** durable guards. Adopted with
one addition.

## Both "not a duplicate" citations verified — and both were accurate

Worth stating, because citations are where a well-argued proposal usually fails here (see
the 2026-08-05 log entry, *"why only one survived quoting"*). Checked against the tree:

- `sota-code-security/rules/10`:286–292 does carry *"a negative claim needs more proof
  than a positive one"* **together with** *"second independent method (grep **and**
  AST/call-graph **and** a mutation run)"*.
- `sota-testing/rules/06`:169 does warn the mutation may not have taken.

The brief's point stands: **both govern the search, not the guard the search leaves
behind.** The missing distinction is **lifetime** — an audit search is discarded the day
it runs; a guard is a standing claim re-evaluated on every commit by people who will not
re-derive it.

Gap verified independently: all seven `AST` mentions in `skills/` are about auditing, RAG
chunk-splitting, Python `match` destructuring, or a Cypher relationship type spelled
`[:AST*]`. **None is about authoring.**

## What landed — `sota-testing/rules/02` §2.10

AST as the floor for structure · execution/interception for behaviour · mutation on both ·
regex only where no parser exists, and **say which**.

Two failure modes specific to text, neither prevented by care: a guard can match a
**comment about** the code it polices, and a **file-scope** check lets one compliant site
excuse every other site in the same file — a real regression passed that way.

**Added beyond the brief: name the parser, per language.** "No parser at hand" is exactly
when people reach for regex, so that choice belongs in the same decision as the guard.

**Kept verbatim in substance — the honest limit**, because "AST-based" is the phrase that
invites false confidence: AST does not resolve types, a name collision reads as live (a
false **negative**, the dangerous direction), and the output is a **candidate list, never
a verdict**.

## The strongest evidence is a recurrence

Failure mode 1 — a regex guard flagging the file that documented **in a comment** that the
call had been removed — is the **second independent report of that exact shape today**.
The earlier one was a test that failed on its own comment, because the comment quoted the
log line it hunted for. Two people, two guards, hours apart. That is a class.

## Also

- **Formatter reflow** added as a fourth *mutation-did-not-take* cause in both homes. It
  is the most common in any `ruff format`/`black`/`prettier` repo and the one an
  environmental checklist cannot catch, because nothing about the environment is wrong.
- **Invariant 18 false-positived on this PR's own prose**, reading a backticked config
  value `` `16` `` as a rules-file reference. A gate that flags correct writing gets
  switched off, so the `` `NN` `` shorthand must now sit immediately before the `§`.
  Verified *discriminating*, not merely disabled: `` `02` §9 `` still resolves to a file
  with a §9 from a file that has only §1–§7. References resolved **1,363 → 1,368**.

The reporter's 74 → 61 orphan-candidate figure is theirs, on their codebase, and is quoted
as such. **No efficacy lift is claimed for the library.**
