### PR TITLE
A pipeline destroys output as well as status — pipefail fixes only one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A pipeline destroys output as well as status** (`sota-shell-scripting/rules/01` §3).
+  The library covered the status half correctly — `$?` after a pipeline is the last
+  stage's, `pipefail` and `${PIPESTATUS[0]}` are the fixes — and said nothing about the
+  second failure mode of the same construct: **`pipefail` does nothing to bring destroyed
+  output back**. For any command whose output you intend to *reason about*, redirect to a
+  file and read the file. The asymmetry is what makes it a rule rather than a tip:
+  **`tail` is selected to keep the summary line**, so a pipe preserves the number and
+  discards the traceback, warnings and stderr context — the material that would tell you
+  the number is wrong — and the surviving line is the one most likely to be quoted.
+  Reproduced before writing (and the *first* reproduction was wrong, keeping the cause
+  because it sat last): rebuilt pytest-shaped, `tail -12` destroyed
+  `AssertionError: expected 16, got 4` while `1 failed, 38265 passed` survived intact.
+  Corollaries: an **empty result and a discarded result are the same value**, and
+  unflushed output in a `timeout`-killed process leaves a file that is empty for a reason
+  unrelated to the result. Scope deliberately narrow — not "never use `tail`", but "not
+  for output that is evidence for a claim". Checklist grep added; cross-referenced from
+  `sota/rules/01`'s evidence standard, which now says an audit should keep the output that
+  produced its findings.
+
 ## [1.24.1] - 2026-08-21
 
 **The last two deferrals, closed with their audit halves.** Both ideas held over from the

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -184,6 +184,7 @@ lessons-log — its own best structural idea, applied to ourselves.
 | 2026-08-20 | **Self-audit of the same day's own work** — "do we have gaps elsewhere?" | Four classes shipped 2026-08-20 were stated only where the incident happened, and were **unreachable from the skills that need them** | **adopted** | `sota-devsecops/rules/05` §5.6 + checklist (a negative control belongs in a `--self-test` **mode of the runner**, not only as a fixture beside it — that file is the canonical home for "every gate ships a known-bad" and a DevSecOps reader never loads `rules/12`), `sota-observability/rules/01` §5 (**"at completion" is load-bearing** — a mid-function line attests only that the line ran; site the claim where the value is consumed), `sota-testing/rules/06` §6.3 (**mutate and read the output, not the suite** — every other probe in that section ends in "run the tests", which cannot answer whether the report is truthful), and `sota-code-security/rules/12` §1b.1 (**a planned change is a legitimate source of a gate**). Verified absent in all four before writing · v1.24.0 |
 | 2026-08-20 | Operator question — "are there other bright ideas like this we should adopt?" | Three refinements of the same day's `--self-test`, which collapsed into one gate: **run it always**, **fail closed**, and **pin the exempt set** | **adopted** | `scripts/check-invariants.sh` invariant **19** + harness probe 19 (25 probes, 14 of 19). The third is the one with teeth: without a pin, "every check is probed or declared unprobeable" is satisfied by adding your new check number to the exempt list. Measured first — the structural pass costs **49 ms**, which is what makes "always" defensible. It caught **itself** on introduction. Also derived probe 17's mutation instead of pinning the invariant count, after that literal went stale twice in one day · v1.24.0 |
 | 2026-08-20 | Field brief — *a method hierarchy for authoring durable guards* (one session on a 38k-test Python codebase) | **Auditing and authoring are different activities**: the library states a method default for the search and none for the guard the search leaves behind | **adopted with one addition** | `sota-testing/rules/02` §2.10 + three checklist items, cross-referenced from `sota-code-security/rules/10`'s absence bullet; **formatter reflow** added as a fourth mutation-did-not-take cause in `sota-testing/rules/06` §6.3 and `sota-code-security/rules/12` §1. Both of the brief's "not a duplicate" citations verified **accurate** (rules/10:286-292 and rules/06:169), and the gap confirmed: all seven `AST` mentions in `skills/` are about auditing, RAG splitting, Python `match`, or a coincidental Cypher relationship name — **none about authoring**. My addition: **name the parser per language**, because "no parser at hand" is precisely when people reach for regex · v1.24.0 |
+| 2026-08-21 | Field brief — *a pipeline is an evidence hazard, not only an exit-status hazard* (three destroyed measurements in one session) | `pipefail` and `${PIPESTATUS[0]}` fix the **status**; nothing in the library said a pipe also destroys the **output**, and the two need different fixes | **adopted** | `sota-shell-scripting/rules/01` §3 + a checklist grep, cross-referenced from `sota/rules/01`'s evidence standard. All three of the brief's citations verified accurate (`rules/01`:47, `rules/01`:124, router `:197`), and the gap confirmed by two independent sweeps. **Reproduced before writing** — and the first reproduction was *wrong*, keeping the cause because it sat last; rebuilt pytest-shaped (cause at the top, summary last), `tail -12` destroyed the `AssertionError` while `1 failed, 38265 passed` survived · unreleased |
 
 ## Entries
 
