### PR TITLE
Router principle 3: "independent" means a different failure mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,28 @@ measured rather than scaled.
   the release entries (7/7 · 4/4 · 6/7 · 6/6 · 4/4 · 4/4), plus both 2026-09-08 intakes in
   full.
 
+### Added
+
+- **Router operating principle 3 — "independent" means a different failure mode, not a
+  different phrasing.** The principle already asked for a second independent method before
+  asserting an absence. Field-reported: two searches of the same tree agreed on **zero** and
+  both were wrong, because both were `grep -r` over a directory of symlinks, which `-r` does
+  not follow. A second method that shares the first's failure mode is one method. The only
+  check that works is a **positive control in the same invocation** — search for something you
+  have already seen there, and if the control returns nothing the instrument is broken and the
+  absence is not evidence.
+- **`sota-shell-scripting` rules/06 §3 — build output is the trap.** `target/`,
+  `node_modules/`, `.venv/`, `vendor/`, `build/`, `dist/` reach tens of gigabytes and are what
+  a naive recursive copy takes; redirect the tool's output instead of copying. And **a full
+  disk is not a clean failure**: on a VM-backed container runtime the guest disk is a sparse
+  file on the host's, so exhausting the host surfaces *inside* the VM as I/O errors that can
+  corrupt the filesystem and image store — minutes later, in an unrelated command.
+- **`sota-detection-engineering` rules/01 §8 — enforce the citation, and record the blind
+  spot.** A source field that is optional is absent by the time anyone needs it, so enforce it
+  the way a runbook link is enforced. And **record what the detection cannot see**: the same
+  paper that supplied one technique also described a wrapper variant evading all three of its
+  own signals. Writing that down is what stops a rule being credited with coverage it lacks.
+
 ### Changed
 
 - **`docs/CONTEXT-MANAGEMENT.md`'s token table now says what it is not.** The 5,000-token

--- a/docs/ADOPTION-LOG.md
+++ b/docs/ADOPTION-LOG.md
@@ -2205,3 +2205,59 @@ own anchor, which is the class of bug that only re-reading the file catches.
 `sota-code-security` rules/13 §6 and rules/14 §8, `sota-testing` rules/04 §4.8 and rules/07
 §7.7–§7.8, `sota-devsecops` rules/07 §7.7, `sota-detection-engineering` rules/01 §8 — each
 with its audit-checklist half in the same change · v1.38.0
+
+### 2026-09-09 — the InterdictOps field report in full, and one of its claims corrected
+
+The full report behind the 2026-09-08 summary that landed in v1.38.0
+(`FIELD-REPORT-INTERDICT-2026-09-08.local.md`, untracked by the same convention as its
+predecessor — the repo is public, the product it describes is not). **Most of it was already
+landed from the summary**; this entry records the four remainders and the one claim that did
+not survive measurement.
+
+**Adopted — router operating principle 3, and this is the one that matters.** The principle
+already said a negative claim needs *"a second independent method"*. The report shows why
+that is necessary and not sufficient: **both its methods were `grep -r`**, so both agreed on
+zero and both were wrong, because `-r` does not follow symlinks met during traversal and
+`~/.claude/skills/` is 42 of them. *"Independent" has to mean a different **failure mode**,
+not a different phrasing.* The remedy is a **positive control in the same invocation** — a
+term you have already seen there. This is a correction to an existing cross-cutting principle
+that could otherwise license the wrong move ("I used two methods, so I am safe"), which is a
+different and lower bar than promoting a new principle, so the two-independent-sources rule
+does not block it.
+
+**Adopted — three sharpenings the summary did not carry.** Build output is the trap for the
+blast-radius rule (`target/`, `node_modules/`, `.venv/`, `vendor/` reach tens of gigabytes and
+are exactly what a naive recursive copy takes — redirect output instead of copying), and **a
+full disk is not a clean failure**: on a VM-backed runtime the guest disk is a sparse file on
+the host's, so host exhaustion surfaces inside the VM as I/O errors that corrupt the
+filesystem and image store, minutes later, in an unrelated command. For detections: **enforce
+the citation** the way a runbook link is enforced, since optional provenance is absent by the
+time anyone needs it; and **record what the rule cannot see** — the same paper that supplied
+the technique described a wrapper variant evading all three of its own signals, and writing
+that down is what stops the rule being credited with coverage it lacks.
+
+**Corrected — "prefer `rg`, which follows symlinks by default".** It does not. Measured
+2026-09-08 on a tree with four matches (plain, hidden, gitignored, behind a symlinked
+directory): **`rg` defaults found 1**, the environment's `grep` found 3, and only
+`rg --hidden --no-ignore --follow` found 4. Recommending ripgrep as the fix would have made
+the under-report *worse*. The library text already says this correctly (rules/06 §2) because
+it was measured before being written rather than accepted from the report — the same
+discipline this log asks of every intake, applied to an intake that was right about everything
+else.
+
+**Placement differences, recorded so the reporter can see the reasoning.** Two of the four
+went somewhere other than proposed: the blast-radius rule to `sota-shell-scripting`
+**rules/06** rather than rules/03, because rules/06 was created in the same release for
+exactly this class (the commands you type rather than commit) and rules/03 is about *secrets
+and injection* in scripts; and the reverted-by-a-neighbour shape to `sota-code-security`
+**rules/14** rather than rules/10, because rules/10 had **16 lines of headroom** and putting
+it there would have let the line cap choose the placement — which this library has now watched
+happen twice.
+
+**Not proposed, and agreed:** no new skill, no change to the detection content (its
+benign-baseline guidance was followed and the rule measured 0 false positives across 4,487
+binaries in three distributions), and no change to the `.local.md` convention.
+
+**Landed:** `sota/SKILL.md` principle 3, `sota-shell-scripting/rules/06` §3,
+`sota-detection-engineering/rules/01` §8 — each with its audit-checklist half in the same
+change · unreleased

