### PR TITLE
refactor(router): offload BUILD/AUDIT detail to rules/, keep the 500-line cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The router gave back its headroom: BUILD/AUDIT detail moved into `skills/sota/rules/`,
+  loaded on demand.** `skills/sota/SKILL.md` went **500 → 484 lines** (16 spare, after
+  sitting at the cap since 2026-07-30) without losing an imperative. §BUILD 37 → 28 lines,
+  §AUDIT 63 → 54.
+  - **New `skills/sota/rules/02-build-workflow.md`** — the reasoning behind the four BUILD
+    steps: why loading lean is correctness rather than economy, why a plan item must be
+    checkable, why the self-audit gate runs LAST, and the two questions that catch inert
+    work.
+  - **Most of what left §AUDIT was duplication, not detail.** `rules/01` already carried
+    the severity model (§4), recon (§2), decision-ledger (§6), refutation (§7) and report
+    structure (§8); the router now points at them instead of restating them.
+  - **Measured first, not assumed.** A length sweep on `cases/router.jsonl`
+    (`claude-sonnet-5`, 3 samples, temp 0.7) found routing recall **flat at 1.000** with
+    the router padded to 902 and 1,302 lines and the routing table pushed 800 lines deeper
+    — while the untreated arm reproduced **0.867** exactly, as on 2026-08-25. So length was
+    never the thing to fear; **per-load cost is** — the router is **16,934 tokens**
+    (`count_tokens`, `claude-sonnet-5`), ~3.4× the ~5k guidance, paid by every task.
+    Offloading detail cuts that; raising the cap would have raised it.
+  - **A compression audit came back clean.** Of 51 concept anchors that ever existed in the
+    router, **49 are present today**; the two absent are a rewording of the same rule and
+    one superseded by a stronger rule whose substance moved to `rules/01` §5. Nothing was
+    quietly dropped to fit the cap.
+
 ### Added
