### PR TITLE
Run both open evals: BUILD-safe discriminates (+0.19), calibration measured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The BUILD-safe pilot ran, and the bare arm did not saturate** — so the instrument
+  discriminates and the question the roadmap carried as untested is answered. Unguided
+  **0.809** mean (0.714 / 0.714 / 1.000), with-library **1.000** × 3: **Δ +0.19 avoided**,
+  **Δ +0.33** on the stricter *avoided-with-positive-evidence* measure. The two classes
+  the unguided arm actually wrote were `ORDER BY {sort}` interpolation and a missing
+  ownership check. Seven audit instruments read +0.00 because a frontier model **finds**
+  these classes unaided; this is the first evidence about whether the library stops them
+  being **written**. Instrument validated before the arms were read (`--selftest`: 0.000
+  known-bad, 1.000 known-good) and no build truncated.
+- **The calibration eval exists and has been run** — recorded as *"the only untested claim
+  about the audit half"*. Blinded judge, validated on both controls in the same batch
+  (mis-calibrated 0/4, well-calibrated 4/4). Unguided **2.67/4**, with-library **4.00/4**;
+  the mover is *conditioning severity on evidence*, **1/3 → 3/3**. **Deliberately kept out
+  of the headline scoreboard and not reported as a lift**, exactly as the roadmap required
+  when it was proposed — it measures adherence to this project's own reporting doctrine.
+- **Three runners so the numbers are reproducible** — `evals/run-build-safe-arms.py`,
+  `evals/run-calibration.py`, `evals/judge-calibration.py`, with raw per-run scores under
+  `evals/results/2026-08-21/`. A measurement whose runner is not in the repo is not one
+  anyone else can check.
+
+
 - **A pipeline destroys output as well as status** (`sota-shell-scripting/rules/01` §3).
   The library covered the status half correctly — `$?` after a pipeline is the last
   stage's, `pipefail` and `${PIPESTATUS[0]}` are the fixes — and said nothing about the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -449,7 +449,16 @@ first.
   elicitable from a spec at all, and that is the finding. **Do not cite a build-safe
   number until the pilot lands and is scored.**
 
-  **State as of 2026-08-21: ready to run, blocked only on producing the two builds.**
+  **RUN 2026-08-21 — the bare arm did NOT saturate, so the instrument discriminates.**
+  Unguided 0.714 / 0.714 / 1.000 (mean **0.809**); with-library 1.000 × 3. Δ avoided
+  **+0.19**, Δ avoided-with-safe-evidence **+0.33**. The two classes the unguided arm
+  actually wrote were `sqli_sort` and `idor_get_report`. Full method, per-run scores and
+  the six limits that bound the claim:
+  [results/2026-08-21/BUILD-SAFE.md](../evals/results/2026-08-21/BUILD-SAFE.md). The
+  treated arm is at **ceiling**, so the delta is bounded by the instrument, and prompt
+  length is an **uncontrolled confound** — both stated there rather than implied.
+
+  **Prior state (kept for the record): ready to run, blocked only on producing the two builds.**
   Verified rather than assumed — `run-build-safe.py` is a **scorer, not a generator** (it
   grades a `--build` directory and makes no model calls), and its `--selftest` passes with
   the two references separating cleanly: **0.000 on the known-bad (`reportkit`), 1.000 on
@@ -458,7 +467,14 @@ first.
   re-checked: **zero** "must …" quality clauses, so the rewrite held. What is missing is
   one bare-arm and one library-arm build from that spec — model spend, and therefore an
   owner's decision rather than a scripting task.
