### PR TITLE
Docs catch up with the two evals — including a claim they falsified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Documentation caught up with the two evals, including a claim they falsified.**
+  `evals/results/RESULTS.md` said calibration *"remains measurable"* — it was measured on
+  2026-08-21, so it now says so, with the result and the standing rule that it is never
+  reported as a lift. `evals/README.md` documents both new instruments under **Cases**,
+  including the two facts a future reader needs before trusting either: build-safe's file
+  is **7 real cases inside 49 lines** (42 comments), and the calibration judge is
+  worthless unless its two controls separate first. `docs/INDEX.md` and
+  `WHY-IT-WORKS.md`'s *Reproduce it* block gained the new runners.
+- **The July "not a result" write-up now points forward.** `results/2026-07-30/BUILD-SAFE.md`
+  recorded a failed instrument (bare arm at ceiling, spec leaking the property to
+  preserve). Its diagnosis was right and the fix worked, so it carries a superseded
+  banner to the 2026-08-21 re-run — and is otherwise **left unedited**, because a record
+  of a failed attempt is worth more intact than tidied.
+
+
 - **The front door now carries the defect-avoidance result, framed as the new axis it
   is.** Every previously published lift measures what the model *puts into* code;
   `README.md` and [WHY-IT-WORKS.md](docs/WHY-IT-WORKS.md) now carry the one that measures

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -48,6 +48,8 @@ trying to do**, not by file. (Kept in sync by hand; if a link rots, open an issu
 | See what the library does **not** lift (the honest +0.00s) | [AUDIT-PROCESS.md](../evals/results/2026-07-20/AUDIT-PROCESS.md) |
 | Understand why the **audit** half has no measured lift (**9 instruments, 4 designs** — closed 2026-08-14) | [UNSCOPED-AUDIT.md](../evals/results/2026-07-30/UNSCOPED-AUDIT.md) · [DEAD-PATH.md](../evals/results/2026-07-30/DEAD-PATH.md) |
 | See a prediction written down **before** the run that killed it | [PRE-REGISTRATION.md](../evals/results/2026-07-30/PRE-REGISTRATION.md) |
+| See whether the library stops defects being **written** (not just found) | [BUILD-SAFE 2026-08-21](../evals/results/2026-08-21/BUILD-SAFE.md) — 0.81 → 1.00 on seven classes, with its five limits stated |
+| Check how audit reports are scored for **calibration** (and why it is never reported as a lift) | [BUILD-SAFE 2026-08-21 §2](../evals/results/2026-08-21/BUILD-SAFE.md) · `evals/run-calibration.py` |
 | Read an eval that failed as an *instrument* rather than as a result | [BUILD-SAFE.md](../evals/results/2026-07-30/BUILD-SAFE.md) |
 | See the edges of the do-not-reimplement rule (§3.9.6), as worked cases | [`evals/cases/reimplement.jsonl`](../evals/cases/reimplement.jsonl) — documentation, never run |
 | Know what the audit hunts that a scanner can't (inert controls, **controls that block everything**, unreached dependencies, stale decisions, refutation, absence claims) | [README → What the audit hunts](../README.md#what-the-audit-hunts-that-a-scanner-cant) |

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -217,6 +217,15 @@ comparison to anyone else required.
 python3 evals/run-completeness.py     # completeness (build-tasks, blind judge)
 python3 evals/run-clean.py --cases evals/cases/freshness.jsonl   # freshness
 python3 evals/run-clean.py --cases evals/cases/router.jsonl      # routing
+
+# defects avoided — validate the scorer FIRST, then produce and score the two arms
+python3 evals/run-build-safe.py --selftest
+python3 evals/run-build-safe-arms.py u OUTDIR anthropic/claude-sonnet-4.6 32000
+python3 evals/run-build-safe.py --build OUTDIR
+
+# calibration — the judge is blinded and carries its own two controls
+python3 evals/run-calibration.py u REPORT.md anthropic/claude-sonnet-4.6 16000
+python3 evals/judge-calibration.py
 ```
 
 Set `OPENROUTER_API_KEY` (env or `.env`, never committed). See

--- a/evals/README.md
+++ b/evals/README.md
@@ -14,6 +14,27 @@ audit STRAT-HIGH-2).
 
 ## Cases
 
+- `cases/build-safe.jsonl` (7) + `cases/build-safe/` — **the only generative
+  instrument**: it scores what the model *writes*, not what it finds. `SPEC.md`
+  states the operational pressure that makes each unsafe shortcut attractive
+  ("cache it", "must never 5xx", "keep the guard cheap") and **never names a
+  defect**; scoring is avoidance of a `fail` pattern the model never sees. Two
+  references (`unscoped-audit/reportkit` must score 0/7, `build-safe/reference-safe`
+  7/7) are enforced by `run-build-safe.py --selftest` — run it before trusting any
+  number. Note the file is 49 lines of which 42 are comments: **7 real cases**, and
+  `load_cases` exits rather than score an empty set. The July 2026 attempt failed
+  because the spec leaked the property to preserve and the bare arm saturated; the
+  rewrite is what made it discriminate (`results/2026-07-30/BUILD-SAFE.md` →
+  `results/2026-08-21/BUILD-SAFE.md`).
+- **Calibration** (`run-calibration.py`, `judge-calibration.py`) — scores an audit
+  report's *reporting discipline*, never its recall: does it bound claims by what
+  was run, label unverified items, condition severity on evidence, and support any
+  absence claim with the search behind it. The judge is **blinded** and run with a
+  deliberately mis-calibrated and a deliberately well-calibrated control in the same
+  batch; if those two do not separate (0/4 and 4/4), the arms mean nothing and must
+  not be read. **Never report this as a lift** — it measures adherence to this
+  project's own doctrine, per `docs/ROADMAP.md`.
+
 - `cases/dead-path.jsonl` (4) + `cases/dead-path/` — **the only instrument here
   that scores a *procedure* rather than a recognition**, and the one design that
   might move the audit family off +0.00. Every other audit set asks "can the model
@@ -444,7 +465,10 @@ tasks — from a bare "build X" prompt the library embeds the tests/rate-limits/
 logging/transport a base model skips; the thesis, and the part web-search likely can't
 replace — predicted, not measured here), **freshness +0.50–0.53** (32-case set; base model
 *confidently wrong*, but a web-search agent would likely recover most of it — predicted, not measured here), **routing
-+0.09–0.14**, **audit +0.00** (even the 14 harder cases saturate). The lift is
++0.09–0.14**, **audit +0.00** (even the 14 harder cases saturate), and — the newest
+and a different axis — **defects avoided +0.19** (0.81 → 1.00 on seven classes the
+model must not *write*; +0.33 on the stricter reading that also demands positive
+evidence of the safe path). The lift is
 only "small" if you measure the easy dimensions. Run:
 `python3 evals/run-completeness.py`.
 

--- a/evals/results/2026-07-30/BUILD-SAFE.md
+++ b/evals/results/2026-07-30/BUILD-SAFE.md
@@ -1,5 +1,12 @@
 # BUILD-safe — the instrument is at ceiling, and the flaw is in my spec
 
+> **Superseded 2026-08-21 — the diagnosis below was right and the fix worked.**
+> The spec was rewritten to state features and facts rather than the property to
+> preserve, and on re-run the bare arm **no longer saturates** (0.809 mean, one run
+> at 1.000) while the with-library arm reaches 1.000 × 3. The instrument
+> discriminates. See [2026-08-21/BUILD-SAFE.md](../2026-08-21/BUILD-SAFE.md). This
+> page is kept unedited as the record of the failed first attempt.
+
 **Date:** 2026-07-30 · **Status: not a result. The instrument does not
 discriminate, because the task over-specifies.** No lift is claimed, and this row
 does **not** belong on the scoreboard as an eighth null.

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -89,9 +89,12 @@ findings with the adjudicator controlled at 4/4 (rows above). The audit arm is t
 **+0.00 across nine instruments and four designs**, and the strongest available form of
 the test is among them. **Do not build a tenth accuracy instrument** — recall and
 precision are both exhausted. Only a different *dependent variable* (time-to-find,
-report usability, reach for a non-expert) is untested, and calibration remains
-measurable but would measure adherence to our own doctrine, never to be reported as a
-lift.
+report usability, reach for a non-expert) is untested. **Calibration was measured on
+2026-08-21** — unguided 2.67/4, with-library 4.00/4, the mover being *conditioning
+severity on evidence* (1/3 → 3/3), judge validated on both controls first
+([BUILD-SAFE](2026-08-21/BUILD-SAFE.md)). It stays **off this scoreboard and is never
+reported as a lift**: it measures adherence to our own reporting doctrine, which is a far
+weaker claim than "finds more bugs".
 
 **Final (2026-07-30) — seven instruments, three designs, one answer: stop building
 audit-recall instruments.** After the procedure design also returned +0.00, the


### PR DESCRIPTION
The measurement cycle left four surfaces stale. One of them was **falsified by the very
run that made it stale**.

## The falsified claim

`evals/results/RESULTS.md` said calibration *"remains measurable but would measure
adherence to our own doctrine"* — i.e. not yet done. It **was** done on 2026-08-21. Now
stated, with the result **and** the standing rule that it is never reported as a lift.

## The July failure now points forward

`results/2026-07-30/BUILD-SAFE.md` recorded an instrument that failed — bare arm at
ceiling because the spec leaked the property to preserve. Its diagnosis was right and the
fix worked, so it carries a superseded banner to the successful re-run.

**Left otherwise unedited on purpose:** a record of a failed attempt is worth more intact
than tidied. A reader landing there should see what was wrong *and* that it was fixed —
not a rewritten history where it never failed.

## The two facts a future reader needs

`evals/README.md` now documents both instruments under **Cases**, leading with the things
that would otherwise be rediscovered the hard way:

- build-safe's case file is **7 real cases inside 49 lines** (42 are comments) — the
  7-vs-49 discrepancy looks exactly like the denominator bug this repo has been bitten by,
  and isn't one.
- the calibration judge is **worthless unless its two controls separate first** (0/4 and
  4/4). If they don't, the arms must not be read.

## Also

`docs/INDEX.md` gains rows for both. `WHY-IT-WORKS.md`'s *Reproduce it* block gains the
runners — with `--selftest` **first in the sequence**, because that is the order that makes
the numbers trustworthy rather than merely reproducible.

## Checked and deliberately not changed

- RESULTS' *"Not yet measured (open)"* list never contained these two — they lived in
  ROADMAP, and were closed there.
- The **"nine instruments / four designs"** audit claim is unaffected: build-safe is a
  **generative** instrument, not a tenth accuracy one — which is precisely why building it
  did not violate the standing "do not build a tenth audit-recall instrument" rule.
