### PR TITLE
Handle the skill-listing budget in install.sh and verify-setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,20 +731,28 @@ why always-on routing below is the recommended path and not a nicety: it is the 
 What is genuinely lost is *direct* auto-selection of a domain skill when the router has not
 fired, which is most likely for the skills you have never used.
 
-**The fix is one setting.** In `~/.claude/settings.json`:
+**`scripts/install.sh` offers to fix this**, on install and on `--update`, in the same
+shape as everything else it touches: it **measures** your actually-installed descriptions
+rather than assuming a number, sizes the fraction against a 200k context (a fraction that
+fits there also fits a larger window) with headroom for skills from other sources, asks
+before writing, backs the file up, and writes *through* a symlink so dotfiles stay in
+charge. It never lowers a value you already set. On this library's 42 skills that works out
+to about **0.07**.
+
+To set it by hand instead, in `~/.claude/settings.json`:
 
 ```json
-{ "skillListingBudgetFraction": 0.05 }
+{ "skillListingBudgetFraction": 0.07 }
 ```
 
-That gives 40,000 characters at a 200k context, enough for all 42. Be aware of what you are
-buying: the listing is sent **every turn**, so this reserves 5% of the context window for
-it. `skillListingMaxDescChars` (default 1536) is a separate per-skill cap — no description
-here exceeds it, so it does not apply.
+Be aware of what you are buying: the listing is sent **every turn**, so this reserves ~7% of
+the context window for it. `skillListingMaxDescChars` (default 1536) is a separate per-skill
+cap — no description here exceeds it, so it does not apply.
 
-**How to check your own install:** look at the skill list Claude is given and count entries
-that are a bare name with no text after the colon. Any such skill is installed, correct, and
-unreachable except by name.
+**To check your own install:** `scripts/verify-setup.sh` reports it as check **1b**, with the
+arithmetic (`descriptions total N chars vs an M-char budget…`). By hand: look at the skill
+list Claude is given and count entries that are a bare name with no text after the colon.
+Any such skill is installed, correct, and unreachable except by name.
 
 ### Always-on routing (recommended)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -365,6 +365,85 @@ setup_update_reminder() {
   rm -f "$tmp"
 }
 