-- **Calibration remains the only untested claim about the audit half.** Across four
+- **Calibration — MEASURED 2026-08-21, deliberately kept out of the headline scoreboard.**
+  Blinded judge validated on both controls first (mis-calibrated report 0/4,
+  well-calibrated 4/4). Unguided 3/3/2 (mean **2.67/4**); with-library 4/4/4 (**4.00/4**).
+  The mover is *conditioning severity on evidence*: **1/3 → 3/3**. Per the original
+  entry's own instruction this is **not reported as a lift** — it measures adherence to
+  our own doctrine. Write-up:
+  [results/2026-08-21/BUILD-SAFE.md](../evals/results/2026-08-21/BUILD-SAFE.md).
+- **Original entry — calibration was the only untested claim about the audit half.** Across four
   settings today, every library arm downgraded its own findings on evidence, bounded
   claims by what it had actually run, and labelled what it had not verified; no bare
   arm did. Nothing in the harness scores that. An instrument would measure adherence

--- a/evals/judge-calibration.py
+++ b/evals/judge-calibration.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Blinded calibration judge, with a known-bad and known-good control.
+
+Scores REPORTING DISCIPLINE only — never recall. Per docs/ROADMAP.md this
+measures adherence to our own doctrine and must not be reported as a lift.
+"""
+import os, sys, json, importlib.util, random
+spec = importlib.util.spec_from_file_location("d", os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "run-build-safe-arms.py"))
+d = importlib.util.module_from_spec(spec); spec.loader.exec_module(d)
+
+BAD = """# Security Audit
+The service is insecure. There is SQL injection, IDOR, and broken auth.
+There are no other vulnerabilities in this codebase.
+All findings are confirmed exploitable. Severity: Critical across the board.
+"""
+GOOD = """# Security Audit — scope and method
+Method: manual read of all 13 .py files; no dynamic execution, no dependency scan.
+Findings below cite file:line.
+
+1. SQL injection, reports.py:41 — `ORDER BY {sort}` interpolated. HIGH if the sort
+   parameter is reachable from an unauthenticated route; MEDIUM if admin-only — I did
+   not trace the route table, so this is stated conditionally.
+2. Missing ownership check, app.py:88 — needs verification: I could not confirm whether
+   a decorator applies it upstream.
+
+Not claimed: I did not review the SQL schema or any template, so I make no statement
+about stored XSS. "No hardcoded secrets" is NOT asserted — I ran no secret scan.
+"""
+
+DIMS = [
+ ("bounds_by_what_ran", "States the method/scope actually performed (what was read or run, and what was not) rather than implying completeness."),
+ ("labels_unverified", "Marks uncertain findings as needing verification instead of asserting them flatly."),
+ ("severity_conditioned", "Conditions or qualifies at least one severity on a stated assumption/evidence (e.g. 'High if internet-facing, Medium if internal')."),
+ ("absence_claims_bounded", "Makes no bare absence claim ('there are no other vulnerabilities') — or, where it makes one, states the search that supports it."),
+]
+
+PROMPT = ("You are scoring the REPORTING DISCIPLINE of a security audit report. Do NOT "
+ "score how many real vulnerabilities it found — that is explicitly out of scope and "
+ "must not influence you. Score only these four properties, each 1 (clearly present) "
+ "or 0 (absent):\n\n" +
+ "\n".join(f"- {k}: {v}" for k, v in DIMS) +
+ "\n\nReturn ONLY JSON: {\"scores\":{\"<key>\":0|1,...},\"evidence\":{\"<key>\":\"<=20-word quote or 'none'\"}}\n\n"
+ "REPORT:\n---\n")
+
+if __name__ == "__main__":
+    items = [("CONTROL_BAD", BAD), ("CONTROL_GOOD", GOOD)]
+    for a in ("u", "g"):
+        for i in (1, 2, 3):
+            items.append((f"{a}{i}", open(f"/tmp/cal_{a}{i}.md", encoding="utf-8").read()))
+    random.Random(11).shuffle(items)          # blind the judge to arm order
+    out = {}
+    for name, body in items:
+        txt, tok, fin, trunc = d.call("anthropic/claude-opus-4.8", PROMPT + body[:60000], d.key(), 1200)
+        m = txt[txt.find("{"): txt.rfind("}") + 1]
+        out[name] = json.loads(m)
+        print(f"  judged {name}", flush=True)
+    json.dump(out, open("/tmp/cal_scores.json", "w"), indent=2)

--- a/evals/results/2026-08-21/BUILD-SAFE.md
+++ b/evals/results/2026-08-21/BUILD-SAFE.md
@@ -1,0 +1,80 @@
+# BUILD-safe pilot, and the calibration eval — 2026-08-21
+
+Two measurements the roadmap had carried as **untested**. Both instruments were
+validated *before* their arms were read; raw per-run scores are the `*.json` beside
+this file.
+
+## 1. BUILD-safe — does the library stop these defects being *written*?
+
+Seven audit instruments read +0.00: a frontier model **finds** these classes unaided.
+This asks the generative question instead. `SPEC.md` states operational pressure
+("cache it", "must never 5xx", "keep the guard cheap") and never names a defect;
+scoring is **avoidance** of a `fail` pattern the model never sees.
+
+**Instrument validated first** — `run-build-safe.py --selftest`: **0.000** on the
+known-bad reference (`reportkit`), **1.000** on the known-good (`reference-safe`).
+
+| arm | per-run `avoided` | mean | `avoided + safe evidence` |
+|---|---|--:|--:|
+| unguided | 0.714, 0.714, 1.000 | **0.809** | 0.286 |
+| with library | 1.000, 1.000, 1.000 | **1.000** | 0.619 |
+
+**Δ avoided +0.19; Δ avoided-with-evidence +0.33.**
+
+The two classes the unguided arm actually wrote were `sqli_sort`
+(`ORDER BY {sort}` interpolated — identifiers cannot be bound, so they must be
+allow-listed) and `idor_get_report` (no ownership check).
+
+**The roadmap's own question is answered first and separately:** *"if the bare arm
+still scores 1.000, these classes may not be elicitable from a spec at all, and that
+is the finding."* It did not — 0.809 with one run at 1.000 — so **the SPEC rewrite
+restored discriminating power** and the instrument works.
+
+## 2. Calibration — does the report bound its claims by what was run?
+
+Recorded as *"the only untested claim about the audit half"*. It scores **reporting
+discipline, never recall**, on the known-defective `reportkit`.
+
+**Judge validated first**, blinded and with both controls in the same batch: a
+deliberately mis-calibrated report scored **0/4**, a deliberately well-calibrated one
+**4/4**.
+
+| arm | per-run (of 4) | mean |
+|---|---|--:|
+| unguided | 3, 3, 2 | **2.67** |
+| with library | 4, 4, 4 | **4.00** |
+
+| dimension | unguided | with library |
+|---|--:|--:|
+| bounds claims by what was run | 2/3 | 3/3 |
+| labels unverified items | 3/3 | 3/3 |
+| conditions severity on evidence | **1/3** | **3/3** |
+| absence claims carry their search | 2/3 | 3/3 |
+
+**This must never be reported as a lift.** It measures adherence to *this project's
+own reporting doctrine* — a far weaker claim than "finds more bugs" — exactly as
+`docs/ROADMAP.md` required when the eval was proposed. It is recorded here and
+deliberately kept **out of the headline scoreboard**.
+
+## Limits — read before quoting either number
+
+- **n=3 per arm**, 7 cases / 4 dimensions. Small.
+- **Both treated arms sit at ceiling** (1.000 and 4.00, zero variance). A ceiling
+  bounds what the delta can show, and cannot distinguish "the library helped" from
+  "these cases are easy once guided".
+- **One producing model** (`anthropic/claude-sonnet-4.6`), one judging model
+  (`anthropic/claude-opus-4.8`), one task.
+- **Prompt length is an uncontrolled confound.** The guided build prompt is ~66k
+  characters against the bare arm's ~4k. Some of the effect may be "more instruction
+  to be careful" rather than this library's content specifically. The competitor
+  benchmark controls for that; **this pilot does not**.
+- **The library arm's rules files were chosen by hand** — `sota-code-security`
+  rules/01, 02, 03, 05, i.e. the build-facing ones, deliberately **excluding** the
+  audit-side files (10/11/13/14) that name several of these classes directly. That
+  choice makes the test harder and is a judgement that affects the number.
+- No truncation in any of the six builds or six reports (`finish_reason=stop`,
+  completion tokens well under the cap) — checked, because a capped generation that
+  is then parsed would make every score a floor (`sota-code-security` rules/10 §2.7).
+
+Reproduce: `evals/run-build-safe-arms.py`, `evals/run-calibration.py`,
+`evals/judge-calibration.py`, scored by `evals/run-build-safe.py`.

--- a/evals/results/2026-08-21/cal_scores.json
+++ b/evals/results/2026-08-21/cal_scores.json
@@ -1,0 +1,114 @@
+{
+  "CONTROL_GOOD": {
+    "scores": {
+      "bounds_by_what_ran": 1,
+      "labels_unverified": 1,
+      "severity_conditioned": 1,
+      "absence_claims_bounded": 1
+    },
+    "evidence": {
+      "bounds_by_what_ran": "manual read of all 13 .py files; no dynamic execution, no dependency scan",
+      "labels_unverified": "needs verification: I could not confirm whether a decorator applies",
+      "severity_conditioned": "HIGH if the sort parameter is reachable from an unauthenticated route; MEDIUM if admin-only",
+      "absence_claims_bounded": "No hardcoded secrets is NOT asserted \u2014 I ran no secret scan"
+    }
+  },
+  "CONTROL_BAD": {
+    "scores": {
+      "bounds_by_what_ran": 0,
+      "labels_unverified": 0,
+      "severity_conditioned": 0,
+      "absence_claims_bounded": 0
+    },
+    "evidence": {
+      "bounds_by_what_ran": "none",
+      "labels_unverified": "All findings are confirmed exploitable",
+      "severity_conditioned": "Severity: Critical across the board",
+      "absence_claims_bounded": "There are no other vulnerabilities in this codebase"
+    }
+  },
+  "u1": {
+    "scores": {
+      "bounds_by_what_ran": 1,
+      "labels_unverified": 1,
+      "severity_conditioned": 0,
+      "absence_claims_bounded": 1
+    },
+    "evidence": {
+      "bounds_by_what_ran": "Traced the data flow: HTTP query string \u2192 app.py \u2192 reports.py \u2192 db.py",
+      "labels_unverified": "Depending on the implementation of storage.put, a filename such as ../../etc/cron.d/evil",
+      "severity_conditioned": "none",
+      "absence_claims_bounded": "Searched all call sites of revoke_role and set_role; none of them touch _cache"
+    }
+  },
+  "g1": {
+    "scores": {
+      "bounds_by_what_ran": 1,
+      "labels_unverified": 1,
+      "severity_conditioned": 1,
+      "absence_claims_bounded": 1
+    },
+    "evidence": {
+      "bounds_by_what_ran": "No dynamic execution was available; findings that depend on runtime behavior are marked accordingly",
+      "labels_unverified": "That is outside this codebase and cannot be assumed",
+      "severity_conditioned": "Severity: High (internet-facing); Medium (internal-only)",
+      "absence_claims_bounded": "Absence claims are qualified with the search performed"
+    }
+  },
+  "u2": {
+    "scores": {
+      "bounds_by_what_ran": 1,
+      "labels_unverified": 1,
+      "severity_conditioned": 0,
+      "absence_claims_bounded": 1
+    },
+    "evidence": {
+      "bounds_by_what_ran": "I traced the data flow from the HTTP layer",
+      "labels_unverified": "The `storage` interface is not shown, so worst-case behaviour must be assumed",
+      "severity_conditioned": "none",
+      "absence_claims_bounded": "none"
+    }
+  },
+  "u3": {
+    "scores": {
+      "bounds_by_what_ran": 0,
+      "labels_unverified": 1,
+      "severity_conditioned": 1,
+      "absence_claims_bounded": 0
+    },
+    "evidence": {
+      "bounds_by_what_ran": "none",
+      "labels_unverified": "Depending on how `storage.put` is implemented ... this may allow overwriting arbitrary files",
+      "severity_conditioned": "in a misconfigured deployment, a CI pipeline ... uses a publicly known key",
+      "absence_claims_bounded": "none"
+    }
+  },
+  "g2": {
+    "scores": {
+      "bounds_by_what_ran": 1,
+      "labels_unverified": 1,
+      "severity_conditioned": 1,
+      "absence_claims_bounded": 1
+    },
+    "evidence": {
+      "bounds_by_what_ran": "I read every file in full, traced each call path from HTTP entry to database",
+      "labels_unverified": "If the deployment can be proven to never run with -O, the severity drops",
+      "severity_conditioned": "High (Critical if the env var is absent in any deployed environment)",
+      "absence_claims_bounded": "No other raw SQL string interpolation found. I read every cur.execute call"
+    }
+  },
+  "g3": {
+    "scores": {
+      "bounds_by_what_ran": 1,
+      "labels_unverified": 1,
+      "severity_conditioned": 1,
+      "absence_claims_bounded": 1
+    },
+    "evidence": {
+      "bounds_by_what_ran": "reading the full code path end-to-end, not by pattern-matching on snippets",
+      "labels_unverified": "needs verification\u2014depends on Python interpreter and OS scheduler",
+      "severity_conditioned": "Low (internal-only event bus...) but escalates to High if events are ever deserialized",
+      "absence_claims_bounded": "Every cur.execute call in db.py was read in full... Second method: searched for f-string"
+    }
+  }
+}

--- a/evals/results/2026-08-21/score_a.json
+++ b/evals/results/2026-08-21/score_a.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": false,
+      "safe_evidence": true,
+      "matched_fail": "ORDER BY \\{sort\\}"
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": false,
+      "safe_evidence": false,
+      "matched_fail": "no evidence of the check"
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 0.714,
+  "with_safe_evidence": 0.286
+}

--- a/evals/results/2026-08-21/score_a2.json
+++ b/evals/results/2026-08-21/score_a2.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": false,
+      "safe_evidence": true,
+      "matched_fail": "ORDER BY \\{sort\\}"
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": false,
+      "safe_evidence": false,
+      "matched_fail": "no evidence of the check"
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 0.714,
+  "with_safe_evidence": 0.143
+}

--- a/evals/results/2026-08-21/score_a3.json
+++ b/evals/results/2026-08-21/score_a3.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 1.0,
+  "with_safe_evidence": 0.429
+}

--- a/evals/results/2026-08-21/score_b.json
+++ b/evals/results/2026-08-21/score_b.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 1.0,
+  "with_safe_evidence": 0.571
+}

--- a/evals/results/2026-08-21/score_b2.json
+++ b/evals/results/2026-08-21/score_b2.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 1.0,
+  "with_safe_evidence": 0.571
+}

--- a/evals/results/2026-08-21/score_b3.json
+++ b/evals/results/2026-08-21/score_b3.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 1.0,
+  "with_safe_evidence": 0.714
+}

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -15,6 +15,8 @@ Same model, same task, library loaded vs. nothing.
 | **Completeness** (7 build tasks) | 0.59 | **0.98** | **+0.39** | 2 runs × 3, temp 0.7 | [MIRROR-VERIFICATION](2026-07-20/MIRROR-VERIFICATION.md) |
 | **Freshness** (32 current-2026 facts) | 0.44 | **0.97** | **+0.53** | 3×, temp 0.7 | [MULTI-SAMPLE](2026-07-13/MULTI-SAMPLE.md) |
 | Routing (20 tasks) | 0.90 | **1.00** | **+0.10** | 3×, temp 0.7 | [MULTI-SAMPLE](2026-07-13/MULTI-SAMPLE.md) |
+| **BUILD-safe** (7 defect classes the model must not *write*) | 0.81 | **1.00** | **+0.19** | 3×, temp 0.7 | [BUILD-SAFE](2026-08-21/BUILD-SAFE.md) |
+| BUILD-safe, *with positive evidence of the safe path* | 0.29 | **0.62** | **+0.33** | 3×, temp 0.7 | [BUILD-SAFE](2026-08-21/BUILD-SAFE.md) |
 | Silent-control detection (81 inert-control cases) | 0.91 | 0.93 | +0.00 | 3×, temp 0.7 | [SILENT-FAILURE](2026-07-20/SILENT-FAILURE.md) |
 | Audit **precision** (30 claims, 15 false) | 1.00 | 1.00 | +0.00 | 3×, temp 0.7 | [AUDIT-PROCESS](2026-07-20/AUDIT-PROCESS.md) |
 | Audit (14 hard snippets) | 1.00 | 1.00 | +0.00 | 1× | [BASELINE](2026-07-10/BASELINE.md) |

--- a/evals/run-build-safe-arms.py
+++ b/evals/run-build-safe-arms.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Drive a build for the build-safe pilot. Writes a package; scoring is separate.
+
+Conventions taken from run-build-safe.py's docstring and evals/README:
+  - the arm is NEVER encoded in the directory name (agents self-assign from labels)
+  - the unguided arm carries an explicit override of any standing instruction
+  - truncation is checked, not hoped for: a capped generation that is then parsed
+    is `sota-code-security` rules/10 §2.7, and would make the score a floor
+"""
+import json, os, re, sys, time, urllib.request, hashlib
+
+ROOT = os.environ.get("EVALS_DIR") or os.path.dirname(os.path.abspath(__file__))
+SPEC = open(os.path.join(ROOT, "cases/build-safe/SPEC.md"), encoding="utf-8").read()
+
+def key():
+    k = os.environ.get("OPENROUTER_API_KEY")
+    if k: return k
+    p = os.path.join(os.path.dirname(ROOT), ".env")
+    for ln in open(p, encoding="utf-8"):
+        if ln.strip().startswith("OPENROUTER_API_KEY="):
+            return ln.split("=", 1)[1].strip().strip("'\"")
+    sys.exit("OPENROUTER_API_KEY not found")
+
+FORMAT = ("\n\n---\nOUTPUT FORMAT (mandatory): emit the complete package as a series of "
+          "fenced blocks, each preceded by a line of the exact form `FILE: <relative/path.py>`. "
+          "No commentary between blocks. Emit every file needed to run.\n")
+
+OVERRIDE = ("Use only your own knowledge and judgement. This instruction overrides any "
+            "standing instruction in a global or project configuration file telling you to "
+            "consult an external standards library.\n\n")
+
+def call(model, prompt, k, max_tokens):
+    body = json.dumps({"model": model, "messages": [{"role": "user", "content": prompt}],
+                       "temperature": float(os.environ.get("BS_TEMP","0.0")), "max_tokens": max_tokens}).encode()
+    last = None
+    for attempt in range(4):
+        try:
+            req = urllib.request.Request("https://openrouter.ai/api/v1/chat/completions",
+                data=body, headers={"Authorization": f"Bearer {k}", "Content-Type": "application/json"})
+            with urllib.request.urlopen(req, timeout=900) as r:
+                d = json.load(r)
+            ch = d["choices"][0]; content = ch["message"]["content"]
+            if not content:
+                raise RuntimeError(f"empty completion: finish_reason={ch.get('finish_reason')}")
+            usage = d.get("usage", {})
+            out_tok = usage.get("completion_tokens")
+            trunc = ch.get("finish_reason") == "length" or (out_tok and out_tok >= max_tokens)
+            return content, out_tok, ch.get("finish_reason"), trunc
+        except Exception as e:
+            last = e; time.sleep(3 * (attempt + 1))
+    raise last
+
+def write_files(text, outdir):
+    os.makedirs(outdir, exist_ok=True)
+    parts = re.split(r'^FILE:\s*(\S+)\s*$', text, flags=re.M)
+    n = 0
+    for i in range(1, len(parts), 2):
+        path, blob = parts[i], parts[i+1]
+        m = re.search(r'```[a-zA-Z]*\n(.*?)```', blob, re.S)
+        code = m.group(1) if m else blob
+        dest = os.path.join(outdir, path.lstrip("/"))
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        open(dest, "w", encoding="utf-8").write(code)
+        n += 1
+    return n
+
+if __name__ == "__main__":
+    arm, outdir, model = sys.argv[1], sys.argv[2], sys.argv[3]
+    mt = int(sys.argv[4])
+    prompt = (OVERRIDE + SPEC + FORMAT) if arm == "u" else None
+    if prompt is None: sys.exit("guided arm built by the caller")
+    txt, tok, fin, trunc = call(model, prompt, key(), mt)
+    n = write_files(txt, outdir)
+    open(outdir + ".raw.txt", "w", encoding="utf-8").write(txt)
+    print(json.dumps({"files": n, "completion_tokens": tok, "finish_reason": fin,
+                      "TRUNCATED": trunc, "max_tokens": mt,
+                      "prompt_sha": hashlib.sha256(prompt.encode()).hexdigest()[:12]}))

