### PR TITLE
n=60: the gap rate collapses to ~4%, and the worst cluster was mine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Seven of the nine language rows added in the in-band-sentinel fan-out shipped with no
+  audit item** — `sota-golang`, `sota-rust` (partial), `sota-c-cpp`, `sota-jvm`,
+  `sota-javascript-typescript`, `sota-dotnet` and `sota-ruby`. Only Python and PHP had
+  one. Each now carries a language-specific probe built from the behaviour measured when
+  the row was written: producer greps for `return -1`, `strconv.Atoi` with a dropped
+  error, `unwrap_or(-1)` and `#[serde(default)]` on numeric fields, `atoi`, `EOF` stored
+  in a `char`, an `indexOf` result **stored rather than tested on the next line**,
+  `TryParse` with a discarded `bool`, and `.to_i` on untrusted input. `sota-jvm` §6
+  (module/package structure) had no probe either and gained one. Found by sampling the
+  library's own BUILD↔AUDIT correspondence — i.e. the fan-out committed, that morning,
+  precisely the failure the sampling exercise existed to look for.
+- **`sota-golang` rules/01's in-band-sentinel subsection was unnumbered**, so `§4a` did
+  not resolve; numbered to match the `1a`/`6a` pattern used in the sibling skills. Caught
+  by invariant 18, which is now three-for-three at catching this session's own citations.
+
 ### Added
 
 - **A parser ladder for languages without a native AST** (`sota-testing/rules/02` §2.10).

--- a/docs/CONVENTIONS-LEDGER.md
+++ b/docs/CONVENTIONS-LEDGER.md
@@ -218,11 +218,27 @@ measurement, not an opinion:
   ungrounded while being grounded in two **sibling** files. Both failure modes are
   intrinsic: correspondence is semantic and often cross-file.
 
-- **Attempt 3 — read a sample, which is the only method that worked.** 20 top-level
-  build sections drawn on a fixed stride from a population of **1,773**, each read against
-  its own checklist and its siblings'. Result: **16 covered, 2 correctly exempt** (HATEOAS
-  and TDD are advisory — you cannot audit "did you practise TDD"), **2 real gaps**. So a
-  genuine-gap rate near **10%**, on n=20 — indicative, not precise, and stated that way.
+- **Attempt 3 — read a sample, which is the only method that works.** 20 sections on a
+  fixed stride from a population of **1,773**: **16 covered, 2 correctly exempt** (HATEOAS
+  and TDD are advisory — you cannot audit "did you practise TDD"), **2 real gaps**.
+- **Attempt 4 — n=60, and the rate collapsed.** A second systematic sample, screened on
+  section-*body* terms against the file's own checklist **and its siblings'**, flagged 7.
+  All 7 read: **5 were covered** (the screen over-flags on synonymy), 1 correctly exempt
+  (a pure cross-reference section), **1 real gap**. Eleven `ok` calls were then read as a
+  false-negative check — including the seven weakest — and **every apparent gap dissolved
+  under correct checking**: one had been searched in the wrong file, one was covered by an
+  item phrased as `cast()` rather than "narrowing".
+  Pooled over the 80 sampled sections the confirmed rate is **~4%**, not the 10% n=20
+  suggested. The honest caveat: 18 of the 60 were read in full, the rest screened, and the
+  screen is known to err **both ways** — so 4% is a floor with a soft ceiling, not a
+  measurement.
+- **The finding that beat the percentage: gaps cluster by *file*, not by section**, and
+  the worst cluster was **self-inflicted the same day**. Ranking files by weak-screen
+  density put two `rules/02-design-api.md` files on top; reading the first showed the real
+  cause — the in-band-sentinel row added to **nine language skills that morning** had
+  shipped with an audit item in only **two** of them. Seven were fixed on discovery. The
+  lesson is procedural, not statistical: **a fan-out across N skills is N chances to ship
+  the build half alone**, and the author is the last person who will notice.
 
 Both real gaps were fixed on discovery: `sota-c-cpp` rules/01 §7 *Error handling* had **no
 probe anywhere in the skill** (one incidental hit across seven files), and

--- a/skills/sota-c-cpp/rules/01-idioms.md
+++ b/skills/sota-c-cpp/rules/01-idioms.md
@@ -185,4 +185,9 @@ grep -rn 'std::expected\|absl::Status\|tl::expected' --include='*.cpp' --include
 
 # Broad idiom enforcement (the canonical config)
 clang-tidy --checks='cppcoreguidelines-*,modernize-*,bugprone-*' <files>
