### PR TITLE
feat(rules): seven rules from a field brief, plus the leak it nearly caused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,15 @@ profiles/*
 # SOTA_DENYLIST repository secret instead.
 .denylist.local
 
+# Local-only working notes — field reports, handoff briefs, scratch analyses.
+# These routinely name private repos, internal hosts and customer detail, and this
+# repository is PUBLIC. Added 2026-08-26 after FIELD-REPORT-*.local.md sat untracked
+# but NOT ignored while `git add -A` ran several times in the same session; it escaped
+# only because it was created afterwards. The convention is a `.local.` infix.
+*.local.md
+*.local.txt
+*.local.json
+
 # OS / editor cruft
 .DS_Store
 *.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to SOTA-skills are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Seven rules from a field brief — a session that *used* the library reporting defects
+  it did not prevent.** Each landed with its audit-checklist half in the same change.
+  Three of the brief's falsifiable claims were **reproduced on a real machine before
+  adoption**: `$( )` newline stripping, BSD `chmod --` rejection, and a `git rev-list`
+  usage error (exit 129) vanishing into a process substitution.
+  - `sota-shell-scripting` **rules/01 §2** — **`$( )` strips every trailing newline**,
+    silently, breaking line-oriented composition. Matters most where the bytes are hashed
+    or signed: a writer and a verifier that disagree about one byte each look correct
+    alone.
+  - `sota-shell-scripting` **rules/02 §4** — **the trade process substitution makes.** The
+    rule recommended `< <(cmd)` over a pipe and stopped; it never said the status is
+    unreachable, `pipefail` does not apply, and a failed producer yields zero lines so the
+    loop reports success over an empty set. **A rule in this library, followed literally,
+    produced a vacuous pass.** Also **§5** (`--` is not portable — BSD `chmod` rejects it
+    while `mkdir` accepts it, and the error names the wrong thing), **§4** (`head -1` over
+    unordered output — test with two elements, never one), and **§9** ("append" to a keyed
+    store is an **upsert**, which silently deletes the link target of a hash chain).
+  - `sota-code-security` **rules/14 §4a** — **a control keyed to a neighbouring setting
+    instead of its own dependency.** A *coupling* defect no per-file review or per-gate
+    probe can see, because the control's own site never changes.
+  - `sota-code-security` **rules/12 §2.1** — a fifth instrument failure mode: **a probe
+    that exercises a neighbouring property**. It explains how the other six survived a
+    green suite.
+  - **Router**: cross-cutting rule 17 now routes evidence-producing shell (attestations,
+    ledgers, gate records) to `sota-code-security` rules/10 + rules/12; BUILD step 4 adds
+    **read back the artifact this run produced**. Both paid for by compressing existing
+    text — the router is at **500/500** and invariant 1 fails at 501, verified by watching
+    it fail.
+
+### Fixed
+
+- **`*.local.md` and friends are now gitignored.** A field report naming a private
+  repository sat **untracked but not ignored** in a public repo while `git add -A` ran
+  several times in the same session; it escaped only because it was created afterwards.
+  Verified by the real test — `git add -A` now leaves it unstaged.
+
+### Changed
+
+- **`ROUTER_BUILD_SHA` re-synced** after the BUILD step 4 edit. The guard **aborted the
+  eval, as designed**, and the mirror was updated with the new clause rather than the hash
+  bumped alone — bumping alone is precisely the drift it exists to prevent. **Consequence:
+  the completeness treatment arm now carries one extra clause, so the next run is not
+  strictly comparable to the +0.38 measured 2026-08-21.** Stated now rather than
+  discovered later.
+
 ## [1.27.0] - 2026-08-26
 
 **Front door checked:** selection bias · freshness set

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -187,6 +187,9 @@ lessons-log — its own best structural idea, applied to ourselves.
 | 2026-08-21 | Field brief — *a pipeline is an evidence hazard, not only an exit-status hazard* (three destroyed measurements in one session) | `pipefail` and `${PIPESTATUS[0]}` fix the **status**; nothing in the library said a pipe also destroys the **output**, and the two need different fixes | **adopted** | `sota-shell-scripting/rules/01` §3 + a checklist grep, cross-referenced from `sota/rules/01`'s evidence standard. All three of the brief's citations verified accurate (`rules/01`:47, `rules/01`:124, router `:197`), and the gap confirmed by two independent sweeps. **Reproduced before writing** — and the first reproduction was *wrong*, keeping the cause because it sat last; rebuilt pytest-shaped (cause at the top, summary last), `tail -12` destroyed the `AssertionError` while `1 failed, 38265 passed` survived · v1.25.0 |
 | 2026-08-21 | An outside assessment of this library, three criticisms | (1) AUDIT is *mostly performative* at +0.00; (2) high friction — Day Zero *halts*, and the rules force production rigour on a throwaway script; (3) completeness collapses if the model skips the self-audit | **one adopted, two rejected as false** | Checked each against the tree. **(1) conceded and already published** — README:138 and :281 say the audit half *"adds nothing a good model doesn't already do"*, in our own words, across nine instruments. **(2a) false** — the router says *"say it once … then get on with the task"* and *"Offer, never perform"*; no halt exists. **(2b) TRUE and the only one that lands** — a search for a proportionality rule found exactly one hit, in `sota-docs-workflow/rules/05`, which a quick-script task never loads. Now router **operating principle 9**, with a measured re-baseline. **(3) false** — the ablation reads base 0.60 → +rules 0.89 → +self-audit 0.93 → +principle 5 0.99, so dropping the self-audit leaves **+0.29**, not a collapse · v1.26.0 |
 | 2026-08-25 | Operator question — "would it help if we rewrite skills files to TOON format?" | [TOON](https://github.com/toon-format/toon) (Token-Oriented Object Notation) as the on-disk format for `skills/*/SKILL.md` and `skills/*/rules/*.md`, to cut context cost | **rejected: measured 1.9% on the best case** | — · TOON's baseline is **JSON**, and Markdown already does its one trick. Converted the router routing table (42 rows, the largest table in the library) to TOON tabular form: **9,992 → 9,802 bytes, 1.9%** — and table rows are **3.1%** of the library (1,955 of 63,885 lines across 300 instruction files), so library-wide that is ~0.06%. Measurement and the cost side in the entry below |
+| 2026-08-26 | **Field brief from a session applying the library** — seven defects it did not prevent, one session building a gate-ledger script (Rust + bash) | Six gaps in `sota-shell-scripting` / `sota-code-security`, plus two routing changes. **Finding 2: a rule in this library, followed literally, produces a vacuous pass** | **all seven adopted, one narrowed, one correction added** | Three falsifiable claims **reproduced on this machine before adopting**: `$( )` newline stripping glues composed records; BSD `chmod 700 -- dir` fails with *"No such file or directory"* while `mkdir -p --` succeeds alongside it; and `git rev-list -3` exits **129** into a process substitution, yielding `count=0` and a "nothing to check" exit 0. Landed: `sota-shell-scripting/rules/01` §2 (newline stripping) and `rules/02` §4/§5/§9 (proc-sub status, `--` portability, unordered selection, keyed-store upsert); `sota-code-security/rules/14` §4a (proxy predicate) and `rules/12` §2.1 (probe scope, now **five** failure modes). Every one shipped with its audit-checklist half in the same change · v1.28.0 |
+| 2026-08-26 | Same brief — finding 3 (`--` is not portable) | Claimed as an unqualified gap | **adopted with a correction** | The hedge already existed — `sota-golang/rules/05`:91 says *"Use `--` end-of-options **where the tool supports it**"*. So the verdict is **UNREACHABLE, not absent**: correct guidance sitting in a skill a shell task never loads. Landed in `sota-shell-scripting/rules/02` §5 with the macOS reproduction and a pointer to the sibling · v1.28.0 |
+| 2026-08-26 | Same brief — **a correction the brief did not make** | Its remedy for finding 2 uses `out="$(cmd)"`, which is command substitution — and therefore **re-introduces finding 1** | **adopted with an addition** | The remedy survives only because `<<<` puts a trailing newline back, and it buffers the whole producer output in memory. Both caveats are now stated beside the GOOD example, so applying fix 2 cannot silently reintroduce bug 1. Found by reading the two findings against each other rather than in sequence · v1.28.0 |
 | 2026-08-25 | [awesome-ai-plugins](https://github.com/hashgraph-online/awesome-ai-plugins) listing invitation, and the `plugin-scanner` run it triggered on this repo | Their scanner reported **8 findings on SOTA-skills**: 7 high + 1 low | **one adopted, seven rejected as false positives** | Reproduced locally with `plugin-scanner==2.0.1116` and checked every one rather than assuming. **Adopted: `DEPENDABOT_MISSING` (low) was correct** — `.github/dependabot.yml` added, scoped to `github-actions` (the only third-party surface: `actions/checkout`, SHA-pinned in 5 places). **Rejected: all 7 highs.** 3× `DANGEROUS_DYNAMIC_EXECUTION` match the word *eval* before a parenthesis in **docstring prose** (`grep -rn 'eval(' evals/*.py` → no matches; only `re.compile`); 4× `HARDCODED_SECRET` are the OpenAI `sk-` prefix inside ordinary English — *ri**sk-r**eduction*, *di**sk-m**anaged* — plus a snippet that *generates* a prefixed token and the deliberately-vulnerable audit fixture. Both regex bugs reported upstream on the PR · v1.27.0 |
 | 2026-08-25 | Same scanner run — the *class* behind its false positives | A pattern-based control's false-positive rate is a property you must measure on your own corpus before trusting its verdict | **rejected: already covered** | `sota-detection-engineering/rules/04` §1 (*"Alert fatigue is the dominant failure"*, *"Precision over recall at the alert tier"*) and §2 (*"Tune by adding context, not by deleting detections"*) already own this class. The scanner episode is an **instance**, not a new class — recorded so it is not re-litigated as a gap · — |
 | 2026-08-25 | **This session's own eval work** (ROADMAP item 21) | Building an eval set out of the cases a model got wrong measures the selection, not the system | **adopted** | `sota-llm-engineering/rules/01` §8 + an audit checklist item. Distinct from the **contamination** bullet already there: that tunes the *prompt* against the set, this builds the *set* from outcomes. Found by nearly doing it — 10 of the old 32 freshness cases still discriminated and reporting those alone would have produced a large number measuring nothing · v1.27.0 |
@@ -1421,3 +1424,54 @@ measurement, and reconciling the two is what confirmed there was no leak.
 
 **Measurement status:** no efficacy claim. The scanner analysis is a verified reading of
 eight findings, and the two regex bugs were reported upstream rather than worked around.
+
+### 2026-08-26 — seven defects the library did not prevent
+
+A session that *used* the library reported seven defects in code written while the
+relevant skill was loaded. The brief's own framing is the useful part: **the check
+verified a neighbouring property, not the property that broke.** A gate validating an
+encoding while the defect is in the composition; a probe mutating a fixture the writer
+never touches; a control whose predicate reads a setting adjacent to its real dependency.
+
+**Reproduced before adopting**, because a brief's technical claims are claims:
+
+```
+$( ) stripping   -> "b: 2c: 3"                        composed record glued
+chmod 700 --     -> "chmod: --: No such file or directory"   (BSD /bin/chmod)
+mkdir -p --      -> succeeds on the same system        which is what disguises it
+git rev-list -3  -> exit 129, count=0, "nothing to check", exit 0
+```
+
+**Finding 2 is the one that matters most, and it is ours.** `rules/02` §4 recommended
+process substitution over a pipe — correctly, because a pipe loses variable updates — and
+stopped there. It never said that the trade swaps a *visible* bug for an *invisible* one:
+a process substitution's exit status is unreachable, `pipefail` does not apply, and a
+failed producer yields zero lines, so the loop reports success over an empty set. That is
+the vacuous-pass shape `rules/11` exists to find, arriving through a shell rule that
+recommends it.
+
+**Finding 5 is the highest-value class.** A control gated on `commit.gpgsign` — a proxy
+that agreed with the real dependency (`user.signingkey`) for months — stopped producing a
+signature at the exact moment that signature became the only per-change attestation, and
+still logged success with a *stale* explanation. It is a **coupling** defect: the
+control's own site never changed, so neither per-file review nor a per-gate probe can see
+it.
+
+**Finding 7 explains why the other six survived a green suite** — a probe licenses
+confidence only over the path it actually traverses, and this one exercised the encoder
+while the defects lived in the composition, the predicate and the write path.
+
+**Two constraints the reporter could not know, and how they were handled.** The router is
+at **500/500 lines** and invariant 1 fails at 501 — verified by adding a line and watching
+`OVER 500 (501 lines)` fail the build — so both routing additions were paid for by
+compressing existing text rather than appended. And editing router BUILD step 4 tripped
+`ROUTER_BUILD_SHA`: the completeness eval's hand-compressed mirror **aborted**, as
+designed. The mirror was re-synced with the new clause and the hash updated —
+re-hashing alone would have been the exact drift the guard exists to prevent.
+
+**Consequence to carry forward:** the completeness treatment arm now contains one extra
+clause, so the next run is **not strictly comparable** to the +0.38 measured on
+2026-08-21. Stated here rather than discovered later.
+
+**Measurement status:** adopted on reasoning plus three verified reproductions. **No
+efficacy lift is claimed** — nothing here has been measured against an eval.

--- a/evals/run-completeness.py
+++ b/evals/run-completeness.py
@@ -101,7 +101,7 @@ def load_cases():
 # longer shipped. Nothing failed; the eval just quietly measured the wrong thing.
 # So: pin the router section's hash. If the router changes, this aborts and forces a
 # decision — re-sync the mirror and update the hash, or consciously accept the drift.
-ROUTER_BUILD_SHA = "71a9d78ea5e9e341"
+ROUTER_BUILD_SHA = "4d1a02c9c483a65b"
 
 
 def _assert_mirror_fresh():
@@ -137,7 +137,9 @@ BUILD_WORKFLOW = (
     "etc.) ADD it, or state explicitly why it is out of scope. For every control, "
     "safeguard, or check you added, also ask: if this were silently a no-op, would "
     "anything observable differ? If nothing would — no log, no metric, no failing "
-    "test — it is not done. Do not present incomplete code.\n\nTask: ")
+    "test — it is not done. If a control you added emits an artifact (a record, "
+    "ledger line, signature), read back the one this run produced rather than "
+    "re-reading the code that writes it. Do not present incomplete code.\n\nTask: ")
 
 
 def principle5():

--- a/skills/sota-code-security/rules/12-verifying-the-verifier.md
+++ b/skills/sota-code-security/rules/12-verifying-the-verifier.md
@@ -202,7 +202,7 @@ passing unit test, and a status read through a pipe (`cmd | tail -1; echo $?` re
 `${PIPESTATUS[0]}` — are in `sota-shell-scripting` rules/01 §3, which nothing will
 route you to when the task does not look shell-shaped. That is exactly when it bites.
 
-### 2.1 Four failure modes specific to instruments
+### 2.1 Five failure modes specific to instruments
 
 - **Unbounded or unread scope.** rules/11 §2.2 turned inward: an instrument must
   report what it examined, *and someone must read it*. A scorer that printed
@@ -228,6 +228,20 @@ route you to when the task does not look shell-shaped. That is exactly when it b
   whatever it is handed. A mutation harness reporting **18/18 controls caught**
   while every run died before the test suite started — each non-zero exit read as
   "caught". Both look exactly like success.
+- **A probe that exercises a neighbouring property.** The probe works, the gate
+  fails on demand, and the green it produces covers code it never touched. Field-
+  reported: a gate whose known-bad corrupts a committed **canonical-encoding
+  vector** caught none of three defects living in the *composition*, the
+  *predicate* and the *write path*. The gate was not weak — it was **precise about
+  the wrong thing**, and its passing is what let the other defects survive review.
+  The tell is a probe that mutates a **fixture** rather than the artifact the
+  control produces at runtime: a fixture probe proves the validator reads, and
+  proves nothing about whether the writer still emits what the validator expects.
+  **State the traversed path in one line beside the probe** — *"exercises the
+  encoder; not the writer, the predicate, or the store"* — then ask what else is
+  claiming coverage from this gate's green. Where the control emits an artifact,
+  probe by corrupting **what the control just produced**, not a stored copy of what
+  it should have produced.
 
 ### 2.2 The bar
 
@@ -403,6 +417,13 @@ whose pathspec drifted.
 ---
 
 ## Audit checklist
+
+- [ ] **Every probe states the path it traverses**, and that statement is narrower than
+      the gate's reputation. For each green gate, name one code path it does *not*
+      exercise; if you cannot, the probe's scope has not been established.
+- [ ] **Probes on artifact-producing controls corrupt the produced artifact**, not a
+      committed fixture of it. A fixture-only probe survives a writer that has stopped
+      writing what the validator expects.
 
 - [ ] Any instrument that runs **over time** (watcher, poller, readiness or completion
       check): does it distinguish **not-yet** from **cannot-tell**, assert the terminal

--- a/skills/sota-code-security/rules/14-control-not-in-force.md
+++ b/skills/sota-code-security/rules/14-control-not-in-force.md
@@ -169,6 +169,38 @@ single job turned out to set a workflow-wide env var that its own first step rej
 so it could never have passed — invisible for as long as nothing ran it (checked
 2026-08-16; GitHub's skipped-reports-Success behaviour is above).
 
+## 4a. A control keyed to a neighbouring setting instead of its own dependency
+
+A control gated on a **proxy** — "is the sibling feature enabled", "is the flag on",
+"does the config file exist" — is correct for exactly as long as the proxy and the real
+dependency are configured together. They are two facts, so one day they are set
+independently, and the control stops in silence.
+
+```bash
+# BAD — commit.gpgsign is a proxy for "signing is set up"
+if [[ "$(git config --get commit.gpgsign)" == "true" ]] && command -v gpg; then
+    sign_head            # what this actually needs is user.signingkey
+fi
+```
+
+Field-reported: a repository moved from per-commit signing to tag-only signing and set
+`commit.gpgsign=false`. The head signature **stopped being produced at the moment it
+became the only per-change attestation**, and the caller still logged success. The two
+settings had agreed for months; they diverged in one commit, three files away.
+
+The defect is a **coupling**, which is why neither a per-file review nor a per-gate probe
+finds it: the control's own site is unchanged and still reads correctly.
+
+- **Ask what the code actually needs to function, and test that.** Here: `user.signingkey`
+  (or attempt the signature and handle failure), not a sibling boolean.
+- **Then falsify the proxy specifically:** *if the proxy flipped and the dependency did
+  not, would anything observable differ?* "The control silently stops" means the predicate
+  is wrong.
+- **Report from live state, never from a hardcoded explanation.** That instance printed
+  "commit signing is not configured yet" — a reason that had been true when written and
+  referred to a closed question. A stale reason is worse than none: it stops the reader
+  looking.
+
 ## 5. A control parked in observe-only mode
 
 A control in audit / warn / dry-run / report-only mode is a *plan* to enforce,
@@ -188,6 +220,14 @@ was supposed to flip it. "Enabled" is not "enforcing", and no consumer of the
 dashboard can tell the difference.
 
 ## Audit checklist
+
+- [ ] **Proxy predicates**: for every `if` guarding a control, name the dependency the
+      body actually needs and confirm the predicate tests *that*. Grep the codebase for
+      the proxy setting — if it is read in more than one place for more than one purpose,
+      the two uses can be configured apart. High when the control is the only attestation
+      of something.
+- [ ] **Skip messages are derived from live state**, not string literals written when the
+      branch was added. A hardcoded reason cannot go stale loudly.
 
 - [ ] Does any **report or output** claim more than the run establishes — a count
       of things not examined, or a verification word (`verified`, `reachable`,

--- a/skills/sota-shell-scripting/rules/01-safety-baseline.md
+++ b/skills/sota-shell-scripting/rules/01-safety-baseline.md
@@ -96,6 +96,22 @@ fi
 Rule: treat `set -e` as a backstop, not error handling. Critical steps get explicit
 `|| { err "..."; exit 1; }` or status capture.
 
+**`$( )` strips every trailing newline — silently, and it breaks line-oriented
+composition.** The code *reads* as though the newline is there, because the helper that
+produced it emitted one; the newline is removed by the substitution, not by the helper.
+
+```bash
+body="$(printf 'a: 1\nb: 2\n')"     # body is "a: 1\nb: 2" — the trailing \n is GONE
+printf '%s%s\n' "$body" "c: 3"      # BAD  -> "a: 1", "b: 2c: 3"   (two fields glued)
+printf '%s\n%s\n' "$body" "c: 3"    # GOOD -> "a: 1", "b: 2", "c: 3"
+```
+
+This matters most where the bytes are **hashed, signed, or parsed by field**: a writer
+and a verifier that disagree about one byte each look correct in isolation. If the
+composed text feeds a digest, assert the round trip against a **committed known-answer
+vector**. Field-reported twice in one session, the second time by the author who had
+just fixed the first instance.
+
 ## 3. Quoting: quote every expansion (SC2086)
 
 Unquoted expansions undergo word splitting (on `$IFS`) **and** glob expansion. This is the
@@ -325,6 +341,11 @@ files=(/data/*); count=${#files[@]}                               # with nullglo
 ```
 
 ## Audit checklist
+
+- [ ] **Composed multi-line records**: `grep -rn '="\$(' --include='*.sh'` where the
+      result is concatenated with more lines — `$( )` dropped the trailing newline and
+      the boundary is gone. High where the bytes are hashed, signed or field-parsed;
+      confirm a known-answer vector exists and that writer and verifier agree byte-for-byte.
 
 - [ ] **Measurements piped into `tail`/`head`.** `grep -rnE '(pytest|go test|cargo|bench|profile|timeout)[^|]*\| *(tail|head)' --include='*.sh' --include='*.yml' .` — and the same in any runbook or CI step whose output someone reads. Evidence commands redirect to a file; `pipefail` does not bring destroyed output back (§3).
 

--- a/skills/sota-shell-scripting/rules/02-robustness-correctness.md
+++ b/skills/sota-shell-scripting/rules/02-robustness-correctness.md
@@ -139,6 +139,40 @@ cmd | while read -r line; do (( ++count )); done
 while IFS= read -r line; do (( ++count )); done < <(cmd)
 ```
 
+**Name the trade you just made: a process substitution's exit status is unreachable.**
+`$?` reflects the redirection, not the producer; `pipefail` does not apply and
+`inherit_errexit` does not help. A producer that fails yields **zero lines**, so the loop
+completes over an empty set and the function reports success — the vacuous-pass shape
+(`sota-code-security` rules/11), now silent. Measured: a `git rev-list` usage error exits
+**129**, the loop sees nothing, and a coverage check announces "nothing to check" and
+exits 0.
+
+Capture the status explicitly wherever *no output* and *the command failed* mean
+different things:
+
+```bash
+# GOOD — status captured; empty and failed are distinguished
+local out status=0
+out="$(git rev-list "$range" 2>&1)" || status=$?
+(( status == 0 )) || { printf 'rev-list failed: %s\n' "$out" >&2; return 2; }
+while IFS= read -r line; do [[ -n $line ]] && arr+=("$line"); done <<<"$out"
+```
+
+Two caveats on that remedy, because it is not free: `$( )` **strips trailing newlines**
+(rules/01 §2) — here `<<<` puts one back, but do not carry the pattern somewhere it
+matters — and it buffers the whole output in memory, which is wrong for an unbounded
+producer. Use bare `< <(cmd)` only where the producer cannot meaningfully fail, or where
+empty and failed are genuinely the same outcome. **Say which, in a comment.**
+
+**`head -1` over unordered output is a coin flip with one side visible in development.**
+Tools that emit *sets* promise no order — `git notes list`, `git for-each-ref` without
+`--sort`, `find`, `ls` on some filesystems, `kubectl get` without sorting. Code that
+takes "the" element is correct while exactly one exists and silently picks wrong
+afterwards. Sort by the field that defines *latest*/*best* and select explicitly, or fail
+when the count is not 1. **Test with two elements, never one** — a single-element fixture
+cannot tell correct selection from arbitrary selection. High when it selects a security
+control's input, where "stale" and "current" then read alike.
+
 ## 5. Portability: bash vs POSIX sh
 
 Decide per script and enforce with the shebang + `shellcheck -s sh`.
