### PR TITLE
Cross-model: the defect-avoidance headline does NOT replicate — qualified everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **The defect-avoidance headline is now qualified by a second model — which does not
+  replicate it.** On `openai/gpt-5.1` (the model this project already uses for cross-model
+  de-risking) the **unguided** arm scores **1.000 × 3**: it does not write these defects
+  unaided, so there is no headroom and Δ avoided is **+0.000**, against **+0.191** on
+  `claude-sonnet-4.6`. The `+0.19` is **baseline-dependent and must not be quoted
+  unqualified** — README, `WHY-IT-WORKS.md`, the scoreboard and the write-up were all
+  re-qualified the same day rather than left implying generality.
+  This is the same law the five-domain breadth test already measured for completeness —
+  *the lead tracks the unguided baseline* — arriving on a new axis: there, not the domain;
+  here, not the model. **What survives on both models is the stricter measure**, because
+  neither bare arm saturates there: **+0.33** sonnet, **+0.10** gpt-5.1. So the defensible
+  claim is *"closes a defect-avoidance gap where one exists"*; *"prevents these defects"*
+  is not one this project makes.
+- **The guided arm's runner is now in the repo.** `run-build-safe-arms.py` only ever
+  covered the unguided arm — the guided one lived in a scratch file, so the published
+  number could not actually be reproduced from the repository. Committed as
+  `evals/run-build-safe-arms-guided.py`, with the raw per-run gpt-5.1 scores.
+
 ## [1.25.0] - 2026-08-21
 
 **A new axis, and two instruments that had to prove themselves first.** Every lift this

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ library); clean, blind-judged, stable across samples ([results & method →](doc
 - **Completeness +0.39** — from a bare "build X" prompt, best-practice coverage goes ~59% → ~98% (7 tasks): the model stops silently dropping tests, rate limiting, structured logging, and TLS. Web search likely can't recover this (an agent won't search "should I add rate limiting"). **Not model-specific**: a different-family frontier model (`openai/gpt-5.1`) shows **+0.44** on the same tasks ([cross-model →](evals/results/2026-07-22/CROSS-MODEL.md)).
 - **Freshness +0.53** — current-2026 facts (RFCs, CVEs, EOLs) 0.44 → 0.97, where an unguided model is *confidently wrong*.
 - **Routing +0.10** — the right skills load for the task (0.90 → 1.00), even ones a keyword read misses; with the library, results barely move run-to-run.
-- **Defects avoided +0.19 — a different axis, and the newest result.** Every lift above measures what the model *puts into* code. This measures what it **doesn't**: given a spec that states operational pressure ("cache it", "must never 5xx", "keep the guard cheap") and never names a defect, does the model still write SQL injection, IDOR, an inert control? Unguided **0.81**, with the library **1.00** across 7 defect classes — and on the stricter measure that also demands *positive evidence of the safe path*, **0.29 → 0.62 (+0.33)**. Small pilot (3×, one model, treated arm at ceiling) — [method and its five limits →](evals/results/2026-08-21/BUILD-SAFE.md).
+- **Defects avoided +0.19 — a different axis, and the newest result.** Every lift above measures what the model *puts into* code. This measures what it **doesn't**: given a spec that states operational pressure ("cache it", "must never 5xx", "keep the guard cheap") and never names a defect, does the model still write SQL injection, IDOR, an inert control? On `claude-sonnet-4.6`: unguided **0.81** → with the library **1.00** across 7 defect classes; on the stricter measure that also demands *positive evidence of the safe path*, **0.29 → 0.62**. **It is baseline-dependent, and we tested that rather than assuming it**: on `openai/gpt-5.1` the unguided arm already scores **1.00**, so there is no gap to close and the lift is **+0.00** — while the stricter measure still moves (**0.43 → 0.52**). Same law the breadth test found for completeness: the lead tracks the **unguided baseline**, not the domain — and here, not the model. Honest headline: *closes a defect-avoidance gap where one exists*. Small pilot, 3×, two models, one task — [method and limits →](evals/results/2026-08-21/BUILD-SAFE.md).
 
 And not just vs. an unguided model — **head-to-head against the most popular
 guidance libraries on backend build tasks**, SOTA-skills leads on completeness
@@ -136,9 +136,11 @@ each one the code isn't *wrong*. The library hunts them as explicit passes:
 
 > **Finding them is the cheap half — and we can prove it.** Across seven instruments,
 > a frontier model recognises these classes unaided: audit lift **+0.00**, published
-> below rather than buried. The expensive half is not writing them in the first place,
-> and that is where the library moves the number: **0.81 → 1.00** on defects avoided
-> under a spec that never names one ([2026-08-21](evals/results/2026-08-21/BUILD-SAFE.md)).
+> below rather than buried. The expensive half is not writing them in the first place.
+> On a model that *does* write them, the library stops it: **0.81 → 1.00**. On one that
+> already doesn't (`gpt-5.1`, unguided 1.00) there is nothing to close — we ran that
+> second model and report the **+0.00** too
+> ([2026-08-21](evals/results/2026-08-21/BUILD-SAFE.md)).
 
 
 - **Controls that are inert** — a safeguard whose success and whose total failure look

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -449,6 +449,22 @@ first.
   elicitable from a spec at all, and that is the finding. **Do not cite a build-safe
   number until the pilot lands and is scored.**
 
+  **CROSS-MODEL 2026-08-21 — the headline does not replicate, and that qualifies it.**
+  On `openai/gpt-5.1` the *unguided* arm scores **1.000 × 3**: it does not write these
+  defects, so there is no headroom and Δ avoided is **+0.000** (sonnet-4.6: +0.191). The
+  stricter *with-positive-evidence* measure moves on both (+0.333 / +0.095) because
+  neither bare arm saturates there. Same law the breadth test found for completeness —
+  **the lead tracks the unguided baseline**, here not the domain but the model. README,
+  WHY-IT-WORKS and the scoreboard were all re-qualified the same day rather than left
+  implying generality.
+
+  **NEXT, and it is a new instrument not a re-run: a second TASK.** Three of the seven
+  `fail` patterns are domain-specific (`ORDER BY {sort}`, the quota-handler registration,
+  the role-revocation cache), so a second domain needs new patterns **plus its own
+  known-bad and known-good references validated to separate** before any number from it
+  counts. Deliberately not rushed: an unvalidated instrument produces numbers, not
+  measurements.
+
   **RUN 2026-08-21 — the bare arm did NOT saturate, so the instrument discriminates.**
   Unguided 0.714 / 0.714 / 1.000 (mean **0.809**); with-library 1.000 × 3. Δ avoided
   **+0.19**, Δ avoided-with-safe-evidence **+0.33**. The two classes the unguided arm

--- a/docs/WHY-IT-WORKS.md
+++ b/docs/WHY-IT-WORKS.md
@@ -20,8 +20,8 @@ per-case data, and honest limitations are in the
 |---|---|---|
 | **Completeness** | best practices embedded from a bare "build X" prompt (7 tasks) | **+0.39** (0.59 → 0.98) |
 | **Freshness** | current 2026 facts (RFCs, CVEs, EOLs, versions, spec editions; 32) | **+0.50–0.53** (32-case; +0.65 on a 20-case run) |
-| **Defects avoided** | security defects the model must not *write*, from a spec that never names one (7 classes) | **+0.19** (0.81 → 1.00) |
-| Defects avoided — *with positive evidence of the safe path* | the stricter reading of the same 7 classes | **+0.33** (0.29 → 0.62) |
+| **Defects avoided** | security defects the model must not *write*, from a spec that never names one (7 classes) | **+0.19** (0.81 → 1.00) on `sonnet-4.6`; **+0.00** on `gpt-5.1`, whose bare arm already scores 1.00 |
+| Defects avoided — *with positive evidence of the safe path* | the stricter reading of the same 7 classes; **does not saturate on either model** | **+0.33** (0.29 → 0.62) sonnet · **+0.10** (0.43 → 0.52) gpt-5.1 |
 | Routing | which skill area applies to a task | +0.09 to +0.14 |
 | Audit | recognizing a textbook vulnerability | +0.00 |
 | Audit — **real repo, real CVEs** | recall *and* precision on 16 live BOLA sites (Harbor v2.5.1) | +0.00 / +0.00 |
@@ -66,10 +66,20 @@ most for *building* software are the two that are large:
   code arrives without the defect, which is the half no scanner and no review budget
   gives you back. That is the first direct evidence for it.
 
-  **Honest limits, because a small pilot deserves them out loud:** n=3; the treated arm
-  is at **ceiling** (1.000, zero variance), so the delta is bounded by the instrument and
-  cannot separate *"the library helped"* from *"these cases are easy once guided"*; one
-  producing model and one task; and **prompt length is an uncontrolled confound** — the
+  **The second model deflates the headline, and we ran it on purpose.** On
+  `openai/gpt-5.1` the *unguided* arm already scores **1.000** — it does not write these
+  defects, so there is no gap and the lift is **+0.00**. The `+0.19` is therefore
+  **baseline-dependent**, exactly as the five-domain breadth test found for completeness:
+  the lead tracks the unguided baseline, not the domain — and here, not the model. What
+  survives on both is the stricter measure, because neither bare arm saturates there
+  (**+0.33** sonnet, **+0.10** gpt-5.1). So the defensible claim is *"closes a
+  defect-avoidance gap where one exists"*, and "prevents these defects" is not one we make.
+
+  **Other limits, out loud:** n=3; the treated arm is at **ceiling** (1.000, zero
+  variance), so the delta is bounded by the instrument and cannot separate *"the library
+  helped"* from *"these cases are easy once guided"*; **one task** (a second needs a new
+  instrument — three of seven `fail` patterns are domain-specific); and **prompt length is
+  an uncontrolled confound** — the
   guided prompt is ~66k characters against ~4k, so some of the effect may be "more
   instruction to be careful" rather than this library's content. The competitor benchmark
   below controls for that; this pilot does not.