+
+# In-band sentinels (§7/§8) — absence encoded as a value
+grep -rnE 'return -1;' --include='*.c' --include='*.cpp' .      # producer: same constant from 2 branches?
+grep -rn 'atoi(\|atol(' --include='*.c' --include='*.cpp' .      # 0 on garbage == 0 on "0" (rules/04)
+grep -rnE 'char[[:space:]]+[a-z_]+[[:space:]]*=[[:space:]]*getchar' --include='*.c' .  # EOF in a char: breaks only where char is UNSIGNED
 ```

--- a/skills/sota-dotnet/rules/02-design-api.md
+++ b/skills/sota-dotnet/rules/02-design-api.md
@@ -100,4 +100,8 @@ grep -rnE 'throw ex;' --include='*.cs' .
 
 # Mutable collection exposed — LOW
 grep -rnE 'public (List|Dictionary|HashSet)<' --include='*.cs' . | head   # prefer IReadOnly* / encapsulate
+
+# In-band sentinels (§1a) — `int?` over a magic int; TryParse's bool is the signal
+grep -rnE 'return -1;' --include='*.cs' .                       # producer; prefer int?
+grep -rnE 'TryParse\([^)]*out var [a-z]+\);' --include='*.cs' .   # bool DISCARDED -> out is 0 on failure
 ```

--- a/skills/sota-golang/rules/01-errors.md
+++ b/skills/sota-golang/rules/01-errors.md
@@ -108,7 +108,7 @@ Context errors: check `errors.Is(err, context.Canceled)` /
 `context.DeadlineExceeded` before counting a failure as a real one — a
 canceled request is not a dependency outage; don't page on it.
 
-### In-band sentinels — Go's are documented, yours are not
+### 4a. In-band sentinels — Go's are documented, yours are not
 
 Go's stdlib deliberately returns in-band sentinels and **documents them**:
 `strings.Index`/`LastIndex` return `-1` when not found (verified, go1.26.5). That is
@@ -272,6 +272,14 @@ see `rules/05`).
 ## Audit checklist
 
 Run from repo root; verify each hit manually.
+
+**In-band sentinels — a value standing in for absence** (§4a). Go's own `-1` from
+`strings.Index` is documented and fine when tested immediately; yours is not:
+
+```bash
+grep -rnE 'return -1$|return -1,' --include='*.go' .        # producer — prefer (T, bool) comma-ok
+grep -rnE ':?= .*strconv\.Atoi\(' --include='*.go' . | grep -v 'err'   # the 0 is in-band if err is dropped
+```
 
 ```bash
 # Discarded errors (also rely on errcheck via golangci-lint)

--- a/skills/sota-javascript-typescript/rules/02-language-idioms.md
+++ b/skills/sota-javascript-typescript/rules/02-language-idioms.md
@@ -258,6 +258,10 @@ const truncate = (s: string, n: number) => [...seg.segment(s)].slice(0, n).map(x
 
 ## Audit checklist
 
+- [ ] In-band sentinels: `grep -rnE 'return -1' --include='*.ts' --include='*.js' src/` — a
+      `-1` that is **stored or passed** rather than tested on the next line. Remember `??`
+      does not rescue it (`-1 ?? x` is `-1`); only `null`/`undefined` trigger it.
+
 - [ ] `grep -rn "[^=!]==[^=]\|!=[^=]" --include="*.ts" src/` — loose equality (MEDIUM; eqeqeq lint).
 - [ ] `grep -rn "|| 0\||| ''\||| \[\]\||| {}" src/` and `\b(port|count|index|limit|offset|retries)\s*=.*||` — `||` where `??` is meant (MEDIUM, HIGH if money/ports).
 - [ ] `grep -rn "forEach(async" src/` — fire-and-forget async iteration (HIGH).

--- a/skills/sota-jvm/rules/02-design-api.md
+++ b/skills/sota-jvm/rules/02-design-api.md
@@ -118,4 +118,11 @@ grep -rn 'throws Exception' --include='*.java' .
 grep -rnE 'org\.springframework\.lang\.(Nullable|NonNull)' --include='*.java' --include='*.kt' .
 
 # Enforcement: Error Prone + NullAway, SpotBugs, detekt
+
+# In-band sentinels (§1a) — `-1` is not absence
+grep -rnE 'return -1;' --include='*.java' --include='*.kt' .    # producer; prefer OptionalInt / Integer + @Nullable
+grep -rnE '(int|long) [a-zA-Z]+ = .*\.(indexOf|lastIndexOf)\(' --include='*.java' .  # result STORED, not tested on the next line
+# Module/package structure (§6) — no probe existed before 2026-08-21
+grep -rn 'module-info.java' --include='*.java' . || echo 'no JPMS module descriptors'
+grep -rnE '^import .*\.(internal|impl)\.' --include='*.java' .   # reaching into another package's internals
 ```