@@ -148,6 +182,14 @@ Decide per script and enforce with the shebang + `shellcheck -s sh`.
   to reuse positional params), `[ ]` not `[[ ]]`, no `pipefail` (run each stage to a temp
   file or use a fifo/status-file trick), `. file` not `source`, no `${var//}`, no
   `<<<`/`<( )`, `printf` always (dash `echo` interprets escapes).
+- `--` (end of options) is **not universal**. GNU coreutils accept it nearly everywhere;
+  BSD/macOS `chmod` does not — `chmod 700 -- dir` fails with `chmod: --: No such file or
+  directory`, which names the wrong thing and reads as a path bug. Adjacent calls mislead
+  further: `mkdir -p -- dir` succeeds on the same system (both verified on macOS
+  2026-08-26). Where the path is a literal you control, drop the `--`; where it is
+  untrusted, prefer `./"$path"` for a relative path — portable, and it defeats
+  leading-dash injection without depending on the flag. (`sota-golang` rules/05 already
+  hedges this as "where the tool supports it"; it was unreachable from a shell task.)
 - bash-targeted: use bash properly (arrays, `[[ ]]`, `mapfile`) — half-POSIX bash is the
   worst of both. But remember macOS = bash 3.2: no associative arrays, no `mapfile`, no
   `${var,,}`, no `inherit_errexit`. If macOS devs run the script, either stay 3.2-clean