@@ -1246,3 +1247,46 @@ file that has only §1–§7. References resolved: 1,363 → 1,368.
 
 **Measurement status:** the brief's 74 → 61 orphan-candidate figure is the reporter's,
 on their codebase, and is quoted as such. **No efficacy lift is claimed for the library.**
+
+### 2026-08-21 — the pipe keeps the number and throws away the evidence it is wrong
+
+`sota-shell-scripting` rules/01 §3 already covered the status half correctly, and the
+brief says so rather than claiming novelty: `$?` after a pipeline is the last stage's,
+`${pipestatus[1]}`/`${PIPESTATUS[0]}` are the fixes, and the preamble prescribes
+`set -euo pipefail`. All three citations checked and all three accurate.
+
+**What was genuinely absent is the second failure mode of the same construct.** Every
+existing line treats a pipeline as a hazard to the *exit status*. It is equally a hazard
+to the *output*, and `pipefail` does nothing for that half — a run can have a perfectly
+correct exit status and have thrown away the only copy of the diagnostic explaining it.
+Two independent sweeps found nothing on it; the one near-miss
+(`sota-cli-ux/SKILL.md`:57, `tool cmd > out.txt 2> err.txt`) is about testing a CLI's
+output contract, not about preserving your own measurement.
+
+**The asymmetry is the reason it deserves a rule rather than a tip.** `tail` is *selected*
+to keep the summary line. So the surviving output is the number, and the destroyed output
+is the traceback, the warnings and the stderr context — precisely the material that would
+tell you the number is not to be trusted. The line most likely to be quoted in a report is
+the line the truncation is designed to preserve. That is the `rules/10` silent-control
+shape (a result that looks identical whether or not the thing worked), reached from the
+harness side instead of the product side.
+
+**Reproduced before writing, and the first attempt was wrong.** A nine-line script with
+the `AssertionError` last "survived" `tail -3` — which would have supported the opposite
+conclusion. Rebuilt to the shape the brief actually describes (200 progress lines, cause
+at the top, summary last, as pytest prints): `tail -12` destroyed
+`AssertionError: expected 16, got 4` while `1 failed, 38265 passed` came through intact;
+redirected, both were present and the cause was one `grep` away with no re-run.
+
+**Adopted partly on first-hand evidence from the same session.** This session ran the
+negative-control harness through `| tail -N`, hit `FAIL: 1 of 24 mutations were not
+caught`, and could not tell *which* — so the four-minute harness was re-run twice more,
+each time with a different filter, to recover output that had already been produced. That
+is the brief's failure mode 1 in miniature, committed while adopting the rule against it.
+
+**Scope kept narrow, as the brief asked.** Not "never use `tail`" — watching a log or
+sampling a file is fine. The rule applies where output is **evidence for a claim**, and
+the tell is whether recovering it would mean re-running the job.
+
+**Measurement status:** adopted on reasoning, a verified reproduction, and first-hand
+recurrence. **No efficacy lift is claimed or measured.**

--- a/skills/sota-shell-scripting/rules/01-safety-baseline.md
+++ b/skills/sota-shell-scripting/rules/01-safety-baseline.md
@@ -123,6 +123,44 @@ calling it. `for x in "a b"; do cmd $x; done` and `${var:+--flag $var}` are wher
 bites hardest. Same family: `$?` after a pipeline is the **last** stage's status —
 `${pipestatus[1]}` in zsh, `${PIPESTATUS[0]}` in bash (rules/02 §4).
 
+**A pipeline is an evidence hazard as well as a status hazard, and `pipefail` only fixes
+the status.** For any command whose output you intend to *reason about* — a test run, a
+benchmark, a profile, a long analysis — **redirect to a file and read the file**:
+
+```bash
+cmd > out.txt 2>&1; echo "EXIT=$?"        # status preserved AND output preserved
+grep -nE 'passed|failed|Error' out.txt    # filter AFTER, as often as you like
+```
+
+`cmd 2>&1 | tail -12` keeps the summary and destroys the traceback, the warnings and the
+stderr context above the cut — which is **the material that tells you the summary is
+wrong**. That asymmetry is the whole hazard: `tail` is *selected* to keep the summary
+line, so the pipe preserves the number and discards the evidence that the number is not
+to be trusted, and the surviving line is the one most likely to be quoted. Reproduced on a
+pytest-shaped run (200 progress lines, cause at the top, summary last): piped through
+`tail -12` the `AssertionError` was gone while `1 failed, 38265 passed` survived;
+redirected, both were there and the cause was one `grep` away.
+
+The cost is not the pipe, it is that a consumed pipe **cannot be re-read** — recovering
+the output means re-running the job. A 36-minute suite re-run to retrieve output that had
+already been produced once is the reported case; a four-minute mutation harness re-run
+three times over, because each `| tail -N` answered a different question than the one
+asked, is the same failure in miniature.
+
+Two corollaries:
+- **An empty result and a discarded result are the same value.** A backgrounded
+  `... 2>&1 | tail -14` that produced a 22-byte file containing only `[exited with code 0]`
+  is indistinguishable from a run that measured nothing — and the exit status says
+  neither.
+- **Buffering turns this into a lie about the cause.** In long-running Python use
+  `print(..., flush=True)` (or `-u`): a process killed by `timeout` otherwise leaves a
+  file that is empty for a reason unrelated to the result.
+
+**Scope, deliberately narrow:** this is not "never use `tail`". Piping to `tail` to watch
+a log, sample a file or check a shape is fine and idiomatic. The rule applies where the
+output is **evidence for a claim**, and the tell is whether you would have to re-run the
+job to get it back.
+
 **Arrays are the portable answer.** They mean what they say in both shells; `${=var}` is
 a zsh-only escape hatch for a string you did not build.
 