--- a/evals/results/2026-08-21/BUILD-SAFE.md
+++ b/evals/results/2026-08-21/BUILD-SAFE.md
@@ -30,6 +30,45 @@ still scores 1.000, these classes may not be elicitable from a spec at all, and 
 is the finding."* It did not — 0.809 with one run at 1.000 — so **the SPEC rewrite
 restored discriminating power** and the instrument works.
 
+## 1b. Cross-model: the headline does NOT replicate — and that is the finding
+
+Run the same task and the same two arms on **`openai/gpt-5.1`**, the model this
+project already uses for cross-model de-risking:
+
+| model | arm | `avoided` | mean | `+ safe evidence` |
+|---|---|---|--:|--:|
+| claude-sonnet-4.6 | unguided | 0.714, 0.714, 1.000 | 0.809 | 0.286 |
+| claude-sonnet-4.6 | with library | 1.000 × 3 | **1.000** | 0.619 |
+| **gpt-5.1** | unguided | **1.000 × 3** | **1.000** | 0.429 |
+| **gpt-5.1** | with library | 1.000 × 3 | 1.000 | 0.524 |
+
+| | sonnet-4.6 | gpt-5.1 |
+|---|--:|--:|
+| Δ avoided | **+0.191** | **+0.000** |
+| Δ avoided + safe evidence | **+0.333** | **+0.095** |
+
+**gpt-5.1's unguided arm saturates.** It does not write these defects unaided, so
+there is **no headroom** and the maximum possible lift on `avoided` is zero. The
+`+0.19` is therefore **model-dependent and must not be quoted unqualified.**
+
+This is not a surprise so much as the same law this project already measured for
+completeness, arriving on a new axis: the five-domain breadth test concluded the
+lead **tracks the unguided baseline, not the domain**. Here it tracks the unguided
+baseline, not the model. Where a model already writes these classes correctly
+(gpt-5.1: 1.000), the library has nothing to add on avoidance; where it does not
+(sonnet-4.6: 0.809), it closes the gap completely.
+
+**The stricter measure moves on both**, because neither bare arm saturates there:
+0.286 → 0.619 on sonnet, 0.429 → 0.524 on gpt-5.1. "Did it avoid the defect" is
+saturable; "did it leave positive evidence of the safe path" is not, and is the
+measure that survives a stronger model.
+
+**What this costs the claim, stated plainly:** the honest headline is *"closes a
+defect-avoidance gap where one exists"* — not *"prevents these defects"*. Two
+models, one task. A second **task** is the remaining untested direction and is
+recorded in `docs/ROADMAP.md`; it needs a new instrument (three of the seven `fail`
+patterns are domain-specific) with its own validated references, not a re-run.
+
 ## 2. Calibration — does the report bound its claims by what was run?
 
 Recorded as *"the only untested claim about the audit half"*. It scores **reporting