@@ -288,6 +330,14 @@ mkdir -p -- "$dir"                       # not mkdir (fails if exists)
 grep -qxF "$line" "$file" || printf '%s\n' "$line" >> "$file"
 ```
 
+- **"Append" to a keyed store is an upsert.** Where the key comes from content or context
+  rather than from the record — a commit SHA, a request id, a date bucket — running twice
+  does not append twice, it **overwrites** (`git notes add -f`, `PUT`, `kubectl apply`).
+  If records are *linked* (hash chain, sequence numbers, prev-pointers) the overwrite
+  silently deletes the link target, and the corruption arrives from the ordinary act of
+  re-running. Detect an existing record for the same key **and** the same content and
+  return success without writing. **Test the second run, not just the first** — re-running
+  is the common path in any hook, retry or CI re-trigger.
 - **Atomic writes via mv**: never write a config/output file in place — a crash mid-write
   leaves a torn file that consumers read.
 
@@ -333,6 +383,15 @@ mapfile -d '' logs < <(find . -name '*.log' -print0)
       read clean while a check did not execute? Probe:
       `PATH=/usr/bin:/bin <script>` with a dependency removed, and confirm the run
       reports a SKIP rather than an `ok`. No script may auto-install a dependency.
+- [ ] **Process substitution with a fallible producer**: `grep -rn '< <(' --include='*.sh'`
+      — for each, can the producer fail? If yes and the status is not captured, a failure
+      is indistinguishable from an empty result. High when the loop's emptiness decides a
+      pass/fail verdict.
+- [ ] **Arbitrary selection**: `grep -rnE '\|\s*head -1|\| head -n ?1' --include='*.sh'`
+      over set-emitting commands with no `--sort`/`sort`. Confirm a two-element fixture
+      exists; a one-element test cannot fail.
+- [ ] **Second-run safety**: re-run the script on unchanged inputs and diff the store.
+      Any write keyed by commit/id/date must be an upsert that preserves linked records.
 - [ ] No `--help`: `grep -rLn -- '--help\|-h)' --include='*.sh'` → MEDIUM for any operator-facing script.
 - [ ] Unknown options silently ignored: `case` parse loops missing a `-*)` error arm.
 - [ ] SC2230 — `grep -rn 'which ' --include='*.sh'` → replace with `command -v`.

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -200,11 +200,12 @@ rules files that match the code in front of you. Never load all skills at once.
     `sota-ux-writing`; marketing/site/email content → `sota-copywriting`; technical docs → `sota-
     docs-workflow`. The component patterns the text lives in stay `sota-frontend-design`.
 17. **Shell scripts hide everywhere** — CI run blocks, Dockerfile RUN lines, Makefiles,
-    entrypoints, **and the one-liners you type to verify a claim**. That last one is
-    unlinted shell run against the system under test: when it is wrong it produces a false
-    finding *about the product*. A usage error (exit 2) from the callee is the tell. Audit
-    all of it with `sota-shell-scripting` — especially its rules/01 §3, which the task will
-    not route you to when the work does not look shell-shaped.
+    entrypoints, **and the one-liners you type to verify a claim**: unlinted shell run
+    against the system under test, which when wrong produces a false finding *about the
+    product* (a usage error, exit 2, from the callee is the tell). Audit it all with
+    `sota-shell-scripting`, especially rules/01 §3. And a script that **produces or
+    verifies evidence** (attestations, ledgers, gate records, audit trails) is a security
+    control written in shell: add `sota-code-security` rules/10 and rules/12.
 18. **Cryptography fans out — there is no single crypto skill (by design).** Algorithm choice,
     AEAD/nonce discipline, CSPRNG, in-code key handling, TLS client config, constant-time
     comparison, tamper-evident logs/audit ledgers (keyed hash chains, external anchoring,
@@ -281,15 +282,14 @@ act only on a yes, and treat a decline as decided.
    also ask the **falsification question**: *if this were silently a no-op,
    would anything observable differ?* If nothing would — no log, no metric, no
    test that fails — the control is not done (`sota-code-security` rules/10).
-   Doing this *last* is deliberate: a long build context
-   makes mid-context rules fade, so a final re-read is what catches the rate
-   limiting, transport, tests, and logging a model otherwise silently drops
-   (measured: this recovery is the bulk of the library's completeness lift,
-   `evals/run-completeness.py`). For a large build, run this as a **separate
-   pass over the diff** (a fresh, minimal context beats a long polluted one),
-   and push the few truly critical invariants into **deterministic gates** (a
-   lint/CI check that fails if an endpoint has no rate limiting or TLS) — don't
-   rely on attention for what a test can enforce.
+   **If the control emits an artifact, read back the one this run just produced**
+   — a record, ledger line or signature is wrong in the *output* long before it
+   looks wrong in the source. Doing this *last* is deliberate: a long context
+   makes mid-context rules fade, so the final re-read is what catches the rate
+   limiting, transport, tests and logging a model otherwise drops (measured: it
+   is the bulk of the completeness lift, `evals/run-completeness.py`). For a large
+   build run it as a **separate pass over the diff**, and push the few critical
+   invariants into **deterministic gates** — attention is not an enforcement mechanism.
 
 ## AUDIT mode — workflow
 


### PR DESCRIPTION
A session that **used** the library reported seven defects it did not prevent. Its own framing is the useful part: **the check verified a neighbouring property, not the property that broke.**

## Reproduced before adopting

A brief's technical claims are claims. All three falsifiable ones landed exactly as described:

```
$( ) stripping   → "b: 2c: 3"                                composed record glued
chmod 700 --     → "chmod: --: No such file or directory"    BSD /bin/chmod
mkdir -p --      → succeeds on the same system               ← what disguises it as a path bug
git rev-list -3  → exit 129, count=0, "nothing to check", exit 0
```

## Finding 2 is ours

`rules/02` §4 recommended `< <(cmd)` over a pipe — correctly, because a pipe loses variable updates — and **stopped there**. It never said the trade swaps a *visible* bug for an *invisible* one: the status is unreachable, `pipefail` does not apply, and a failed producer yields zero lines, so the loop reports success over an empty set. That's the vacuous-pass shape `rules/11` exists to find, arriving through a shell rule that recommends it.

## What landed

Each with its audit-checklist half, since shipping the BUILD half alone is this repo's documented failure mode:

| Rule | Class |
|---|---|
| shell `rules/01` §2 | `$( )` strips every trailing newline |
| shell `rules/02` §4 | proc-sub status unreachable; empty ≡ failed |
| shell `rules/02` §4 | `head -1` over unordered output — test with two, never one |
| shell `rules/02` §5 | `--` is not portable, and the error names the wrong thing |
| shell `rules/02` §9 | "append" to a keyed store is an **upsert** — deletes a chain's link target |
| code-sec `rules/14` §4a | control keyed to a **neighbouring setting** (a *coupling* defect) |
| code-sec `rules/12` §2.1 | fifth mode: a probe exercising a neighbouring property |

## Two corrections to the brief

- **Its fix for finding 2 re-introduces finding 1.** The remedy uses `out="$(cmd)"` — command substitution, which strips trailing newlines. It survives only because `<<<` puts one back, and it buffers the whole producer in memory. Both caveats now sit beside the GOOD example so nobody applies fix 2 and quietly restores bug 1.
- **Finding 3 was already half-stated** — `sota-golang/rules/05`:91 hedges "where the tool supports it". **UNREACHABLE, not absent**: right guidance, in a skill a shell task never loads.

## Two constraints handled

- **The router is at 500/500.** Verified rather than assumed: adding one line gives `[1/19] OVER 500 (501 lines) → FAIL` (`MAX_LINES=500`, `-gt`). Both routing additions were paid for by **compressing existing text**, not appended.
- **`ROUTER_BUILD_SHA` aborted the completeness eval** on the BUILD step 4 edit — as designed. The mirror was **re-synced with the new clause**, not just re-hashed; re-hashing alone is precisely the drift the guard exists to prevent. **Consequence recorded: the treatment arm changed, so the next completeness run is not strictly comparable to the +0.38 of 2026-08-21.**

## The leak it nearly caused

`FIELD-REPORT-*.local.md` names a private repository and sat **untracked but not ignored** in this public repo, while `git add -A` ran several times in the same session. It escaped only because it was created afterwards. `.gitignore` now covers `*.local.md` / `.txt` / `.json`, verified by the real test: `git add -A` leaves it unstaged.

## Measurement status

Adopted on reasoning plus three verified reproductions. **No efficacy lift is claimed** — none of this has been measured against an eval.