--- a/skills/sota-detection-engineering/rules/01-detection-engineering-discipline.md
+++ b/skills/sota-detection-engineering/rules/01-detection-engineering-discipline.md
@@ -204,6 +204,14 @@ have passed every test, because the test corpus is the demo.
   that keeps the mechanism and changes every one of the author's choices; if the rule stops
   firing, it was keyed on scaffolding (`sota-code-security` rules/15 §2.1 — a probe that
   exercises a neighbouring property).
+- **Enforce the citation the way a runbook link is enforced** — a rule with no source field
+  does not load. Provenance that is optional is provenance that is absent by the time anyone
+  needs it.
+- **Record what the detection *cannot* see, beside what it catches.** Sources usually tell
+  you: the same paper that supplied the technique described a wrapper variant producing a
+  structurally ordinary binary that evades all three of its own signals. Writing that down is
+  what stops the rule being credited with coverage it does not have — the counting discipline
+  in `sota-code-security` rules/14 §6, applied before anyone asks.
 - **Re-read the source when the rule misbehaves.** "It worked in the paper" and "it works
   here" are claims about different corpora; §2's benign baseline is what turns the second
   into a number.
@@ -213,7 +221,9 @@ have passed every test, because the test corpus is the demo.
 - [ ] **Does every derived detection record its source, and separate the attack's mechanism
       from the author's instrumentation?** (§8) Filenames, markers, ports and banners are
       usually the demonstrator's choices; a rule keyed on them detects the demo. Test with a
-      variant that keeps the mechanism and changes all of them.
+      variant that keeps the mechanism and changes all of them. Is the source field
+      **enforced** (a rule without one does not load), and is **what the rule cannot see**
+      recorded beside what it catches?
 ## Audit checklist
 
 - [ ] Are detections in version control, with PR review and CI tests, or edited

--- a/skills/sota-shell-scripting/rules/06-ad-hoc-commands.md
+++ b/skills/sota-shell-scripting/rules/06-ad-hoc-commands.md
@@ -153,6 +153,15 @@ export, a bulk archive, a recursive `cp`/`rsync`, anything with `--output` on a 
   to a path you chose. A check that cannot write to its subject cannot corrupt it.
 - **Bound it before running it** — `du -sh` the thing you are about to copy. "It is only the
   repo" is a guess about size, and the number is one command away.
+- **Build output is the trap, and it is never in your mental model of the repo.** `target/`,
+  `node_modules/`, `.venv/`, `vendor/`, `build/` and `dist/` reach tens of gigabytes and are
+  exactly what a naive recursive copy takes. Exclude them, or better, do not copy: point the
+  tool's output elsewhere (`CARGO_TARGET_DIR=/build`, `--target-dir`, `-o`) and leave the
+  source read-only.
+- **A full disk is not a clean failure.** On a VM-backed container runtime the guest's disk is
+  a sparse file on the host's, so exhausting the host surfaces *inside* the VM as I/O errors
+  and can corrupt the filesystem and image store — minutes later, in an unrelated command,
+  long after the one that caused it.
 - Cleanup on a shared runtime is not housekeeping: see `sota-devsecops` rules/07 §7.7.
 
 ## Audit checklist
