### PR TITLE
The pipe hazard generalises: any filter chosen before you know the output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The pipeline rule generalises: the hazard is not `tail`, it is any filter chosen
+  before you know what the output contains** (`sota-shell-scripting/rules/01` §3). A
+  reported fourth case: `tool compare … | grep -E "baseline|current|LOST|GAINED"` silently
+  discarded `!! GRAPH CHANGED: 245827 -> 245808 …` — a guard that had **fired** — and the
+  conclusion forming from what survived was that the guard was *inert*, i.e. a defect
+  report about working code. **`grep` is the more dangerous form precisely because it
+  reads as selective rather than lossy**: the line you did not think to match is the one
+  worth reading. `head`, `tail`, `grep`, `awk`, `cut` and `jq` all destroy output
+  selectively, so the remedy is stated as the general one — **redirect first, filter the
+  file afterwards**, because a saved file can be re-grepped once the first pattern proves
+  wrong and a consumed pipe cannot. Second checklist item added.
+
+
 - **The defect-avoidance headline is now qualified by a second model — which does not
   replicate it.** On `openai/gpt-5.1` (the model this project already uses for cross-model
   de-risking) the **unguided** arm scores **1.000 × 3**: it does not write these defects

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -1288,5 +1288,16 @@ is the brief's failure mode 1 in miniature, committed while adopting the rule ag
 sampling a file is fine. The rule applies where output is **evidence for a claim**, and
 the tell is whether recovering it would mean re-running the job.
 
+**A fourth case, added by the reporter after the rule shipped (2026-08-21).** A `grep`
+filter hid a guard that had *fired*: `tool compare … | grep -E "baseline|current|LOST|GAINED"`
+discarded the line `!! GRAPH CHANGED: 245827 -> 245808 REACHING_DEF edges`, and the
+conclusion forming from what survived was that the guard was inert — a defect report about
+working code. This **generalises the rule** rather than adding an instance: the hazard is
+not `tail`, it is that **a filter written before you know what the output contains is a
+filter chosen to exclude the surprise**. `grep` is the more dangerous form precisely
+because it reads as *selective* rather than *lossy*. Folded into `rules/01` §3 with a
+second checklist item; the remedy is unchanged and now stated as the general one —
+**redirect first, filter the file afterwards**.
+
 **Measurement status:** adopted on reasoning, a verified reproduction, and first-hand
 recurrence. **No efficacy lift is claimed or measured.**

--- a/skills/sota-shell-scripting/rules/01-safety-baseline.md
+++ b/skills/sota-shell-scripting/rules/01-safety-baseline.md
@@ -156,6 +156,21 @@ Two corollaries:
   `print(..., flush=True)` (or `-u`): a process killed by `timeout` otherwise leaves a
   file that is empty for a reason unrelated to the result.
 
+**And it is not only `tail` — a `grep` filter is worse, because it looks selective rather
+than lossy.** Reported case: a comparison tool was run as
+`tool compare … | grep -E "baseline|current|LOST|GAINED"`. The tool had correctly detected
+that its input changed between the two runs and printed
+`!! GRAPH CHANGED: 245827 -> 245808 REACHING_DEF edges`. That line matched none of the
+four alternatives, so it was discarded — and the conclusion being formed from what
+survived was that the guard was **inert**, i.e. a defect report about working code.
+
+The general form: **a filter written before you know what the output contains is a filter
+chosen to exclude the surprise.** `head`, `tail`, `grep`, `awk`, `cut` and `jq` all
+destroy output selectively, and the thing you did not think to match is exactly the thing
+worth reading. So **redirect first, filter the file afterwards** — a saved file can be
+re-grepped with a better pattern once the first one proves wrong; a consumed pipe cannot,
+and the second pattern costs a full re-run.
+
 **Scope, deliberately narrow:** this is not "never use `tail`". Piping to `tail` to watch
 a log, sample a file or check a shape is fine and idiomatic. The rule applies where the
 output is **evidence for a claim**, and the tell is whether you would have to re-run the
@@ -330,6 +345,7 @@ So the practical answer is `zsh -n` in CI for syntax, plus a **manual read for t
 splitting/joining class** — no widely-adopted static analyser catches
 `cmd $args` being one argument in zsh.
 
+- [ ] **Measurements piped into a filter — `tail`, `head`, *or* `grep`/`awk`/`jq`.** The `grep` form is the more dangerous one: it reads as selective rather than lossy, and the line it silently drops is the one you did not know to look for (§3).
 - [ ] `grep -rn '^#!/bin/sh' scripts/` then scan those files for `[[`, arrays, `local -`,
       `${var//`, `pipefail` → bashism-in-sh (SC3xxx series).
 - [ ] **`set -e` believed inside a suspended context**: `set -e`/`set -o errexit`


### PR DESCRIPTION
The reporter added a fourth case after the rule shipped, and it **generalises the rule**
rather than adding an instance.

## The case

```
tool compare … | grep -E "baseline|current|LOST|GAINED"
```

The tool had correctly detected that its input changed between the two runs and printed:

```
!! GRAPH CHANGED: 245827 -> 245808 REACHING_DEF edges
```

That line matched none of the four alternatives, so it was discarded — and the conclusion
forming from what survived was that the guard was **inert**. A defect report about working
code.

## Why this is the stronger form

The hazard was never `tail`. It is that **a filter written before you know what the output
contains is a filter chosen to exclude the surprise.** `head`, `tail`, `grep`, `awk`, `cut`
and `jq` all destroy output selectively — and **`grep` is the more dangerous form precisely
because it reads as *selective* rather than *lossy***. The line you did not think to match
is the one worth reading.

Remedy unchanged, now stated generally: **redirect first, filter the file afterwards.** A
saved file can be re-grepped once the first pattern proves wrong; a consumed pipe cannot,
and the second pattern costs a full re-run.

Second audit-checklist item added in the same change.

## Footnote, kept because it is the same class

The **first** version of this commit message used `-m "…"`, and zsh history-expanded the
`!!` — silently deleting the evidence line and leaving prose that still read fine
(*"discarded  — a guard that had FIRED"*). A shell mechanism destroying content while the
surrounding text still parses, in the commit about shell mechanisms destroying content.
Amended with a quoted heredoc; the mangled version is described rather than hidden.