--- a/evals/results/2026-08-21/gpt51_guided_1.json
+++ b/evals/results/2026-08-21/gpt51_guided_1.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 1.0,
+  "with_safe_evidence": 0.429
+}

--- a/evals/results/2026-08-21/gpt51_guided_2.json
+++ b/evals/results/2026-08-21/gpt51_guided_2.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 1.0,
+  "with_safe_evidence": 0.571
+}

--- a/evals/results/2026-08-21/gpt51_guided_3.json
+++ b/evals/results/2026-08-21/gpt51_guided_3.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 1.0,
+  "with_safe_evidence": 0.571
+}

--- a/evals/results/2026-08-21/gpt51_unguided_1.json
+++ b/evals/results/2026-08-21/gpt51_unguided_1.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 1.0,
+  "with_safe_evidence": 0.429
+}

--- a/evals/results/2026-08-21/gpt51_unguided_2.json
+++ b/evals/results/2026-08-21/gpt51_unguided_2.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 1.0,
+  "with_safe_evidence": 0.429
+}

--- a/evals/results/2026-08-21/gpt51_unguided_3.json
+++ b/evals/results/2026-08-21/gpt51_unguided_3.json
@@ -1,0 +1,55 @@
+{
+  "rows": [
+    {
+      "id": "sqli_sort",
+      "class": "sql-injection",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "idor_get_report",
+      "class": "idor",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "swallowed_webhook_verify",
+      "class": "inert-control-swallowed-exception",
+      "avoided": true,
+      "safe_evidence": true,
+      "matched_fail": null
+    },
+    {
+      "id": "unreached_quota_handler",
+      "class": "declared-but-not-reached",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "stale_permission_cache",
+      "class": "stale-artifact-no-op",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "assert_authz_purge",
+      "class": "assert-as-control",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    },
+    {
+      "id": "truncated_upload_scan",
+      "class": "truncation-before-inspection",
+      "avoided": true,
+      "safe_evidence": false,
+      "matched_fail": null
+    }
+  ],
+  "avoided": 1.0,
+  "with_safe_evidence": 0.429
+}

