### PR TITLE
Two audit gaps found by sampling, both fixed — and the honest answer to BUILD↔AUDIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than working around it, and **rung 5 can be cheaper than rung 1**. Shell and
   config are explicitly not exceptions: `mvdan.cc/sh/v3/syntax` parses POSIX sh, bash and
   mksh with a `Walk`, and YAML/HCL/JSON/Dockerfile/SQL all have parsers.
+- **Two audit gaps found by sampling, and fixed.** `sota-c-cpp` rules/01 §7 *Error
+  handling: exceptions vs expected vs codes* is a full build section that had **no audit
+  probe anywhere in the skill** — one incidental hit across seven files. It now carries
+  greps for empty and swallow-all `catch` blocks, `bugprone-empty-catch` /
+  `bugprone-exception-escape` / `misc-throw-by-value-catch-by-reference`, ignored error
+  returns via `bugprone-unused-return-value` (aliased by `cert-err33-c`), and the question
+  a grep cannot ask — whether one error model is used across a boundary or three meet at
+  an ABI seam. `sota-ml-engineering` advertised **train/serve skew** twice in its own
+  description while **no checklist in any of its seven rules files** mentioned skew,
+  point-in-time correctness or feature stores; `rules/02` now audits all three, including
+  the case where no feature store exists ("we are careful" is not a mechanism).
 - **The BUILD↔AUDIT correspondence is now a stated convention** (`CONTRIBUTING.md`),
   in both directions and with its exception. Invariant 2 checks a checklist *exists*;
   nothing checked that it matches the guidance above it. An item with no build rule marks

--- a/docs/CONVENTIONS-LEDGER.md
+++ b/docs/CONVENTIONS-LEDGER.md
@@ -218,12 +218,24 @@ measurement, not an opinion:
   ungrounded while being grounded in two **sibling** files. Both failure modes are
   intrinsic: correspondence is semantic and often cross-file.
 
+- **Attempt 3 — read a sample, which is the only method that worked.** 20 top-level
+  build sections drawn on a fixed stride from a population of **1,773**, each read against
+  its own checklist and its siblings'. Result: **16 covered, 2 correctly exempt** (HATEOAS
+  and TDD are advisory — you cannot audit "did you practise TDD"), **2 real gaps**. So a
+  genuine-gap rate near **10%**, on n=20 — indicative, not precise, and stated that way.
+
+Both real gaps were fixed on discovery: `sota-c-cpp` rules/01 §7 *Error handling* had **no
+probe anywhere in the skill** (one incidental hit across seven files), and
+`sota-ml-engineering` advertised *train/serve skew* twice in its own description with
+**zero** checklist items on skew, point-in-time correctness or feature stores across all
+seven of its rules files.
+
 So it is written as a convention in [CONTRIBUTING.md](../CONTRIBUTING.md) with its
-exception (advisory sections, and checks owned by a sibling skill) and left ungated. The
-useful residual, and the reason the numbers are recorded rather than discarded: **no
-evidence was found of the direction that would be worst** — an audit half systematically
-demanding what the build half never asked for. Every sampled instance of it was an
-artifact of the instrument.
+exception (advisory sections, and checks owned by a sibling skill) and left ungated. Two
+things the sample settled that the mechanical attempts could not: the asymmetry is real
+but **modest and one-directional**, and **the feared direction did not appear at all** —
+not one sampled checklist item demanded something the build half never asked for. Every
+apparent instance of that was an artifact of the instrument.
 
 **Where invariant 17 stops, stated with an instance (2026-08-19, the v1.22.14 cut).**
 It asserts two things and no more: every stated count equals the script's own `[k/N]`,

--- a/skills/sota-c-cpp/rules/01-idioms.md
+++ b/skills/sota-c-cpp/rules/01-idioms.md
@@ -172,6 +172,17 @@ grep -rn 'return std::move' --include='*.cpp' .          # pessimizes RVO
 grep -rn 'using namespace std;' --include='*.h' --include='*.hpp' .  # in headers: bad
 grep -rnE '#define [A-Z_]+\(' --include='*.h' .          # function-like macros → constexpr/inline
 