@@ -163,7 +172,8 @@ export, a bulk archive, a recursive `cp`/`rsync`, anything with `--output` on a 
       known-present term **in the same invocation**.
 - [ ] **Ad-hoc commands that write at scale** (§3): headroom checked (`df -h` on the target
       *and* the runtime's own filesystem), source mounted read-only, output outside the source
-      tree, size bounded with `du -sh` before the copy.
+      tree, size bounded with `du -sh` before the copy, and build output (`target/`,
+      `node_modules/`, `.venv/`, `vendor/`) excluded or redirected rather than copied.
 - [ ] **zsh joining bugs** (the inverse of SC2086, and unlinted): in any zsh script or
       snippet, `grep -nE '\$\{[a-zA-Z_]+:\+[^}]*\$' -e '[a-z] \$[a-zA-Z_]+$'` for
       `${var:+--flag $var}` and bare `cmd $args`. Each passes **one** argument in zsh

--- a/skills/sota/SKILL.md
+++ b/skills/sota/SKILL.md
@@ -58,7 +58,13 @@ rules files that match the code in front of you. Never load all skills at once.
    proof than a positive one**: "no instances of X" and "I only looked one way"
    are indistinguishable from the outside, so before asserting absence, widen
    the search and use a second independent method — and state the search you
-   actually ran.
+   actually ran. **"Independent" means a different failure mode, not a different
+   phrasing.** Field-reported: two searches of the same tree agreed on zero and
+   both were wrong, because both were `grep -r` over a directory of symlinks,
+   which `-r` does not follow. The only check that works is a **positive
+   control** — search for something you have already seen there, in the same
+   invocation; if the control returns nothing, the instrument is broken and the
+   absence is not evidence (`sota-shell-scripting` rules/06 §2).
 4. **Stack profile.** If the repo or `~/.claude` contains a `profiles/*.md`
    stack profile (preferred stores, auth provider, license policy, platform
    conventions), its choices are the defaults for BUILD mode and the expected


### PR DESCRIPTION
The full InterdictOps field report behind the summary that landed in v1.38.0. **Most of it was already in**; these are the four remainders and one correction. Docs-only, folded into the existing `[Unreleased]`.

## The one that matters — router operating principle 3

The principle already asked for *"a second independent method"* before asserting an absence. The report shows why that is **necessary and not sufficient**: **both its methods were `grep -r`**, so both agreed on zero and both were wrong — `-r` does not follow symlinks met during traversal, and `~/.claude/skills/` is 42 of them.

*"Independent" has to mean a different **failure mode**, not a different phrasing.* The remedy is a **positive control in the same invocation**: search for something you have already seen there; if the control returns nothing, the instrument is broken and the absence is not evidence.

This is a **correction to an existing cross-cutting principle** that could otherwise license the wrong move ("I used two methods, so I'm safe") — a lower bar than promoting a new principle, so the two-independent-sources rule doesn't block it.

## Three sharpenings the summary didn't carry

- **Build output is the trap** (`rules/06` §3). `target/`, `node_modules/`, `.venv/`, `vendor/` reach tens of gigabytes and are exactly what a naive recursive copy takes — redirect the tool's output instead of copying.
- **A full disk is not a clean failure.** On a VM-backed container runtime the guest disk is a sparse file on the host's, so host exhaustion surfaces *inside* the VM as I/O errors that corrupt the filesystem and image store — minutes later, in an unrelated command.
- **Detections: enforce the citation, record the blind spot** (`rules/01` §8). Optional provenance is absent by the time anyone needs it. And the same paper that supplied one technique described a wrapper variant evading all three of its own signals — writing that down is what stops a rule being credited with coverage it lacks.

## One claim corrected

The report recommends *"prefer `rg`, which follows symlinks by default"*. **It does not.** Measured on a tree with four matches:

| searcher | found |
|---|---|
| `rg` (defaults) | **1** |
| the environment's `grep` | 3 |
| `rg --hidden --no-ignore --follow` | **4** |

Recommending ripgrep as the fix would have made the under-report *worse*. The library text was already right, because it was measured before being written rather than accepted — the same discipline the adoption log asks of every intake, applied to an intake that was right about everything else.

## Placement differences, recorded for the reporter

Two items went somewhere other than proposed: the blast-radius rule to **rules/06** rather than rules/03 (rules/06 was created in the same release for exactly this class — the commands you type rather than commit — while rules/03 is secrets and injection), and the reverted-by-a-neighbour shape to **rules/14** rather than rules/10, because rules/10 had **16 lines of headroom** and putting it there would have let the line cap choose the placement.

## Gates

`check-invariants.sh` **25/25** · `check-negative-controls.sh` **33/33**, both exit 0.