+
+- **The coupling is now stated in four places, because it fails silently in three.**
+  Adding to §BUILD or §AUDIT usually means editing another file too: `rules/02` §5 tables
+  BUILD's four surfaces, new `rules/01` §10 tables AUDIT's two (and says plainly that
+  **nothing catches AUDIT divergence automatically**), the router's own two sections carry
+  a one-line warning, and `CONTRIBUTING.md` explains it for humans.
+- **`ROUTER_BUILD_SHA` guidance sharpened by having to follow it.** The rule first written
+  as "never the hash alone" was unfollowable when only prose moved. It now says: re-read
+  the mirror against the new §BUILD **clause by clause**, then state in the commit which
+  case it is — *an imperative changed* (re-sync first) or *only prose moved* (hash alone is
+  correct). Both of this change's two pin trips were resolved that way, verified.
 
 - **Seven rules from a field brief — a session that *used* the library reporting defects
   it did not prevent.** Each landed with its audit-checklist half in the same change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,6 +325,29 @@ Run the invariant checks any time:
 ./scripts/check-invariants.sh
 ```
 
+### Changing the router's BUILD or AUDIT workflow
+
+The router (`skills/sota/SKILL.md`) is capped at **500 lines** and is read on every task,
+so both workflow sections hold **imperatives only**; the procedure and reasoning live in
+`skills/sota/rules/`. That split means a change usually lands in more than one file.
+
+**BUILD is mirrored in four places** and three of them fail silently — the table is in
+[`skills/sota/rules/02-build-workflow.md`](skills/sota/rules/02-build-workflow.md) §5.
+The one loud surface is `ROUTER_BUILD_SHA` in `evals/run-completeness.py`: it pins a hash
+over the router's §BUILD, so editing that section **aborts the completeness eval** until
+you deal with it. Never bump the hash without first re-reading `BUILD_WORKFLOW` against
+the new §BUILD clause by clause, then say in the commit which case it was — *an imperative
+changed* (re-sync the mirror first) or *only prose moved* (hash alone is correct).
+
+**AUDIT is mirrored in two** — the router's §AUDIT and
+[`rules/01-audit-methodology.md`](skills/sota/rules/01-audit-methodology.md) §10. There is
+**no hash pin over §AUDIT**, so nothing catches divergence automatically; a new pass needs
+a line in the router *and* a section in `rules/01`.
+
+Adding a `skills/sota/rules/NN` file also touches the router's **library map** (invariant
+15) and the README's file count (invariant 6) — and both gates read `git ls-files`, so
+`git add` the new file before believing either of them.
+
 ### Dependency updates
 
 `.github/dependabot.yml` watches **`github-actions` only**. There is no pip or npm

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ survives a long context instead of fading into it. That's why it beats a bigger 
 instead of becoming one. Native on Claude Code; works with Gemini CLI, Codex, and any
 agent that reads `AGENTS.md`.
 
-Under the hood: **41 skills (300 files, ~64k lines)** of state-of-the-art 2026
+Under the hood: **41 skills (301 files, ~64k lines)** of state-of-the-art 2026
 practice, each **instruction** file under 500 lines so only the matching rules load —
 the cap applies to `skills/**` alone, never to README/CHANGELOG/`docs/` — every fast-moving
 claim web-verified against a primary source.

--- a/evals/run-completeness.py
+++ b/evals/run-completeness.py
@@ -101,7 +101,7 @@ def load_cases():
 # longer shipped. Nothing failed; the eval just quietly measured the wrong thing.
 # So: pin the router section's hash. If the router changes, this aborts and forces a
 # decision — re-sync the mirror and update the hash, or consciously accept the drift.
-ROUTER_BUILD_SHA = "4d1a02c9c483a65b"
+ROUTER_BUILD_SHA = "0c85814f366fe860"
 
 
 def _assert_mirror_fresh():

--- a/scripts/check-negative-controls.sh
+++ b/scripts/check-negative-controls.sh
@@ -143,11 +143,15 @@ probe 1 "line budget (rules file over 500 lines)" "OVER 500"
 probe 2 "audit checklist missing from a rules file" "MISSING/NOT-LAST '## Audit checklist'"
 
 # 6 — count-bearing surfaces match the tree.
-# The literal here tracks the README's real count and goes stale on every file
-# add/split — which is exactly what the mutation-landed assertion is for: it
-# printed PROBE BROKEN on 2026-08-20 when rules/13 and rules/14 moved 298 -> 300,
-# instead of reporting a healthy invariant 6 as uncaught.
-( cd "$WT" && perl -0pi -e 's/\*\*41 skills \(300 files/**41 skills (999 files/' README.md )
+# The mutation is count-AGNOSTIC: it matches whatever numbers the README currently
+# carries and rewrites only the file count. A hardcoded literal here went stale twice
+# (298 -> 300 when rules/13 and rules/14 landed, 2026-08-20; 300 -> 301 when
+# sota/rules/02 landed, 2026-08-26), each time costing a red CI run that said PROBE
+# BROKEN. That assertion did its job both times — it never accused the healthy gate —
+# but the staleness added no signal invariant 6 doesn't already give, since a changed
+# count fails invariant 6 first. The regex still asserts it landed, so a change to the
+# hero SENTENCE (not its numbers) is still reported as a broken probe.
+( cd "$WT" && perl -0pi -e 's/\*\*(\d+) skills \(\d+ files/**$1 skills (999 files/' README.md )
 probe 6 "README file count drifted from the tree" "README hero file count"
 
 # 10 — a rules file its own SKILL.md never indexes.

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -256,108 +256,92 @@ act only on a yes, and treat a decline as decided.
 
 ## BUILD mode — workflow
 
+Reasoning and worked examples: `rules/02-build-workflow.md`. **Changing a step below?
+It is mirrored in four places — `rules/02` §5 lists them, and three fail silently.**
+
 1. Identify the domains the feature touches (table above) and the language(s).
-2. **Load lean.** Read each relevant skill's `SKILL.md` and, from its index,
-   open **only** the rules files that match the work (e.g. a websocket endpoint
-   → api-design rules/05, async rules/06, code-security rules/02). Loading
-   unrelated rules is not free: a long context of similar-looking guidance
-   *measurably reduces* how many rules the model actually applies (transformer
-   attention degrades with length and near-duplicate distractors). Lean is
-   correctness, not just economy.
-3. **Plan first, with the checks in the plan.** Before writing code, list a
-   short **requirements checklist for this task** — the top-10 non-negotiables
-   of each loaded skill + the **universal build non-negotiables** (operating
-   principle 5) that apply to any endpoint/handler. Make each item **concrete
-   and checkable** — a specific outcome you can mark done/not-done at step 4
-   ("rate-limit login to N/min per IP", not "add rate limiting"; "reject uploads
-   over N MB", not "validate uploads"); vague items ("handle errors", "make it
-   secure") don't survive to the plan. Named up front and verified at the end,
-   constraints are followed far better than when left implicit. Then implement
-   against that checklist; apply detailed rules as code demands.
-4. **Self-audit gate (do this LAST — do not present code until it passes).**
-   Re-read each loaded rules file's **Audit checklist** (every rules file ends
-   with one) *and* operating principle 5, and verify your diff satisfies every
-   item. For each unmet item, **implement it** or state why it's out of scope —
-   silence is not allowed. For every control, safeguard, or check in the diff,
-   also ask the **falsification question**: *if this were silently a no-op,
-   would anything observable differ?* If nothing would — no log, no metric, no
-   test that fails — the control is not done (`sota-code-security` rules/10).
-   **If the control emits an artifact, read back the one this run just produced**
-   — a record, ledger line or signature is wrong in the *output* long before it
-   looks wrong in the source. Doing this *last* is deliberate: a long context
-   makes mid-context rules fade, so the final re-read is what catches the rate
-   limiting, transport, tests and logging a model otherwise drops (measured: it
-   is the bulk of the completeness lift, `evals/run-completeness.py`). For a large
-   build run it as a **separate pass over the diff**, and push the few critical
-   invariants into **deterministic gates** — attention is not an enforcement mechanism.
+2. **Load lean.** Read each relevant skill's `SKILL.md` and, from its index, open **only**
+   the rules files that match the work. Loading unrelated rules *measurably reduces* how
+   many rules the model applies — lean is correctness, not economy.
+3. **Plan first, with the checks in the plan.** Before writing code, list the task's
+   requirements as **concrete, checkable items** — a specific outcome you can mark
+   done/not-done ("rate-limit login to N/min per IP", not "add rate limiting") — covering
+   the top-10 non-negotiables of each loaded skill plus operating principle 5. Vague items
+   don't survive to step 4. Then implement against that list.
+4. **Self-audit gate (do this LAST — do not present code until it passes).** Re-read each
+   loaded rules file's **Audit checklist** *and* operating principle 5, and verify your
+   diff satisfies every item. For each unmet item, **implement it** or state why it is out
+   of scope — silence is not allowed. For every control, ask the **falsification
+   question**: *if this were silently a no-op, would anything observable differ?* If
+   nothing would — no log, no metric, no failing test — it is not done
+   (`sota-code-security` rules/10). **If the control emits an artifact, read back the one
+   this run just produced.** Doing this *last* is deliberate: a long context makes
+   mid-context rules fade, and the final re-read is what recovers the rate limiting,
+   transport, tests and logging a model otherwise drops — measured as the bulk of the
+   library's completeness lift (`evals/run-completeness.py`). For a large build, run it as
+   a separate pass over the diff, and push the few critical invariants into deterministic
+   gates (`rules/02` §3).
 
 ## AUDIT mode — workflow
 
-Process and reporting are governed by `rules/01-audit-methodology.md` — read it
-first for any full audit: scoping/rules-of-engagement, the verified tool
-matrix and triage discipline, the evidence standard, and the report template.
+Process and reporting are governed by `rules/01-audit-methodology.md` — read it first for
+any full audit: scoping and rules of engagement, the verified tool matrix and triage
+discipline, the **severity model** (§4), the **evidence standard** (§5) and the report
+template (§8). **Adding or changing a pass below? The procedure lives in `rules/01` —
+put the detail there and keep the step here to one imperative.**
 
-For a focused audit, load the matching skills and follow their AUDIT sections.
-For a **full project audit**, work in passes:
+For a focused audit, load the matching skills and follow their AUDIT sections. For a
+**full project audit**, work in passes:
 
-1. **Recon.** Inventory the repo: languages, frameworks, entry points (HTTP routes, queues, cron,
-   webhooks), data stores, CI config, Dockerfiles, IaC. This determines which skills apply; skip
-   skills with no matching surface.
+1. **Recon.** Inventory languages, frameworks, entry points (HTTP routes, queues, cron,
+   webhooks), data stores, CI config, Dockerfiles, IaC. This determines which skills
+   apply; skip skills with no matching surface. Full procedure: `rules/01` §2.
 2. **Threat model first.** `sota-threat-modeling` rules/06 (reconstruction): assets, trust
    boundaries, entry points. Its output prioritizes the rest.
-3. **Per-domain passes.** For each applicable skill, follow its AUDIT mode and audit checklists.
-   Suggested order: secrets sweep (fast, high yield) → code security (incl. rules/09 untrusted-
-   data ingestion) → language-specific (incl. shell scripts) → API → database → async/concurrency
-   → identity & access → sandboxing/devsecops → kubernetes platform → network security → cloud
-   infrastructure → privacy/compliance → architecture → testing suite health → performance →
-   observability → detection-engineering posture → frontend/a11y → LLM features, data pipelines,
-   mobile, CLI, docs as applicable. For an infrastructure/cluster audit the heavy hitters are
-   `sota-kubernetes`, `sota-network-security`, `sota-identity-access`, `sota-sandboxing`, and
+3. **Per-domain passes.** For each applicable skill, follow its AUDIT mode and audit
+   checklists. Suggested order: secrets sweep (fast, high yield) → code security (incl.
+   rules/09 untrusted-data ingestion) → language-specific (incl. shell scripts) → API →
+   database → async/concurrency → identity & access → sandboxing/devsecops → kubernetes
+   platform → network security → cloud infrastructure → privacy/compliance → architecture
+   → testing suite health → performance → observability → detection-engineering posture →
+   frontend/a11y → LLM features, data pipelines, mobile, CLI, docs as applicable. For an
+   infrastructure/cluster audit the heavy hitters are `sota-kubernetes`,
+   `sota-network-security`, `sota-identity-access`, `sota-sandboxing` and
    `sota-detection-engineering`.
-4. **Silent-control pass (always run it).** The per-domain passes ask "is the control there?" —
-   this one asks "does it *do* anything?". For every control they confirmed exists, apply `sota-
-   code-security` rules/10: swallowed enforcement exceptions, presence decided by `exists()`
-   rather than a loaded artifact, rulesets that load zero rules, truncation into an inspector or
-   out of a generator, attacker-triggerable early returns, config keys silently ignored, defaults
-   that differ between docs and code, degradation nothing logs, and controls whose tests still
-   pass when the body is replaced with a no-op. This class is invisible to the other passes — the
-   code isn't wrong, it's inert — and to pattern-based SAST for the same reason. **Sweep with
-   `rules/11` first** to find *where* to look: stage duration vs work claimed, every gate's
-   denominator (`0 checked, 0 failed, exit 0`), size-gated paths no fixture crosses, cache keys
-   narrower than the behaviour, one-sample parsers, `assert`-as-control.
-5. **Decision-ledger review.** Code passes find defects in what was built; they cannot find the
-   defect where the code faithfully implements a choice that **stopped being right** — a store
-   picked for scale that never arrived, a rewrite justified by a benchmark that no longer
-   reproduces, an expired constraint still shaping the design. Reconstruct the expensive-to-
-   reverse decisions (ADRs, design docs, CHANGELOG, the PRs that introduced each major component)
-   and classify each **JUSTIFIED / STALE / UNJUSTIFIED / UNVERIFIABLE**. Where a decision rests on
-   a number, **re-measure it this session** — a benchmark in a two-year-old ADR is a historical
-   claim, not a current fact. Full procedure: `rules/01-audit-methodology.md` §6.
-6. **Findings.** Emit every finding in the canonical cross-domain format (`file:line | rule |
-   severity | effort | fix`) — skill-local block formats are fine within a domain pass but must
-   carry an effort field so the roll-up can be sequenced — deduplicate across domains, and roll up
-   into the report structure from `rules/01-audit-methodology.md`: executive summary → scope &
-   methodology → findings by severity → remediation roadmap sequenced by risk-reduction-per-effort
-   → positive observations → appendix. Severity meanings:
-- **Critical** — exploitable now or data-loss risk; fix before anything else.
-- **High** — serious weakness or reliability hazard; fix this sprint.
-- **Medium** — deviation from SOTA with real but bounded impact.
-- **Low** — hygiene, polish, future-proofing.
-- **Info** — no direct risk: observations, tech-debt notes, future-proofing.
-7. **Refute before reporting.** Re-reading your own finding re-runs the reasoning that produced it
-   — it is the weakest check available. Every Critical/High gets an **independent pass prompted to
-   kill it** (a separate agent, or a fresh-context hostile read), working from the code at the
-   pinned commit rather than your write-up, defaulting to REFUTED when the evidence is ambiguous.
-   Use distinct lenses where a finding can fail more than one way — is the mechanism real, is it
-   reachable, is the stated impact inflated. Survivors ship; the rest are dropped or downgraded
-   **with the refutation recorded**, so the next auditor doesn't re-raise them. Absence claims
-   ("no X found") get a refuter too, and carry the heavier burden of principle 3. Full procedure
-   and failure modes: `rules/01-audit-methodology.md` §7.
+4. **Silent-control pass (always run it).** The per-domain passes ask "is the control
+   there?" — this one asks "does it *do* anything?". For every control they confirmed
+   exists, apply `sota-code-security` rules/10: the code isn't wrong, it's **inert**, which
+   is why this class is invisible both to the other passes and to pattern-based SAST.
+   **Sweep with `rules/11` first** to find *where* to look — stage duration vs work
+   claimed, every gate's denominator (`0 checked, 0 failed, exit 0`), size-gated paths no
+   fixture crosses, cache keys narrower than the behaviour, one-sample parsers,
+   `assert`-as-control.
+5. **Decision-ledger review.** Code passes find defects in what was built; they cannot
+   find the defect where the code faithfully implements a choice that **stopped being
+   right** — a store picked for scale that never arrived, an expired constraint still
+   shaping the design. Reconstruct the expensive-to-reverse decisions (ADRs, design docs,
+   CHANGELOG, the PRs behind each major component) and classify each **JUSTIFIED / STALE /
+   UNJUSTIFIED / UNVERIFIABLE**. Where a decision rests on a number, **re-measure it this
+   session**. Full procedure: `rules/01` §6.
+6. **Findings.** Emit every finding in the canonical cross-domain format (`file:line |
+   rule | severity | effort | fix`) — skill-local block formats are fine within a domain
+   pass but must carry an effort field so the roll-up can be sequenced — deduplicate across
+   domains, and roll up into the report structure from `rules/01` §8. **Severity
+   definitions: `rules/01` §4** (Critical / High / Medium / Low / Info).
+7. **Refute before reporting.** Re-reading your own finding re-runs the reasoning that
+   produced it — it is the weakest check available. Every Critical/High gets an
+   **independent pass prompted to kill it** (a separate agent, or a fresh-context hostile
+   read), working from the code at the pinned commit rather than your write-up, defaulting
+   to REFUTED when the evidence is ambiguous. Survivors ship; the rest are dropped or
+   downgraded **with the refutation recorded**, so the next auditor doesn't re-raise them.
+   Absence claims ("no X found") get a refuter too, and carry the heavier burden of
+   principle 3. Full procedure and failure modes: `rules/01` §7.
 
 ## Library map (rules files per skill)
 
-- **sota/rules**: 01 audit methodology (process, tool matrix, evidence standard, report template —
-  read first for any full audit)
+- **sota/rules**: 01 audit methodology (process, tool matrix, severity model, evidence standard,
+  report template — read first for any full audit), 02 build workflow (the reasoning behind the
+  four BUILD steps, and the four surfaces a BUILD change must be mirrored into)
 - **sota-architecture/rules**: 01 styles & decisions, 02 domain modeling, 03 distributed systems &
   events, 04 resilience, 05 scalability & state, 06 cloud-native config & delivery, 07 anti-
   patterns catalog, 08 NATS JetStream messaging

--- a/skills/sota/rules/01-audit-methodology.md
+++ b/skills/sota/rules/01-audit-methodology.md
@@ -369,6 +369,23 @@ Deliver in exactly this order:
 
 ---
 
+## 10. Changing the AUDIT workflow? Change both places
+
+The audit workflow lives in **two** surfaces and they drift independently:
+
+| Surface | What it holds |
+|---|---|
+| `skills/sota/SKILL.md` §AUDIT | the seven passes, one imperative each — read on every audit |
+| this file | the procedure, severity model, evidence standard, report template |
+
+The router's §AUDIT is deliberately terse because it is read every time; detail belongs
+here. So a new pass needs **a line there and a section here**, and a change to an existing
+pass needs both updated together — a step whose procedure contradicts §1-§9 is worse than
+no step, because the reader follows whichever they loaded.
+
+Unlike BUILD there is no hash pin over §AUDIT (`rules/02` §5), so **nothing catches this
+automatically** — the check is this section existing and being read.
+
 ## Audit checklist — quality gate on the audit itself
 
 **Coverage**

--- a/skills/sota/rules/02-build-workflow.md
+++ b/skills/sota/rules/02-build-workflow.md
@@ -1,0 +1,95 @@
+# BUILD mode — the reasoning behind the four steps
+
+**The router holds the imperatives; this file holds the *why*.** `skills/sota/SKILL.md`
+§BUILD is deliberately terse — it is read on every build, and length there is paid by
+every task. Load this file when a build is large or unusual, when a step is being
+skipped, or when you are changing the workflow itself.
+
+**If you change anything here, see §5 — three other places may need the same change.**
+
+## 1. Why "load lean" is correctness, not economy
+
+Reading unrelated rules files is not free. A long context of similar-looking guidance
+*measurably reduces* how many rules the model applies: transformer attention degrades
+with length, and near-duplicate distractors compete with the rule that matters. Loading
+five relevant rules files beats loading twenty, and the difference shows up as dropped
+cross-cutting concerns rather than as a visible error.
+
+This is the same effect [WHY-COMPLETENESS-RESIDUAL](../../../docs/WHY-COMPLETENESS-RESIDUAL.md)
+documents: the residual is a **salience** problem, not a coverage gap. Adding the missing
+rule made it worse; a short, salient reminder fixed it.
+
+## 2. Why the plan comes before the code, and must be concrete
+
+Named up front and verified at the end, constraints are followed far better than when
+left implicit. The failure mode is a plan of vague intentions — "handle errors", "make it
+secure" — which cannot be marked done or not-done at step 4 and therefore never is.
+
+A checkable item states an outcome with a number or a subject:
+
+- "rate-limit login to N/min per IP", not "add rate limiting"
+- "reject uploads over N MB", not "validate uploads"
+- "structured log on auth failure, no credentials in the line", not "add logging"
+
+## 3. Why the self-audit gate runs LAST
+
+A long build context makes mid-context rules fade. The final re-read is what recovers the
+rate limiting, transport, tests and logging that a model otherwise drops silently —
+**measured: this recovery is the bulk of the library's completeness lift**
+(`evals/run-completeness.py`; 0.62 → 1.00 on `claude-sonnet-5`, 2026-08-21).
+
+Doing it first, or continuously, does not work: at that point there is no diff to audit.
+
+**For a large build, run it as a separate pass over the diff.** A fresh, minimal context
+beats a long polluted one — the same reason the gate exists at all.
+
+**Push the few truly critical invariants into deterministic gates.** A lint or CI check
+that fails when an endpoint has no rate limiting or no TLS does not depend on attention.
+Attention is not an enforcement mechanism; a test is.
+
+## 4. The two questions that catch inert work
+
+- **The falsification question** — *if this control were silently a no-op, would anything
+  observable differ?* No log, no metric, no failing test means the control is not done
+  (`sota-code-security` rules/10).
+- **Read back the artifact this run produced.** Where a control emits something — a
+  record, a ledger line, a signature — it is wrong in the *output* long before it looks
+  wrong in the source. Re-reading the code that writes it re-runs the reasoning that
+  produced it, which is the weakest check available.
+
+## 5. Changing BUILD? Change these too
+
+The BUILD workflow is **mirrored in four places**. They drift independently, and three of
+the four fail silently.
+
+| Surface | What it holds | What happens if you forget |
+|---|---|---|
+| `skills/sota/SKILL.md` §BUILD | the imperatives an agent reads every build | the change never ships |
+| this file | the reasoning | the *why* rots away from the *what* |
+| `evals/run-completeness.py` → `BUILD_WORKFLOW` | a hand-compressed mirror used as the eval's treatment arm | **the eval measures a workflow that is not shipped** |
+| `evals/run-completeness.py` → `ROUTER_BUILD_SHA` | a hash pin over the router's BUILD section | the eval **aborts** — this one is loud, and is the guard that catches the row above |
+
+The pin is the only reason this is survivable: edit §BUILD and the next eval run stops
+and prints the new hash. **Never bump the hash without first re-reading the mirror
+against the new §BUILD, clause by clause.** Then one of two things is true, and you must
+say which in the commit:
+
+- **an imperative changed** → re-sync `BUILD_WORKFLOW`, *then* set the new hash;
+- **only prose moved** (rationale relocated here, wording tightened) → the mirror is
+  already accurate; record the clause-by-clause check and set the hash alone.
+
+Bumping the hash *without that check* is exactly the drift the guard exists to prevent,
+and it happened once (2026-07-20, PR #119: a falsification clause added to the
+router was missing from the mirror for four days while the project's most-cited number
+was measured against a workflow that no longer shipped).
+
+## Audit checklist (meta — for changes to this workflow)
+
+- [ ] A change to §BUILD in the router is reflected in this file's reasoning, in
+      `BUILD_WORKFLOW`, and in `ROUTER_BUILD_SHA` — all four, same commit.
+- [ ] `ROUTER_BUILD_SHA` was updated only **after** the mirror was re-read against the
+      new §BUILD, and the commit says whether an imperative changed or only prose moved.
+      Run the guard once and confirm it passes rather than assuming it.
+- [ ] The router's §BUILD still states every imperative; only reasoning lives here. An
+      agent that never opens this file must still build correctly.
+- [ ] Any new step is checkable at step 4 — it states an outcome, not an intention.


### PR DESCRIPTION
The router sat at exactly **500/500 since 2026-07-30**, so every addition since has been paid for by compressing something else. This gives the headroom back **without raising the cap** and without losing an imperative.

```
skills/sota/SKILL.md   500 → 484 lines   (16 spare)
  §BUILD                37 → 28
  §AUDIT                63 → 54
  new rules/02-build-workflow.md (88)
```

## Most of what left §AUDIT was duplication, not detail

`rules/01` already carried the **severity model (§4)**, recon (§2), decision-ledger (§6), refutation (§7) and report structure (§8). The router was restating them. It now points instead — so the same content is one `Skill` call away rather than in every task's context.

## Measured before cutting

A length sweep on `cases/router.jsonl` (`claude-sonnet-5`, 3 samples, temp 0.7):

| arm | lines | prompt tokens | recall |
|---|---|---|---|
| no-router (control) | 0 | 1,367 | 0.867 |
| base | 501 | 18,302 | **1.000** |
| +400 after | 902 | 29,005 | **1.000** |
| +400 before | 902 | 29,005 | **1.000** |
| +800 before | 1,302 | 39,772 | **1.000** |

Flat at 2.6× the length with the routing table pushed 800 lines deeper. The untreated arm reproduced **0.867** — exactly the 2026-08-25 figure, and it cannot see the router, so it's a free control on the measurement.

**So length was never the risk; per-load cost is.** The router is **16,934 tokens** (`count_tokens`, `claude-sonnet-5` — the Anthropic API now that the key has credit; it matches OpenRouter's native figure to the token). That's ~3.4× the ~5k guidance, paid by *every* task. Offloading detail cuts that; raising the cap would have raised it. That's why this PR does the former.

Caveats stated in advance: the metric is at ceiling (it can only detect a drop), and the filler is inert — it tests length and depth, not competition between real rules.

## Compression audit: clean

You asked whether past compressions lost anything. Across the router's **entire history**, 51 concept anchors ever existed and **49 are present today**. The two absent:

- *"Self-audit gate — do not present code until this passes"* → **reworded**, still there.
- *"Verify before reporting"* → **superseded** by "Refute before reporting" (independent refuter, pinned commit, default-REFUTED, distinct lenses); substance moved to `rules/01` §5.

One phrase didn't survive: *"substantiate with a concrete failure scenario"*. Nearest equivalents are `rules/01` §5 item 4 (Evidence) and item 6 (Impact — "what the attacker *actually gets*"), which are more specific. Absorbed, not dropped — but worth knowing it's no longer in the router.

## The coupling is now stated — because it fails silently in three of four places

| Surface | Holds | If forgotten |
|---|---|---|
| router §BUILD | the imperatives | change never ships |
| `rules/02` | the reasoning | *why* rots away from *what* |
| `BUILD_WORKFLOW` | the eval's treatment arm | **eval measures an unshipped workflow** |
| `ROUTER_BUILD_SHA` | hash pin over §BUILD | eval **aborts** — the one loud surface |

Plus new **`rules/01` §10** for AUDIT's two surfaces, which says plainly that **no pin exists over §AUDIT, so nothing catches divergence automatically**. Both router sections carry a one-line warning; `CONTRIBUTING.md` explains it for humans.

**And the pin rule got sharpened by having to follow it.** "Never the hash alone" was unfollowable when only prose moved. It now requires a clause-by-clause re-read of the mirror, then stating which case it is: *an imperative changed* (re-sync first) or *only prose moved* (hash alone is correct). Both pin trips here were resolved that way — all seven imperatives verified still present in `BUILD_WORKFLOW`.

## Checks

`check-invariants.sh` **19/19** · `check-negative-controls.sh` **25/25** · scorers **38/38**. Invariant 6 caught the README file count (300→301) and invariant 10/15 the library map — both only after `git add`, since those gates read `git ls-files`.