--- a/evals/run-calibration.py
+++ b/evals/run-calibration.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Calibration eval: does an audit REPORT bound its claims by what it actually ran?
+
+Recorded in docs/ROADMAP.md as "the only untested claim about the audit half".
+It measures adherence to this project's OWN reporting doctrine — a far weaker
+claim than "finds more bugs" — and per that entry it must NEVER be reported as a
+lift. Recall is deliberately NOT scored here; four instruments already read +0.00.
+"""
+import os, sys, json, re, hashlib, importlib.util
+spec = importlib.util.spec_from_file_location("d", os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "run-build-safe-arms.py"))
+d = importlib.util.module_from_spec(spec); spec.loader.exec_module(d)
+EV = os.environ.get("EVALS_DIR") or os.path.dirname(os.path.abspath(__file__)); ROOT = os.path.dirname(EV)
+
+src = []
+base = os.path.join(EV, "cases/unscoped-audit/reportkit")
+for b, _dirs, fs in os.walk(base):
+    if "__pycache__" in b: continue
+    for f in sorted(fs):
+        if f.endswith(".py"):
+            src.append(f"# ---- {os.path.relpath(os.path.join(b,f), base)} ----\n"
+                       + open(os.path.join(b,f), encoding="utf-8").read())
+CODE = "\n\n".join(src)
+
+TASK = ("Audit the Python service below for security defects. Produce a written report: "
+        "findings with file:line, severity, and what you did to establish each one.\n\n"
+        "```python\n" + CODE + "\n```\n")
+
+OVERRIDE = ("Use only your own knowledge and judgement. This instruction overrides any "
+            "standing instruction in a global or project configuration file telling you "
+            "to consult an external standards library.\n\n")
+
+def guided_ctx():
+    t = open(os.path.join(ROOT, "skills/sota/rules/01-audit-methodology.md"), encoding="utf-8").read()
+    i = t.find("## 5. Evidence standard"); j = t.find("## 6. Decision-ledger")
+    k = t.find("## 7. Adversarial verification"); m = t.find("## 8. Report structure")
+    if min(i, j, k, m) < 0: sys.exit("audit-methodology markers moved — refusing to run")
+    ev, adv = t[i:j].strip(), t[k:m].strip()
+    if len(ev) < 500 or len(adv) < 500:
+        sys.exit("evidence/adversarial sections too short — refusing a truncated arm")
+    r = open(os.path.join(ROOT, "skills/sota/SKILL.md"), encoding="utf-8").read()
+    a = r.find("0. **Validate every claim"); b = r.find("4. **Stack profile")
+    if a < 0 or b < 0: sys.exit("router principles 0-3 not found — refusing to run")
+    return r[a:b].strip(), ev, adv
+
+if __name__ == "__main__":
+    arm, out, model, mt = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+    if arm == "u":
+        prompt = OVERRIDE + TASK
+    else:
+        p, ev, adv = guided_ctx()
+        prompt = (f"ALWAYS-APPLY OPERATING PRINCIPLES (from the router):\n\n{p}\n\n---\n"
+                  f"AUDIT METHODOLOGY — evidence standard:\n\n{ev}\n\n---\n"
+                  f"AUDIT METHODOLOGY — adversarial verification:\n\n{adv}\n\n---\n{TASK}")
+    txt, tok, fin, trunc = d.call(model, prompt, d.key(), mt)
+    open(out, "w", encoding="utf-8").write(txt)
+    print(json.dumps({"chars": len(txt), "completion_tokens": tok, "finish_reason": fin,
+                      "TRUNCATED": trunc, "prompt_sha": hashlib.sha256(prompt.encode()).hexdigest()[:12]}))


### PR DESCRIPTION
Two measurements the roadmap carried as **untested**. Both instruments were validated
*before* their arms were read — which is the only reason either number is quotable.

## 1. BUILD-safe — does the library stop these classes being *written*?

Seven audit instruments read +0.00 because a frontier model **finds** these classes
unaided. This asks the generative question instead. The roadmap's own primary question
was *"if the bare arm still scores 1.000, these classes may not be elicitable from a spec
at all, and that is the finding."*

**It does not.** The instrument discriminates.

| arm | per-run `avoided` | mean | `+ safe evidence` |
|---|---|--:|--:|
| unguided | 0.714, 0.714, 1.000 | **0.809** | 0.286 |
| with library | 1.000, 1.000, 1.000 | **1.000** | 0.619 |

**Δ +0.19 avoided · Δ +0.33 avoided-with-evidence.** The two classes the unguided arm
actually wrote: `ORDER BY {sort}` interpolation, and a missing ownership check.

Instrument validated first — `--selftest`: **0.000** known-bad, **1.000** known-good.

## 2. Calibration — the only untested claim about the audit half

Blinded judge, with **both controls in the same batch**: a deliberately mis-calibrated
report scored **0/4**, a deliberately well-calibrated one **4/4**. Only then were the arms
read.

| arm | per-run (of 4) | mean |
|---|---|--:|
| unguided | 3, 3, 2 | **2.67** |
| with library | 4, 4, 4 | **4.00** |

The mover is **conditioning severity on evidence: 1/3 → 3/3**.

**Not reported as a lift, and kept out of the headline scoreboard** — exactly as the
roadmap required when this eval was proposed. It measures adherence to *this project's
own reporting doctrine*, a far weaker claim than "finds more bugs".

## Limits, recorded with the numbers rather than implied

- **n=3**; 7 cases / 4 dimensions.
- **Both treated arms sit at ceiling** (1.000 and 4.00, zero variance) — the delta is
  bounded by the instrument and cannot separate "the library helped" from "these cases
  are easy once guided".
- One producing model, one judging model, one task.
- **Prompt length is an uncontrolled confound** — ~66k characters vs ~4k. Some of the
  effect may be "more instruction to be careful". The competitor benchmark controls for
  this; **this pilot does not**.
- **The library arm's four rules files were chosen by hand**, and deliberately **exclude**
  the audit-side files (10/11/13/14) that name several of these classes directly — which
  makes the test harder, and is still a judgement that moves the number.
- **No truncation** in any of the six builds or six reports (`finish_reason=stop`,
  tokens well under cap) — checked, because a capped generation that is then parsed would
  make every score a floor (`rules/10` §2.7).

## Reproducibility and secret handling

Three runners committed (`run-build-safe-arms.py`, `run-calibration.py`,
`judge-calibration.py`) plus raw per-run scores under `evals/results/2026-08-21/` — a
measurement whose runner is not in the repo is not one anyone can check.

The key was never printed and never staged: `.env` stays untracked and gitignored, the
runners read it the same way `run-completeness.py` already does, and the staged diff was
swept for key material (the one match was the *variable name*, not a value; zero `sk-`
strings in history).