@@ -272,6 +310,8 @@ files=(/data/*); count=${#files[@]}                               # with nullglo
 ```
 
 ## Audit checklist
+
+- [ ] **Measurements piped into `tail`/`head`.** `grep -rnE '(pytest|go test|cargo|bench|profile|timeout)[^|]*\| *(tail|head)' --include='*.sh' --include='*.yml' .` — and the same in any runbook or CI step whose output someone reads. Evidence commands redirect to a file; `pipefail` does not bring destroyed output back (§3).
 
 Run `shellcheck -S style` first; then hunt manually.
 

--- a/skills/sota/rules/01-audit-methodology.md
+++ b/skills/sota/rules/01-audit-methodology.md
@@ -210,6 +210,13 @@ full evidence block for the report. Skill-local block formats are fine during
 a single-domain pass, but they must carry the effort field — §8's roadmap is
 sequenced by risk-reduction-per-effort and can't be built without it.
 
+**Keep the output that produced the finding.** A command whose result you will cite is
+evidence: redirect it to a file rather than piping it through `tail`/`head`, because a
+consumed pipe cannot be re-read and the truncation keeps the summary while discarding the
+context that would qualify it (`sota-shell-scripting` rules/01 §3). An audit that cannot
+reproduce its own quoted output without re-running the job has a weaker evidence chain
+than it appears to.
+
 ## 6. Decision-ledger review — audit the decisions, not just the code
 
 Code review finds defects in what was built. It cannot find the defect where the


### PR DESCRIPTION
A field brief with an unusual property: it **credits the library correctly first**, then
extends it. All three of its citations were checked and all three are accurate —
`sota-shell-scripting/rules/01`:47 (the pipefail failure table), `:124` (`$?` is the last
stage's; `${pipestatus[1]}` / `${PIPESTATUS[0]}`), and router `:197` (the one-liners you
type to verify a claim).

## The gap

Every existing line treats a pipeline as a hazard to the **exit status**. It is equally a
hazard to the **output**, and the two need different fixes:

| hazard | fix |
|---|---|
| wrong exit status | `set -o pipefail`, `${PIPESTATUS[0]}` |
| **destroyed evidence** | **redirect to a file and read the file** |

`pipefail` fully solves the first and does **nothing** for the second. A run can have a
perfectly correct exit status and still have thrown away the only copy of the diagnostic
that explains it. Two independent sweeps found nothing on this; the single near-miss
(`sota-cli-ux/SKILL.md`:57) is about testing a CLI's output contract, not preserving your
own measurement.

## Why it earns a rule rather than a tip

**`tail` is *selected* to keep the summary line.** So the pipe preserves the number and
discards the traceback, the warnings and the stderr context — precisely the material that
would tell you the number is not to be trusted. The line most likely to be quoted in a
report is the line the truncation is designed to keep. That is `rules/10`'s silent-control
shape — a result that looks identical whether or not the thing worked — reached from the
harness side rather than the product side.

## Reproduced before writing — and my first attempt was wrong

A nine-line script with the `AssertionError` last "survived" `tail -3`, which would have
supported the **opposite** conclusion. Rebuilt to the shape the brief describes (200
progress lines, cause at the top, summary last, as pytest prints):

```
piped   `cmd 2>&1 | tail -12`  ->  "1 failed, 38265 passed" survived
                                   "AssertionError: expected 16, got 4"  DESTROYED
redirect `cmd > out.txt 2>&1`   ->  both present, cause one grep away, no re-run
```

## Adopted partly on first-hand recurrence

This session ran the negative-control harness through `| tail -N`, hit
`FAIL: 1 of 24 mutations were not caught`, and **could not tell which** — so the
four-minute harness was re-run twice more with different filters to recover output that
had already been produced. The brief's failure mode 1, committed while adopting the rule
against it.

## Scope, kept narrow as the brief asked

Not "never use `tail`" — watching a log or sampling a file is fine and idiomatic. The rule
applies where output is **evidence for a claim**, and the tell is whether recovering it
would mean re-running the job.

Checklist grep added **in the same change**; cross-referenced from `sota/rules/01`'s
evidence standard, which now says an audit should keep the output that produced its
findings.

**No efficacy lift is claimed or measured.**