+# Error handling (§7) — the section had no probe at all until 2026-08-21
+grep -rnE 'catch[[:space:]]*\([^)]*\)[[:space:]]*\{[[:space:]]*\}' --include='*.cpp' .  # empty catch — HIGH
+grep -rn 'catch (...)' --include='*.cpp' .               # swallow-all: needs a rethrow or a logged reason
+clang-tidy --checks='bugprone-empty-catch,bugprone-exception-escape,misc-throw-by-value-catch-by-reference' <files>
+# Ignored error returns — the C half of §7, and the one nobody greps
+clang-tidy --checks='bugprone-unused-return-value,cert-err33-c' <files>   # cert-err33-c aliases the former
+grep -rn 'std::expected\|absl::Status\|tl::expected' --include='*.cpp' --include='*.hpp' . | head
+# ^ then ask the §7 question a grep cannot: is ONE error model used across a
+#   given boundary, or do exceptions, codes and expected<> meet at an ABI seam?
+#   Mixed models at a boundary is the finding, not any one of them.
+
 # Broad idiom enforcement (the canonical config)
 clang-tidy --checks='cppcoreguidelines-*,modernize-*,bugprone-*' <files>
 ```

--- a/skills/sota-ml-engineering/rules/02-data-and-features.md
+++ b/skills/sota-ml-engineering/rules/02-data-and-features.md
@@ -83,6 +83,20 @@ cross_val_score(pipe, X_train, y_train, cv=TimeSeriesSplit())
 
 ## Audit checklist
 
+- [ ] **Train/serve skew**: is the transformation that produces a training feature the
+      *same code path* as the one serving it — a shared library or a feature store — or
+      two implementations that must be kept in step by hand? Two implementations is the
+      finding, whether or not they currently agree.
+- [ ] **Point-in-time correctness**: does every training label join features **as of** the
+      label's timestamp? A join that picks up feature values computed after the event
+      leaks the future into training and inflates offline metrics — it will not reproduce
+      in serving, which is how it is usually discovered.
+- [ ] If a **feature store** is in use: are offline and online stores written from one
+      pipeline, is freshness monitored per feature, and is a feature's serving default
+      (on a store miss) the same value training saw for a missing feature?
+- [ ] If one is **not** in use: what enforces the two answers above instead? "We are
+      careful" is not a mechanism (`rules/01` §3).
+
 ```bash
 # Preprocessing leakage — CRITICAL
 grep -rnE '\.fit(_transform)?\(' --include='*.py' . | grep -vE 'Pipeline|fit\(X_train|fit\(train'  # fit on full data?


### PR DESCRIPTION
The previous PR said *"no evidence found"* of an audit half demanding what the build half
never asked for. **That was reassurance I had not earned** — two mechanical proxies had
failed, and a failed instrument cannot support a negative claim (router principle 3: a
negative claim needs more proof than a positive one). So I sampled and read.

## Method

20 top-level BUILD sections, drawn on a **fixed stride** from a population of **1,773**
across 259 rules files, each read against its own checklist *and its siblings'*.

## Result

| | |
|---|--:|
| covered | **16** |
| correctly exempt | **2** |
| **real gaps** | **2** |

The two exempt ones are the useful calibration: `sota-api-design` §8 *"HATEOAS — pragmatic
dose"* and `sota-testing` §8 *"TDD: when it pays"* are **advisory**. You cannot audit
"did you practise TDD" from a repo, and a checklist item there would be noise, not rigour.
That distinction is now written into the convention rather than left implicit.

## The two real gaps — both fixed here

**`sota-c-cpp/rules/01` §7 "Error handling: exceptions vs expected vs codes"** — a whole
build section with **no audit probe anywhere in the skill**: one incidental hit across all
seven rules files. Now carries greps for empty and swallow-all `catch`, the relevant
clang-tidy checks (`bugprone-empty-catch`, `bugprone-exception-escape`,
`misc-throw-by-value-catch-by-reference`, `bugprone-unused-return-value` aliased by
`cert-err33-c` — **names verified against the official check list**, not recalled), and
the question a grep cannot ask: *is one error model used across a boundary, or do three
meet at an ABI seam?*

**`sota-ml-engineering`** — its own skill description advertises **train/serve skew
twice**, and **zero checklists across all seven rules files** mention skew, point-in-time
correctness, or feature stores. `rules/02` now audits all three, including the case where
no feature store exists — *"we are careful" is not a mechanism*.

## The answer to the original question

**Yes, there is a problem — but it is modest, and it runs opposite to the concern.**

- **The feared direction did not appear at all.** Not one sampled checklist item demanded
  something the build half never asked for. Every apparent instance in the earlier
  lexical pass was an artifact of the instrument.
- **The real direction is build-without-probe**, at roughly **10% of sections** on n=20 —
  **indicative, not precise**, and recorded that way.

## Third instrument failure, recorded

My own sampling one-liner mangled a shell alternation — `${spec##*|}` kept only the last
branch, so two sections were searched for `_links` and `errno` alone and nearly logged as
false gaps. Redone in Python. That is three failed instruments in one investigation
(`§`-anchors, lexical overlap, the shell harness), which is the strongest available
argument for the convention landing as **judgement, not a gate**.