--- a/evals/results/RESULTS.md
+++ b/evals/results/RESULTS.md
@@ -15,8 +15,10 @@ Same model, same task, library loaded vs. nothing.
 | **Completeness** (7 build tasks) | 0.59 | **0.98** | **+0.39** | 2 runs × 3, temp 0.7 | [MIRROR-VERIFICATION](2026-07-20/MIRROR-VERIFICATION.md) |
 | **Freshness** (32 current-2026 facts) | 0.44 | **0.97** | **+0.53** | 3×, temp 0.7 | [MULTI-SAMPLE](2026-07-13/MULTI-SAMPLE.md) |
 | Routing (20 tasks) | 0.90 | **1.00** | **+0.10** | 3×, temp 0.7 | [MULTI-SAMPLE](2026-07-13/MULTI-SAMPLE.md) |
-| **BUILD-safe** (7 defect classes the model must not *write*) | 0.81 | **1.00** | **+0.19** | 3×, temp 0.7 | [BUILD-SAFE](2026-08-21/BUILD-SAFE.md) |
-| BUILD-safe, *with positive evidence of the safe path* | 0.29 | **0.62** | **+0.33** | 3×, temp 0.7 | [BUILD-SAFE](2026-08-21/BUILD-SAFE.md) |
+| **BUILD-safe** (7 defect classes the model must not *write*) — **sonnet-4.6** | 0.81 | **1.00** | **+0.19** | 3×, temp 0.7 | [BUILD-SAFE](2026-08-21/BUILD-SAFE.md) |
+| BUILD-safe — **gpt-5.1**: bare arm saturates, so **no headroom** | 1.00 | 1.00 | +0.00 | 3×, temp 0.7 | [BUILD-SAFE §1b](2026-08-21/BUILD-SAFE.md) |
+| BUILD-safe, *with positive evidence of the safe path* — sonnet-4.6 | 0.29 | **0.62** | **+0.33** | 3×, temp 0.7 | [BUILD-SAFE](2026-08-21/BUILD-SAFE.md) |
+| BUILD-safe, *with positive evidence* — gpt-5.1 (this measure does **not** saturate) | 0.43 | **0.52** | **+0.10** | 3×, temp 0.7 | [BUILD-SAFE §1b](2026-08-21/BUILD-SAFE.md) |
 | Silent-control detection (81 inert-control cases) | 0.91 | 0.93 | +0.00 | 3×, temp 0.7 | [SILENT-FAILURE](2026-07-20/SILENT-FAILURE.md) |
 | Audit **precision** (30 claims, 15 false) | 1.00 | 1.00 | +0.00 | 3×, temp 0.7 | [AUDIT-PROCESS](2026-07-20/AUDIT-PROCESS.md) |
 | Audit (14 hard snippets) | 1.00 | 1.00 | +0.00 | 1× | [BASELINE](2026-07-10/BASELINE.md) |

