### PR TITLE
check-negative-controls: stop the cleanup swallowing its own failure

### DIFF
--- a/scripts/check-negative-controls.sh
+++ b/scripts/check-negative-controls.sh
@@ -46,7 +46,26 @@ GATE=scripts/check-invariants.sh
 [ -f "$GATE" ] || { echo "FAIL: $GATE not found"; exit 1; }
 
 WT=$(mktemp -d)/wt
-cleanup() { git worktree remove --force "$WT" >/dev/null 2>&1 || true; rm -rf "$(dirname "$WT")"; }
+# REPORTED, NEVER GATED. This runs on EXIT, so a non-zero here would overwrite the
+# harness's real exit code — and the whole point of this script is that a non-zero for
+# any reason other than the intended check is a FALSE PASS. Same stance as
+# `evals/_elapsed.py`: it reports, it never decides. Also `docs/CONVENTIONS-LEDGER.md` —
+# a flaky gate gets disabled and leaves you worse off than no gate.
+#
+# The `|| true` here used to swallow the failure while `rm -rf` deleted the directory
+# anyway, which orphans the worktree REGISTRATION: `git worktree list` then shows a
+# `prunable` entry forever, and success and failure of this cleanup were
+# indistinguishable — `sota-code-security` rules/10 §2.4, in the one script whose job is
+# proving that failures surface. Found 2026-09-03 with two orphans already registered
+# (concurrent runs against one repo are the likely trigger). `git gc` does prune them,
+# but only at `gc.worktreePruneExpire`, which defaults to 3 months — that grace is why
+# this went unnoticed, not why it was fine.
+cleanup() {
+  git worktree remove --force "$WT" >/dev/null 2>&1 \
+    || echo "  warn: could not remove worktree $WT — pruning its registration" >&2
+  rm -rf "$(dirname "$WT")"
+  git worktree prune                 # the rm above orphans the registration otherwise
+}
 trap cleanup EXIT
 
 echo "Negative controls for $GATE"


### PR DESCRIPTION
Queued behind #308 by request — but it turns out **it does not have to be.** I claimed earlier that a separate PR touching `check-negative-controls.sh` would conflict with #308. That was wrong: #308's only hunk in that file is at ~line 159, `cleanup()` is at line 49, and a test-merge confirms they merge cleanly. **These can land in either order.**

## The defect

```sh
cleanup() { git worktree remove --force "$WT" >/dev/null 2>&1 || true; rm -rf "$(dirname "$WT")"; }
```

The removal's failure is swallowed; the directory is then deleted **unconditionally**. When the removal fails, the directory goes away but the *registration* does not — `git worktree list` shows a `prunable` entry, forever, and nothing says so.

Success and failure of that cleanup were **indistinguishable**. That is `sota-code-security` rules/10 §2.4, sitting in the one script whose entire job is proving that failures surface (`rules/12`).

Found 2026-09-03 with **two orphans already registered** in this repo. Concurrent runs against one repo are the likely trigger. `git gc` does clear them, but only at `gc.worktreePruneExpire` — **3 months** by default. That grace period is why this went unnoticed, not why it was fine.

## The fix — reported, never gated

```sh
cleanup() {
  git worktree remove --force "$WT" >/dev/null 2>&1 \
    || echo "  warn: could not remove worktree $WT — pruning its registration" >&2
  rm -rf "$(dirname "$WT")"
  git worktree prune                 # the rm above orphans the registration otherwise
}
```

The exit code is deliberately untouched. This runs on `EXIT`, so a non-zero here would overwrite the harness's real status — in a script whose own rule is that *a non-zero exit for any reason other than the intended check is a FALSE PASS*. Same stance as `evals/_elapsed.py` (*"it reports, it never decides"*), and `docs/CONVENTIONS-LEDGER.md` makes the general case: a flaky gate gets disabled and leaves you worse off than no gate.

## Watched to work, not assumed

- **Warning path fired** when driven against a non-worktree directory; exit still `0`; directory still removed.
- **Orphan reproduced end to end** — added a worktree, `rm -rf`'d its directory (exactly what the old cleanup did after a failed remove), confirmed **1 prunable entry** registered, then ran the new cleanup and confirmed **0**.

```
--- OLD behaviour: dir gone, registration orphaned ---
/private/var/folders/.../tmp.RA6hhP5kqU/wt  133ab1d (detached HEAD) prunable
orphans: 1
--- NEW cleanup's prune step ---
  warn: could not remove worktree /var/folders/.../tmp.RA6hhP5kqU/wt — pruning its registration
orphans after: 0
```

## Verification

- `check-negative-controls.sh` — **26/26 mutations caught by the intended check**, real (unpiped) exit status, and the run left **0 orphans** behind
- `check-invariants.sh` — **20/20**
- `shellcheck` — clean, exit 0 read unpiped

*(Both exit codes were re-read unpiped after I first checked one through `| head`, where `$?` reports the pipe's last stage rather than the command's.)*

## Scope

**No CHANGELOG entry, no VERSION bump** — internal harness hygiene with no user-facing surface, and CONTRIBUTING requires neither per PR (invariant 5 only checks the top entry against `VERSION`; invariant 14 only fires on a release). Fold it into whichever release ships next.

**Not proposed as a gate.** It fails `docs/CONVENTIONS-LEDGER.md`'s filters — not mechanically checkable from a static tree, and the consequence is cosmetic.