+# Claude Code reserves a per-turn CHARACTER budget for the skill listing and sizes it
+# as `(contextTokens x 4) x skillListingBudgetFraction`, fraction defaulting to 0.01 —
+# so 8,000 characters on a 200k-context model, for every skill from every source. Read
+# out of the shipped binary (2.1.268) on 2026-09-11, not inferred: over budget, entries
+# are RANKED by recent usage and the ones that do not fit render as a bare `- name` with
+# NO description at all. That is the whole trigger classifier gone, while the skill stays
+# installed, correct and invocable-by-name. This library's descriptions need ~38k, so on
+# the default fraction most of them arrive with no trigger text — measured live, ~20 of
+# 42 were name-only in the session that found this.
+#
+# So this is not a tuning nicety, it is whether the skills can be selected at all. It is
+# still OFFERED and never imposed: it writes to the user's GLOBAL settings and reserves a
+# slice of every context window, which is their call, not ours.
+setup_listing_budget() {
+  local s="$HOME/.claude/settings.json" tmp need frac cur
+  command -v jq >/dev/null 2>&1 || { warn "jq not found — skipping skill-listing budget"; return; }
+  [ -d "$TARGET" ] || return 0
+
+  # Measure, never assume: sum the real descriptions of what is actually linked, plus
+  # each entry's "- name: " overhead, the way the listing itself counts them.
+  # Cross-checked against an independent implementation before being trusted: the first
+  # draft read 17,402 against a real 38,283 because `/^---/ { next }` fires on line 1 and
+  # skipped the per-file bookkeeping entirely — an under-report with no symptom. This one
+  # reads 38,507 vs 38,283 (+0.58%, the `>-` block indicator and folded-scalar join
+  # spacing), and errs HIGH, which is the safe direction when sizing a budget.
+  need="$(awk '
+    FNR == 1 {
+      if (seen) total += len + nlen + 6
+      seen = 1; len = 0; fm = 0; ind = 0
+      n = FILENAME; sub(/\/SKILL\.md$/, "", n); sub(/.*\//, "", n); nlen = length(n)
+    }
+    /^---[[:space:]]*$/ { fm = !fm; next }
+    fm && /^description:/ {
+      ind = 1; sub(/^description:[[:space:]]*/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+      len += length($0); next
+    }
+    fm && ind && /^[[:space:]]/ {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, ""); len += length($0) + 1; next
+    }
+    fm { ind = 0 }
+    END { total += len + nlen + 6; print total + 0 }
+  ' "$TARGET"/*/SKILL.md 2>/dev/null)"
+  [ -n "${need:-}" ] && [ "$need" -gt 0 ] 2>/dev/null || return 0
+  # `find -L`, not `find`: an install links each skill as a SYMLINK into the checkout,
+  # and find does not follow those without -L. The first draft printed "0 skills" on
+  # every real install while the awk glob above (globs do follow) read 38,507.
+
+  # Size against a 200k context — the documented fallback and the common case. A
+  # fraction that fits there also fits a larger window, because the budget scales with
+  # it. +25% headroom for bundled and plugin skills we cannot enumerate from here.
+  frac="$(jq -n --argjson n "$need" '(($n * 1.25) / 800000 * 100 | ceil) / 100 | if . < 0.02 then 0.02 elif . > 0.10 then 0.10 else . end')"
+  cur="$(jq -r '.skillListingBudgetFraction // empty' "$s" 2>/dev/null || true)"
+  if [ -n "$cur" ] && jq -n --argjson a "$cur" --argjson b "$frac" -e '$a >= $b' >/dev/null 2>&1; then
+    log "skillListingBudgetFraction already $cur (needs ~$frac) — leaving it alone"; return
+  fi
+
+  printf '  %s%s %s%s\n' "$C_DIM" "$G_INFO" \
+    "$(printf '%s skills need ~%s chars of listing; the default budget is 8,000 on a 200k context' \
+       "$(find -L "$TARGET" -maxdepth 2 -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')" "$need")" "$C_RESET"
+  ask_yn "Set skillListingBudgetFraction=$frac so every skill keeps its description (reserves ~$frac of each context window, every turn)?" y || {
+    log "left unset — expect skills beyond the first few to be listed name-only"; return; }
+
+  tmp="$(mktemp)"; track "$tmp"
+  if [ -e "$s" ]; then
+    backup "$s"
+    if jq --argjson f "$frac" '.skillListingBudgetFraction = $f' "$s" >"$tmp" 2>/dev/null; then
+      cat "$tmp" >"$s"   # cat (not mv) so a symlinked settings.json keeps its link
+      ok "set skillListingBudgetFraction=$frac in ~/.claude/settings.json"
+    else
+      warn "could not parse $s as JSON — left unchanged"
+    fi
+  else
+    mkdir -p "$(dirname "$s")"
+    jq -n --argjson f "$frac" '{skillListingBudgetFraction: $f}' >"$s"
+    ok "created ~/.claude/settings.json with skillListingBudgetFraction=$frac"
+  fi
+  rm -f "$tmp"
+}
+
 setup_hook() {
   local s="$HOME/.claude/settings.json" tmp
   if ! command -v jq >/dev/null 2>&1; then
@@ -603,6 +682,11 @@ if [ "$TARGET" = "$HOME/.claude/skills" ] && [ "$USE_COPY" -eq 0 ]; then
 fi
 
 maybe_setup_routing
+# Independent of the routing opt-in on purpose: the listing budget matters MORE when
+# always-on routing is declined, because that is exactly when per-skill auto-selection
+# is the only path and a name-only entry has nothing to match on.
+section '📏' 'Skill listing budget'
+setup_listing_budget || true
 maybe_setup_precommit
 
 section '✅' 'Done'

--- a/scripts/verify-setup.sh
+++ b/scripts/verify-setup.sh
@@ -178,6 +178,53 @@ else
   row "N/A" "3. stack profile" "none present — optional; the skills' own defaults apply"
 fi
 
+# --- 1b. Do the descriptions actually REACH the classifier? ----------------
+#
+# Check 1 answers "is the skill installed". This answers the question one layer
+# further in, which has a different answer: Claude Code reserves a per-turn
+# CHARACTER budget for the skill listing, `(contextTokens x 4) x
+# skillListingBudgetFraction` with the fraction defaulting to 0.01 — 8,000 chars
+# on a 200k-context model, shared across every skill from every source. Read out
+# of the shipped 2.1.268 binary on 2026-09-11: over budget, entries are RANKED by
+# recent usage and the ones that do not fit render as a bare `- name` with NO
+# description. The skill is installed, correct, invocable by name, and carries no
+# trigger text at all — so check 1 says PASS and auto-selection is dead.
+#
+# INFO-only and never fatal: the real budget depends on the model's context window
+# at runtime, which this script cannot know, and the user may have set the fraction
+# deliberately. It reports the arithmetic and lets the operator judge.
+listing_need=0
+for d in $skill_dirs; do
+  n="$(find -L "$d" -maxdepth 3 -name SKILL.md 2>/dev/null | wc -l | tr -d ' ')"
+  [ "${n:-0}" -gt 0 ] || continue
+  # shellcheck disable=SC2016  # awk program, not a shell expansion
+  add="$(find -L "$d" -maxdepth 3 -name SKILL.md -exec awk '
+    FNR == 1 {
+      if (seen) total += len + nlen + 6
+      seen = 1; len = 0; fm = 0; ind = 0
+      nm = FILENAME; sub(/\/SKILL\.md$/, "", nm); sub(/.*\//, "", nm); nlen = length(nm)
+    }
+    /^---[[:space:]]*$/ { fm = !fm; next }
+    fm && /^description:/ { ind = 1; sub(/^description:[[:space:]]*/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, ""); len += length($0); next }
+    fm && ind && /^[[:space:]]/ { gsub(/^[[:space:]]+|[[:space:]]+$/, ""); len += length($0) + 1; next }
+    fm { ind = 0 }
+    END { total += len + nlen + 6; print total + 0 }
+  ' {} + 2>/dev/null)"
+  listing_need=$((listing_need + ${add:-0}))
+done
+cfg_frac="$(jq -r '.skillListingBudgetFraction // empty' "$CLAUDE_HOME/settings.json" 2>/dev/null || true)"
+eff_frac="${cfg_frac:-0.01}"
+budget_200k="$(awk -v f="$eff_frac" 'BEGIN { printf "%d", 200000 * 4 * f }')"
+if [ "$listing_need" -eq 0 ]; then
+  row "INFO" "1b. listing budget" "no SKILL.md descriptions found to measure — nothing to report"
+elif [ "$listing_need" -le "$budget_200k" ]; then
+  row "PASS" "1b. listing budget" \
+    "descriptions total ${listing_need} chars, within the ${budget_200k}-char budget at a 200k context (fraction ${eff_frac})"
+else
+  row "INFO" "1b. listing budget" \
+    "descriptions total ${listing_need} chars vs a ${budget_200k}-char budget at a 200k context (fraction ${eff_frac}) — over by $((listing_need - budget_200k)); the lowest-USED skills will be listed name-only, with no trigger text. Raise skillListingBudgetFraction (scripts/install.sh offers this) or disable skills you do not use"
+fi
+
 # --- B. Is this repo's own context in place? ------------------------------
 if [ "$REACH_ONLY" -eq 1 ]; then
   printf '\n%s\n' "PASS $n_pass · FAIL $n_fail · PARTIAL $n_partial"


### PR DESCRIPTION
Follow-up to #349. A README instruction the operator must remember is the weak
form of the rule this library added to `sota-skill-security` rules/03 §1a this
morning: **if something must apply every time, don't leave it to someone reading
a paragraph.** The default budget cannot fit 42 skills, so on a stock install
most of these descriptions never reach the classifier at all.

## `install.sh` — `setup_listing_budget()`

Follows `setup_update_reminder()` exactly: jq guard, idempotency check, `ask_yn`
with the recommended answer pre-filled, backup first, `cat` not `mv` so a
symlinked `settings.json` keeps its link. **Offered, never imposed** — it writes
to global settings and reserves a slice of every context window, which is the
user's call.

It **measures** instead of hardcoding: sums the descriptions actually linked,
sizes against a 200k context (a fraction that fits there fits a larger window,
since the budget scales with it), adds 25% headroom for skills it can't
enumerate, clamps to `[0.02, 0.10]`. Reads **~0.07** for this library. Called
independently of the always-on-routing opt-in **on purpose** — the budget matters
*more* when routing is declined, because that's exactly when per-skill
auto-selection is the only path.

### Two defects caught by testing, both of the silent kind

- The first measurement read **17,402** against a real **38,283** — `/^---/ {
  next }` fires on line 1 and skipped the per-file bookkeeping. Found only by
  cross-checking against an independent implementation; an under-report has no
  symptom. Shipped version reads 38,507 vs 38,283 (+0.58%) and errs **high**.
- `find` without `-L` counted **0 skills**, because an install links each skill as
  a symlink. It would have printed "0 skills need…" on every real install.

### Tested end-to-end in a disposable HOME — six cases, none touching the real file

fresh create · existing keys preserved · idempotent re-run · a higher existing
value **not** lowered · malformed JSON left unchanged with a warning · a
symlinked `settings.json` still a symlink afterwards, written through.

## `verify-setup.sh` — check 1b

Check 1 answers *is the skill installed*. 1b answers the layer further in, which
has a different answer. **INFO-only and never fatal** — the real budget depends on
the runtime context window, which the script cannot know. On this machine:

```
INFO  1b. listing budget  descriptions total 38507 chars vs a 8000-char budget
                          at a 200k context (fraction 0.01) — over by 30507
```

README reconciled: it told people to set `0.05` by hand, contradicting the
computed `0.07` and ignoring the script that now does it.

## Verification

shellcheck `-S style` clean on both scripts · `bash -n` both ·
`check-invariants.sh` PASS 29/29 · `check-negative-controls.sh` **PASS 44/44** ·
`verify-setup.sh --reach-only` run for real.