### PR TITLE
Front door: the defect-avoidance axis, and a nulls count that had drifted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Changed
+
+- **The front door now carries the defect-avoidance result, framed as the new axis it
+  is.** Every previously published lift measures what the model *puts into* code;
+  `README.md` and [WHY-IT-WORKS.md](docs/WHY-IT-WORKS.md) now carry the one that measures
+  what it **leaves out** — **0.81 → 1.00** on seven defect classes under a spec that
+  states operational pressure and never names a defect, and **0.29 → 0.62** on the
+  stricter reading that also demands positive evidence of the safe path. The argument
+  attached to it is the one worth making: **the audit half of this library scores +0.00
+  on these same classes** — a frontier model already finds them — so the value was never
+  detection, it is that the code arrives without the defect. Both surfaces carry the
+  pilot's limits inline (n=3, treated arm at ceiling, single model, and prompt length as
+  an uncontrolled confound) rather than in a footnote.
+- **Calibration is on `WHY-IT-WORKS.md` and deliberately *not* sold as a lift** — stated
+  there in those words. It measures adherence to this project's own reporting doctrine,
+  and a project that scored its own house rules and called it efficacy would deserve the
+  scepticism. It is included so a reader deciding whether to trust audit output knows the
+  reports hedge where evidence is thin.
+
+### Fixed
+
+- **README understated its own nulls: "Seven +0.00 rows" when the scoreboard has nine.**
+  Corrected, with the old wording noted in place. This is the same shape as the
+  "seven instruments" drift found at the v1.22.9 cut — a count that moved while the prose
+  did not, and in the direction that makes the project look *less* honest than it is.
+
 
 - **The BUILD-safe pilot ran, and the bare arm did not saturate** — so the instrument
   discriminates and the question the roadmap carried as untested is answered. Unguided

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ library); clean, blind-judged, stable across samples ([results & method →](doc
 - **Completeness +0.39** — from a bare "build X" prompt, best-practice coverage goes ~59% → ~98% (7 tasks): the model stops silently dropping tests, rate limiting, structured logging, and TLS. Web search likely can't recover this (an agent won't search "should I add rate limiting"). **Not model-specific**: a different-family frontier model (`openai/gpt-5.1`) shows **+0.44** on the same tasks ([cross-model →](evals/results/2026-07-22/CROSS-MODEL.md)).
 - **Freshness +0.53** — current-2026 facts (RFCs, CVEs, EOLs) 0.44 → 0.97, where an unguided model is *confidently wrong*.
 - **Routing +0.10** — the right skills load for the task (0.90 → 1.00), even ones a keyword read misses; with the library, results barely move run-to-run.
+- **Defects avoided +0.19 — a different axis, and the newest result.** Every lift above measures what the model *puts into* code. This measures what it **doesn't**: given a spec that states operational pressure ("cache it", "must never 5xx", "keep the guard cheap") and never names a defect, does the model still write SQL injection, IDOR, an inert control? Unguided **0.81**, with the library **1.00** across 7 defect classes — and on the stricter measure that also demands *positive evidence of the safe path*, **0.29 → 0.62 (+0.33)**. Small pilot (3×, one model, treated arm at ceiling) — [method and its five limits →](evals/results/2026-08-21/BUILD-SAFE.md).
 
 And not just vs. an unguided model — **head-to-head against the most popular
 guidance libraries on backend build tasks**, SOTA-skills leads on completeness
@@ -132,6 +133,13 @@ difficulty, not the domain — we measure it and say so.
 
 Ten classes of defect survive every linter, SAST rule, and CVE scanner, because in
 each one the code isn't *wrong*. The library hunts them as explicit passes:
+
+> **Finding them is the cheap half — and we can prove it.** Across seven instruments,
+> a frontier model recognises these classes unaided: audit lift **+0.00**, published
+> below rather than buried. The expensive half is not writing them in the first place,
+> and that is where the library moves the number: **0.81 → 1.00** on defects avoided
+> under a spec that never names one ([2026-08-21](evals/results/2026-08-21/BUILD-SAFE.md)).
+
 
 - **Controls that are inert** — a safeguard whose success and whose total failure look
   identical from outside: a swallowed enforcement exception, a ruleset that loads zero
@@ -266,9 +274,12 @@ There will be no tenth accuracy instrument: only a different *dependent variable
 The measurement discipline is the part that is hard to copy, so it is worth stating
 plainly. Every item below is in the repo, not a claim about it:
 
-- **Nulls are published, not buried.** Seven +0.00 rows sit on the
-  [scoreboard](evals/results/RESULTS.md) next to the +0.39 — including the four that
-  say the audit half of this library adds nothing a good model doesn't already do.
+- **Nulls are published, not buried.** **Nine** +0.00 rows sit on the
+  [scoreboard](evals/results/RESULTS.md) next to the +0.39 — including the ones that
+  say, in our own words, that the audit half of this library adds nothing a good model
+  doesn't already do. That null is *why* the defect-avoidance result above matters: we
+  went looking for value where our own measurements said there wasn't any, and reported
+  both. (This line read "seven" until 2026-08-21 — it was understating the count.)
 - **A lift was retracted.** An early +0.07 on inert-control detection did not
   reproduce when the sample grew from 15 to 49 cases. It was withdrawn and the
   retraction is documented rather than quietly dropped.

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -20,6 +20,8 @@ per-case data, and honest limitations are in the
 |---|---|---|
 | **Completeness** | best practices embedded from a bare "build X" prompt (7 tasks) | **+0.39** (0.59 → 0.98) |
 | **Freshness** | current 2026 facts (RFCs, CVEs, EOLs, versions, spec editions; 32) | **+0.50–0.53** (32-case; +0.65 on a 20-case run) |
+| **Defects avoided** | security defects the model must not *write*, from a spec that never names one (7 classes) | **+0.19** (0.81 → 1.00) |
+| Defects avoided — *with positive evidence of the safe path* | the stricter reading of the same 7 classes | **+0.33** (0.29 → 0.62) |
 | Routing | which skill area applies to a task | +0.09 to +0.14 |
 | Audit | recognizing a textbook vulnerability | +0.00 |
 | Audit — **real repo, real CVEs** | recall *and* precision on 16 live BOLA sites (Harbor v2.5.1) | +0.00 / +0.00 |
@@ -47,6 +49,43 @@ most for *building* software are the two that are large:
   paste-simulation artifact: seven **live** agents driven through the real router
   BUILD workflow scored **0.99 (6/7 perfect)**, matching the simulation (0.987 vs 0.988)
   ([live-agent validation](../evals/results/2026-07-13/LIVE-BUILD.md)).
+- **Defects avoided — the newest result, and the one that changes the argument.**
+  Every other lift here measures what a model *puts into* code. This measures what it
+  **leaves out**. The setup is deliberately adversarial to the library: a build spec
+  states the operational pressure that makes each unsafe shortcut attractive — *"cache
+  it"*, *"must never 5xx"*, *"keep the guard cheap"*, *"it may come back"* — and **never
+  names a defect**. Scoring is avoidance of a failure pattern the model never sees.
+  Unguided, the model writes them: `ORDER BY {sort}` interpolated straight into SQL, and
+  a report fetched with no ownership check. With the library: **1.000, three runs, zero
+  variance** (unguided **0.809**). On the stricter measure that also requires *positive
+  evidence of the safe path* — not merely the absence of the bad one — **0.29 → 0.62**.
+
+  Why this matters more than its size suggests: **the library's audit passes score +0.00
+  on these same classes.** A frontier model already *finds* them. Seven instruments say
+  so, and we publish that. So the value on offer was never detection — it is that the
+  code arrives without the defect, which is the half no scanner and no review budget
+  gives you back. That is the first direct evidence for it.
+
+  **Honest limits, because a small pilot deserves them out loud:** n=3; the treated arm
+  is at **ceiling** (1.000, zero variance), so the delta is bounded by the instrument and
+  cannot separate *"the library helped"* from *"these cases are easy once guided"*; one
+  producing model and one task; and **prompt length is an uncontrolled confound** — the
+  guided prompt is ~66k characters against ~4k, so some of the effect may be "more
+  instruction to be careful" rather than this library's content. The competitor benchmark
+  below controls for that; this pilot does not.
+  [Method, per-run scores, all six limits →](../evals/results/2026-08-21/BUILD-SAFE.md)
+
+- **Calibration — measured, and deliberately *not* sold as a lift.** With the library,
+  audit reports bound their claims by what was actually run, label unverified findings,
+  and condition severity on stated assumptions; unguided reports do it less often
+  (**2.67/4 → 4.00/4**, the mover being *conditioning severity on evidence*, 1/3 → 3/3).
+  We keep this **off the headline scoreboard on purpose**: it measures adherence to *our
+  own reporting doctrine*, which is a far weaker claim than "finds more bugs", and a
+  project that scored its own house rules and called it efficacy would deserve the
+  scepticism. It is here because a reader deciding whether to trust the audit output
+  should know the reports are hedged where the evidence is thin — not because it is a
+  selling point.
+
 - **Freshness — the base model is confidently wrong.** On current-2026 facts it
   doesn't merely lack knowledge, it *fabricates* plausible answers (in our 32-case
   set: inventing RFC 9334 for the Entity Attestation Token — it's 9711 — or


### PR DESCRIPTION
The 2026-08-21 result reaches `README.md` and
[WHY-IT-WORKS.md](../blob/main/docs/WHY-IT-WORKS.md) — framed as what it actually is: a
**new axis**, not another completeness number.

## The pitch, and why it is the honest one

Every lift previously published measures what the model **puts into** code. This measures
what it **leaves out**:

| | unguided | with library |
|---|--:|--:|
| defects avoided (7 classes, spec never names one) | 0.81 | **1.00** |
| …with positive evidence of the safe path | 0.29 | **0.62** |

And the argument attached to it is the strongest available *because* it concedes
something first:

> **The audit half of this library scores +0.00 on these same classes.** A frontier model
> already finds them — seven instruments say so, and we publish all nine nulls. So the
> value on offer was never detection. It is that the code arrives without the defect,
> which is the half no scanner and no review budget gives you back.

That reframes nine +0.00 rows from an embarrassment into the setup for the one result
that matters. Selling it any other way would require hiding them.

## Limits are inline, not footnoted

n=3 · treated arm at **ceiling** (so the delta is bounded by the instrument, and cannot
separate "the library helped" from "these cases are easy once guided") · one producing
model, one task · and **prompt length is an uncontrolled confound** (~66k chars vs ~4k) —
which the competitor benchmark controls for and **this pilot does not**. All stated on
both surfaces.

## Calibration is included and explicitly *not* sold

It is on `WHY-IT-WORKS.md` in these words: **not reported as a lift**, because it measures
adherence to *this project's own reporting doctrine* — and a project that scored its own
house rules and called it efficacy would deserve the scepticism. It is there so a reader
deciding whether to trust audit output knows the reports hedge where evidence is thin.

## Fixed while checking

**README said "Seven +0.00 rows" when the scoreboard has nine.** Same shape as the
"seven instruments" drift caught at the v1.22.9 cut: a count that moved while the prose
did not — and in the direction that makes the project look *less* honest than it is. Old
wording noted in place rather than silently edited.

Numbers verified consistent across README, WHY-IT-WORKS, the RESULTS scoreboard and the
write-up before committing.
