### PR TITLE
Record build-safe pilot readiness: instrument verified, blocked on builds

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -448,6 +448,16 @@ first.
   power is untested: if the bare arm still scores 1.000, these classes may not be
   elicitable from a spec at all, and that is the finding. **Do not cite a build-safe
   number until the pilot lands and is scored.**
+
+  **State as of 2026-08-21: ready to run, blocked only on producing the two builds.**
+  Verified rather than assumed — `run-build-safe.py` is a **scorer, not a generator** (it
+  grades a `--build` directory and makes no model calls), and its `--selftest` passes with
+  the two references separating cleanly: **0.000 on the known-bad (`reportkit`), 1.000 on
+  the known-good (`reference-safe`)**. The case file's 49 lines are 42 comments and **7
+  real cases**, and `load_cases` exits rather than score an empty set. `SPEC.md`
+  re-checked: **zero** "must …" quality clauses, so the rewrite held. What is missing is
+  one bare-arm and one library-arm build from that spec — model spend, and therefore an
+  owner's decision rather than a scripting task.
 - **Calibration remains the only untested claim about the audit half.** Across four
   settings today, every library arm downgraded its own findings on evidence, bounded
   claims by what it had actually run, and labelled what it had not verified; no bare


### PR DESCRIPTION
The roadmap said the BUILD-safe pilot was *untested* but not what **state** it was in.
Checked rather than assumed, all of it free:

- **`run-build-safe.py` is a scorer, not a generator.** It grades a `--build` directory
  and makes **no model calls** — so the pilot's cost is producing the builds, not scoring
  them. That reframes the blocker entirely.
- **Its `--selftest` passes, with the references separating cleanly:** `0.000` on the
  known-bad (`reportkit`), `1.000` on the known-good (`reference-safe`). This is the
  precondition for trusting any number it later produces — and this repo has found 8
  scorer defects in a single day before, so it is not a formality.
- **The 49-line case file is 42 comments and 7 real cases**, and `load_cases` exits rather
  than score an empty set. Checked because 7-vs-49 is exactly the denominator shape the
  library has been bitten by; here it is correct.
- **`SPEC.md` re-checked: zero `"must …"` quality clauses**, so the 2026-08 rewrite held.

## Effect

The item moves from *"untested, unclear state"* to **"ready, blocked on one bare-arm and
one library-arm build from that spec"** — model spend, and therefore an owner's decision
rather than a scripting task.

`OPENROUTER_API_KEY` is not present in this shell, so I can neither check the credit
balance nor run the arms; both are stated rather than assumed.

No number is claimed. The standing instruction — *do not cite a build-safe number until
the pilot lands and is scored* — is untouched.