--- a/skills/sota-ruby/rules/01-language-idioms.md
+++ b/skills/sota-ruby/rules/01-language-idioms.md
@@ -203,6 +203,14 @@ Rules:
 
 Run from repo root; verify each hit manually.
 
+**In-band sentinels** (§5a) — Ruby's search API returns `nil`, so these arrive from
+conversion and from hand-rolled returns:
+
+```bash
+grep -rnE '\.to_i\b|\.to_f\b' --include='*.rb' app/ lib/     # 0 on garbage, 12 on "12abc" — use Integer(s)
+grep -rnE 'return (-1|0)$' --include='*.rb' app/ lib/         # prefer nil, which is falsy and pattern-matchable
+```
+
 ```bash
 # Interpreter floor — EOL Ruby is HIGH
 cat .ruby-version 2>/dev/null; grep -n "^ruby" Gemfile 2>/dev/null

--- a/skills/sota-rust/rules/02-errors-and-panics.md
+++ b/skills/sota-rust/rules/02-errors-and-panics.md
@@ -236,6 +236,10 @@ fn main() -> ExitCode {
 
 ## Audit checklist
 
+- [ ] Sentinel re-entry (§6a): `rg 'unwrap_or\(-?[0-9]+\)|unwrap_or_default\(\)' -t rust`
+      on numeric `Option`s, and `#[serde(default)]` on numeric fields — each discards the
+      absence the type system was carrying.
+
 - [ ] `rg '\.unwrap\(\)' -t rust -g '!*test*' -g '!benches/*' -g '!examples/*'`
       — every hit in production paths is a finding; severity scales with input
       reachability (attacker-reachable unwrap = High).


### PR DESCRIPTION
The n=20 estimate said ~10%. A second systematic sample says the rate is lower — and
turned up something far more useful than a percentage.

## Method

60 sections, fixed stride, population **1,773** across 259 rules files. The screen was
rebuilt after the last pass's failures: it keys on each section's **body** terms (not just
its heading, which synonymy defeated) and searches the file's own checklist **and its
siblings'**.

## Result

| stratum | read | outcome |
|---|--:|---|
| flagged by screen | 7 of 7 | 5 **covered** (screen over-flags), 1 correctly exempt, **1 real gap** |
| passed by screen | 11 of 53 | **0 real gaps** — every apparent one dissolved under correct checking |

Both apparent false-passes were **my checking, not the library**: one searched the wrong
file (`§1 Web frontend` lives in `rules/03`, not `rules/02`), and one was covered by an
item phrased `cast()` rather than "narrowing".

**Pooled over 80 sampled sections: ~4% confirmed**, not 10%.

**Stated caveat:** 18 of the 60 were read in full, the rest screened, and the screen errs
**both ways**. So 4% is a floor with a soft ceiling — not a measurement, and recorded as
such rather than quoted as one.

## The finding that beats the percentage

Ranking files by weak-screen density put two `rules/02-design-api.md` files on top.
Reading the first showed the real cause, and it was **self-inflicted that morning**:

> The in-band-sentinel row I added to **nine language skills** shipped with an audit
> checklist item in **two** of them.

`sota-golang`, `sota-c-cpp`, `sota-jvm`, `sota-javascript-typescript`, `sota-dotnet`,
`sota-ruby` — no item. `sota-rust` — partial. Only Python and PHP were complete.

So the sampling exercise found the exact failure it existed to look for, committed hours
earlier, in the work presented as thorough. **Gaps cluster by file, and a fan-out across
N skills is N chances to ship the build half alone** — the author being the last person
who will notice.

## Fixed here

Seven language rows gained probes built from the behaviour **measured when the row was
written**: `return -1` producers, `strconv.Atoi` with a dropped error, `unwrap_or(-1)` and
`#[serde(default)]` on numeric fields, `atoi`, `EOF` stored in a `char`, an `indexOf`
result **stored rather than tested on the next line**, `TryParse` with a discarded `bool`,
`.to_i` on untrusted input. `sota-jvm` §6 (module/package structure) had no probe either
and gained one.

Also: `sota-golang`'s subsection was **unnumbered**, so `§4a` didn't resolve — caught by
**invariant 18**, now three-for-three at catching this session's own citations.