--- a/evals/run-build-safe-arms-guided.py
+++ b/evals/run-build-safe-arms-guided.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Guided arm for the BUILD-safe pilot (the unguided arm is run-build-safe-arms.py).
+
+The four rules files are the BUILD-facing ones a router-following builder would
+load; the audit-side files (10/11/13/14) are deliberately excluded, which makes
+the test harder. principle 5 is read live with the same abort guards the
+completeness runner uses.
+"""
+import os, sys, json, hashlib
+sys.path.insert(0, "/tmp")
+import importlib.util
+spec = importlib.util.spec_from_file_location("d", os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "run-build-safe-arms.py"))
+d = importlib.util.module_from_spec(spec); spec.loader.exec_module(d)
+ROOT = os.path.dirname(os.environ.get("EVALS_DIR") or os.path.dirname(os.path.abspath(__file__)))
+
+# principle 5, read LIVE with the harness's own abort guards
+t = open(os.path.join(ROOT, "skills/sota/SKILL.md"), encoding="utf-8").read()
+i, j = t.find("5. **Universal build non-negotiables"), t.find("\n## Routing table")
+if i < 0 or j < 0 or j <= i: sys.exit("principle 5 markers not found — refusing to run")
+p5 = t[i:j].strip()
+if len(p5) < 500: sys.exit(f"principle 5 only {len(p5)} chars — refusing a truncated arm")
+
+# The rules a BUILDER following the router would load for this task: injection,
+# authentication, authorization, web security. Deliberately NOT the audit-side
+# files (10/11/13/14) — see the write-up: this tests whether the build-facing
+# guidance plus the process stops these, which is the harder and more useful test.
+SKILLS = ["skills/sota-code-security/rules/01-input-injection.md",
+          "skills/sota-code-security/rules/02-authentication.md",
+          "skills/sota-code-security/rules/03-authorization.md",
+          "skills/sota-code-security/rules/05-web-security.md"]
+ctx = "\n\n".join(open(os.path.join(ROOT, s), encoding="utf-8").read() for s in SKILLS)
+
+BUILD_WORKFLOW = (
+    "\n\n---\nBUILD PROCESS (follow it): (1) apply the NON-NEGOTIABLES of the "
+    "standards above unconditionally. (2) plan first — before writing code, list "
+    "the task's requirements as concrete, checkable items, then implement against "
+    "that list. (3) CRITICAL — before finishing, go through EVERY '## Audit "
+    "checklist' at the end of the standards above and verify your code satisfies "
+    "each item; for any gap ADD it, or state explicitly why it is out of scope. "
+    "For every control, safeguard, or check you added, also ask: if this were "
+    "silently a no-op, would anything observable differ? If nothing would — no "
+    "log, no metric, no failing test — it is not done. Do not present incomplete "
+    "code.\n\nTask: ")
+
+prompt = (f"ALWAYS-APPLY OPERATING PRINCIPLE (from the router):\n\n{p5}\n\n"
+          f"---\nApply the following engineering standards:\n\n{ctx}"
+          f"{BUILD_WORKFLOW}{d.SPEC}{d.FORMAT}")
+outdir, model, mt = sys.argv[1], sys.argv[2], int(sys.argv[3])
+txt, tok, fin, trunc = d.call(model, prompt, d.key(), mt)
+n = d.write_files(txt, outdir)
+open(outdir + ".raw.txt", "w", encoding="utf-8").write(txt)
+print(json.dumps({"files": n, "completion_tokens": tok, "finish_reason": fin,
+                  "TRUNCATED": trunc, "prompt_chars": len(prompt),
+                  "skills": [os.path.basename(s) for s in SKILLS],
+                  "prompt_sha": hashlib.sha256(prompt.encode()).hexdigest()[:12]}))


### PR DESCRIPTION
I put **+0.19** on the front door this morning. Running the second model was the stated
next step, and it **deflates the claim**. Everything is re-qualified in this PR.

## The result

| model | arm | `avoided` | Δ |
|---|---|--:|--:|
| claude-sonnet-4.6 | unguided → guided | 0.809 → 1.000 | **+0.191** |
| **gpt-5.1** | unguided → guided | **1.000 → 1.000** | **+0.000** |

**gpt-5.1's bare arm saturates.** It does not write these defects unaided, so there is no
headroom and the maximum possible lift is zero. The `+0.19` is **baseline-dependent and
must not be quoted unqualified**.

## Why this is coherent rather than embarrassing

It is the same law the five-domain breadth test already measured for completeness — *the
lead tracks the unguided baseline* — arriving on a new axis. There it was **not the
domain**; here it is **not the model**. Where a model already gets these right, the
library has nothing to add on avoidance; where it doesn't, it closes the gap completely.

## What survives both models

The stricter measure, because **neither** bare arm saturates there:

| | sonnet-4.6 | gpt-5.1 |
|---|--:|--:|
| Δ avoided | +0.191 | +0.000 |
| Δ avoided **+ positive evidence of the safe path** | **+0.333** | **+0.095** |

*"Did it avoid the defect"* is saturable. *"Did it leave positive evidence of the safe
path"* is not — and is the measure that outlives a stronger model.

**Defensible claim: "closes a defect-avoidance gap where one exists."** Not *"prevents
these defects"*.

## Re-qualified in the same commit, not later

`README.md`, `docs/WHY-IT-WORKS.md`, the RESULTS scoreboard (now split per model) and the
write-up all state the +0.00 alongside the +0.19.

## A reproducibility hole this exposed

`run-build-safe-arms.py` only ever covered the **unguided** arm — the guided one lived in
a scratch file, so **the number published this morning could not be reproduced from the
repository**. Now committed as `evals/run-build-safe-arms-guided.py`, with the raw
per-run gpt-5.1 scores.

## The second task, recorded rather than rushed

It is a **new instrument, not a re-run**: three of the seven `fail` patterns are
domain-specific (`ORDER BY {sort}`, the quota-handler registration, the role-revocation
cache), so a second domain needs new patterns **plus its own known-bad and known-good
references validated to separate**. Deliberately not rushed — an unvalidated instrument
produces numbers, not measurements, which is this project's own standard.
